### PR TITLE
Don't use GNU grep for Go detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build/snapshot: build/ia32/bin/toitc $(ESP32_ENTRY)
 
 GO_USE_INSTALL = 1
 GO_USE_INSTALL_FROM = 1 16
-GO_VERSION = $(subst ., ,$(shell go version |grep --perl-regexp --only-matching "(?<=go version go)[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*(?= .*/.*)"))
+GO_VERSION = $(subst ., ,$(shell go version |cut -d' ' -f 3| tail -c+3))
 ifeq ($(shell echo "$(word 1,$(GO_VERSION)) >= $(word 1,$(GO_USE_INSTALL_FROM))"|bc), 1)
   ifeq ($(shell echo "$(word 2,$(GO_VERSION)) < $(word 2,$(GO_USE_INSTALL_FROM))"|bc), 1)
   GO_USE_INSTALL = 0

--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,9 @@ build/snapshot: build/ia32/bin/toitc $(ESP32_ENTRY)
 
 GO_USE_INSTALL = 1
 GO_USE_INSTALL_FROM = 1 16
-GO_VERSION = $(subst ., ,$(shell go version |cut -d' ' -f 3| tail -c+3))
-ifeq ($(shell echo "$(word 1,$(GO_VERSION)) >= $(word 1,$(GO_USE_INSTALL_FROM))"|bc), 1)
-  ifeq ($(shell echo "$(word 2,$(GO_VERSION)) < $(word 2,$(GO_USE_INSTALL_FROM))"|bc), 1)
+GO_VERSION = $(subst ., ,$(shell go version | cut -d" " -f 3 | cut -c 3-))
+ifeq ($(shell echo "$(word 1,$(GO_VERSION)) >= $(word 1,$(GO_USE_INSTALL_FROM))" | bc), 1)
+  ifeq ($(shell echo "$(word 2,$(GO_VERSION)) < $(word 2,$(GO_USE_INSTALL_FROM))" | bc), 1)
   GO_USE_INSTALL = 0
   endif
 else


### PR DESCRIPTION
Use POSIX compliant invocation of [cut](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cut.html) for Go version parsing instead of GNU grep.

Assumes version is the string following the two first characters of the third element of the space delimited set of strings of the one newline delimited line output on stdout by "go version".

* stdout="go version go1.13.8 linux/amd64"
* version="1.13.8"

Fixes #34