### PR TITLE
Expand use of check-env target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ ESP32_WIFI_SSID=
 all: tools
 
 .PHONY: tools
-tools: toitpkg toitlsp build/host/bin/toitvm build/host/bin/toitc
+tools: check-env toitpkg toitlsp build/host/bin/toitvm build/host/bin/toitc
 
 .PHONY: esp32
-esp32: build/esp32/toit.bin
+esp32: check-env build/esp32/toit.bin
 
 build/esp32/toit.bin build/esp32/toit.elf: build/esp32/lib/libtoit_image.a
 	make -C toolchains/esp32/


### PR DESCRIPTION
Add check-env phony target as prerequisite for tools and esp32 targets.

This causes make to bail out immediately if IDF_PATH is unset, preventing
unclear path failure messages during cmake's attempt at adding mbedtls paths based
on this.

Failure after:

```
$ echo $IDF_PATH && make tools

Makefile:99: *** IDF_PATH is not set.  Stop.
$
```

Failure before:

```
$ echo $IDF_PATH && make tools

...
CMake Error at CMakeLists.txt:91 (add_subdirectory):
  add_subdirectory given source "/components/mbedtls/mbedtls" which is not an
  existing directory.
...
-- Configuring incomplete, errors occurred!
...
make: *** [Makefile:48: build/host/CMakeCache.txt] Error 1
$
```