### PR TITLE
Workaround issue preventing multiple processes from using net.open.

### DIFF
--- a/lib/net/wifi.toit
+++ b/lib/net/wifi.toit
@@ -41,7 +41,9 @@ class WifiInterface_ extends net.Interface:
       return [dns_lookup host]
     unreachable
 
-  udp_open -> udp.Socket: return udp_open --port=null
+  udp_open -> udp.Socket:
+    return udp_open --port=null
+
   udp_open --port/int? -> udp.Socket:
     with_wifi_:
       return Socket "0.0.0.0" (port ? port : 0)


### PR DESCRIPTION
We need a cleaner solution that also takes care of the cross process network interface closing (#58).

This unblocks https://github.com/toitlang/jaguar/issues/24.