### PR TITLE
Renamed platform names and added constants in toit

### DIFF
--- a/lib/core/utils.toit
+++ b/lib/core/utils.toit
@@ -292,6 +292,11 @@ simple_interpolate_strings_ array:
 platform:
   #primitive.core.platform
 
+PLATFORM_FREERTOS ::= "FreeRTOS"
+PLATFORM_WINDOWS ::= "Windows"
+PLATFORM_MACOS ::= "macOS"
+PLATFORM_LINUX ::= "Linux"
+
 /**
 Returns an array with stats for the current process.
 The stats, listed by index in the array, are:

--- a/lib/net/impl.toit
+++ b/lib/net/impl.toit
@@ -17,7 +17,7 @@ WIFI_ALREADY_STARTED_EXCEPTION_ ::= "OUT_OF_BOUNDS"
 wifi_interface_/Interface? := null
 
 open -> Interface:
-  if platform == "FreeRTOS":
+  if platform == PLATFORM_FREERTOS:
     // Was WiFi already started in this process?
     if wifi_interface_: return wifi_interface_
     exception ::= catch:

--- a/src/compiler/filesystem_local.cc
+++ b/src/compiler/filesystem_local.cc
@@ -26,6 +26,7 @@
 #include "lock.h"
 #include "util.h"
 #include "../flags.h"
+#include "../os.h"
 #include "../top.h"
 #include "../utils.h"
 
@@ -126,7 +127,12 @@ List<const char*> FilesystemLocal::package_cache_paths() {
     if (cache_paths != null) {
       _package_cache_paths = string_split(strdup(cache_paths), ":");
     } else {
-      char* home_path = getenv("HOME");
+      char* home_path;
+      if (strcmp(OS::get_platform(), "Windows") == 0) {
+        home_path = getenv("USERPROFILE");
+      } else {
+        home_path = getenv("HOME");
+      }
       if (home_path == null) {
         // TODO(florian): we could use getpwuid(getuid())->pw_dir instead.
         // However, the LSP server currently only looks at the env var.

--- a/src/os_darwin.cc
+++ b/src/os_darwin.cc
@@ -87,7 +87,7 @@ void OS::tear_down() {
 }
 
 const char* OS::get_platform() {
-  return "OSX";
+  return "macOS";
 }
 
 int OS::read_entire_file(char* name, uint8** buffer) {

--- a/src/os_linux.cc
+++ b/src/os_linux.cc
@@ -82,7 +82,7 @@ void OS::tear_down() {
 }
 
 const char* OS::get_platform() {
-  return "Debian";
+  return "Linux";
 }
 
 int OS::read_entire_file(char* name, uint8** buffer) {


### PR DESCRIPTION
This also fixes `filesystem_local.cc` such that we use `USERPROFILE`  env variable instead of  `HOME` on windows.