### PR TITLE
Mitigate go 1.13/Ubuntu 20.04 "path@version" syntax error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,17 @@ build/esp32/esp32.image.s: build/esp32/ build/snapshot build/ia32/bin/toitvm too
 build/snapshot: build/ia32/bin/toitc $(ESP32_ENTRY)
 	build/ia32/bin/toitc -w $@ $(ESP32_ENTRY) -Dwifi.ssid=$(ESP32_WIFI_SSID) -Dwifi.password=$(ESP32_WIFI_PASSWORD)
 
+GO_USE_INSTALL = 1
+GO_USE_INSTALL_FROM = 1 16
+GO_VERSION = $(subst ., ,$(shell go version |grep --perl-regexp --only-matching "(?<=go version go)[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*(?= .*/.*)"))
+ifeq ($(shell echo "$(word 1,$(GO_VERSION)) >= $(word 1,$(GO_USE_INSTALL_FROM))"|bc), 1)
+  ifeq ($(shell echo "$(word 2,$(GO_VERSION)) < $(word 2,$(GO_USE_INSTALL_FROM))"|bc), 1)
+  GO_USE_INSTALL=0
+  endif
+else
+  GO_USE_INSTALL=0
+endif
+
 GO_BUILD_FLAGS ?=
 ifeq ("$(GO_BUILD_FLAGS)", "")
 $(eval GO_BUILD_FLAGS=CGO_ENABLED=1 GODEBUG=netdns=go)
@@ -82,7 +93,11 @@ toitpkg: build/toitpkg
 
 TOITPKG_VERSION := "v0.0.0-20211126161923-c00da039da00"
 build/toitpkg:
+ifeq ($(GO_USE_INSTALL),1)
+	GOBIN=$(shell pwd)/build go install github.com/toitlang/tpkg/cmd/toitpkg@$(TOITPKG_VERSION)
+else
 	GO111MODULE=on GOBIN=$(shell pwd)/build go get github.com/toitlang/tpkg/cmd/toitpkg@$(TOITPKG_VERSION)
+endif
 
 build/ia32/ build/host/:
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,10 @@ toitlsp: build/toitlsp
 .PHONY: toitpkg
 toitpkg: build/toitpkg
 
+
 TOITPKG_VERSION := "v0.0.0-20211126161923-c00da039da00"
 build/toitpkg:
-	GOBIN=$(shell pwd)/build go install github.com/toitlang/tpkg/cmd/toitpkg@$(TOITPKG_VERSION)
+	GO111MODULE=on GOBIN=$(shell pwd)/build go get github.com/toitlang/tpkg/cmd/toitpkg@$(TOITPKG_VERSION)
 
 build/ia32/ build/host/:
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,10 @@ GO_USE_INSTALL_FROM = 1 16
 GO_VERSION = $(subst ., ,$(shell go version |grep --perl-regexp --only-matching "(?<=go version go)[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*(?= .*/.*)"))
 ifeq ($(shell echo "$(word 1,$(GO_VERSION)) >= $(word 1,$(GO_USE_INSTALL_FROM))"|bc), 1)
   ifeq ($(shell echo "$(word 2,$(GO_VERSION)) < $(word 2,$(GO_USE_INSTALL_FROM))"|bc), 1)
-  GO_USE_INSTALL=0
+  GO_USE_INSTALL = 0
   endif
 else
-  GO_USE_INSTALL=0
+  GO_USE_INSTALL = 0
 endif
 
 GO_BUILD_FLAGS ?=
@@ -90,10 +90,9 @@ toitlsp: build/toitlsp
 .PHONY: toitpkg
 toitpkg: build/toitpkg
 
-
 TOITPKG_VERSION := "v0.0.0-20211126161923-c00da039da00"
 build/toitpkg:
-ifeq ($(GO_USE_INSTALL),1)
+ifeq ($(GO_USE_INSTALL), 1)
 	GOBIN=$(shell pwd)/build go install github.com/toitlang/tpkg/cmd/toitpkg@$(TOITPKG_VERSION)
 else
 	GO111MODULE=on GOBIN=$(shell pwd)/build go get github.com/toitlang/tpkg/cmd/toitpkg@$(TOITPKG_VERSION)


### PR DESCRIPTION
From Go 1.16 install subcommand accepts version suffixes and should be used for
executable installation according to [go get deprecation notice](https://go.dev/doc/go-get-install-deprecation)
and [release notes](https://go.dev/doc/go1.16).

Go <1.16 will error out when parsing a version suffix so this adds a check for
Go version and switches the argument and module mode between get and install
accordingly when installing toitpkg.

Shells out with "go version" piped through grep and two additional shell
invocations of bc for integer comparision.

Assumes to have available;
* grep with --perl-regexp for doing look-around (GNU only?)
* echo
* bc

Tested on Ubuntu 20.04 with go 1.13.8.

See also [writeup of module usage across Go versions](https://maelvls.dev/go111module-everywhere/).