### PR TITLE
Follow symlinks when trying to find the SDK root.

### DIFF
--- a/tools/toitlsp/cmd/analyze.go
+++ b/tools/toitlsp/cmd/analyze.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	doclsp "github.com/sourcegraph/go-lsp"
 	"github.com/sourcegraph/jsonrpc2"
@@ -51,15 +50,8 @@ func analyze(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	sdk, err := cmd.Flags().GetString("sdk")
+	sdk, err := computeSDKPath(cmd.Flags(), toitc)
 	if err != nil {
-		return err
-	}
-	if sdk == "" {
-		sdk = filepath.Dir(toitc)
-	}
-	if sdk, err = filepath.Abs(sdk); err != nil {
 		return err
 	}
 

--- a/tools/toitlsp/cmd/archive.go
+++ b/tools/toitlsp/cmd/archive.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	doclsp "github.com/sourcegraph/go-lsp"
 	"github.com/sourcegraph/jsonrpc2"
@@ -54,14 +53,8 @@ func createArchive(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	sdk, err := cmd.Flags().GetString("sdk")
+	sdk, err := computeSDKPath(cmd.Flags(), toitc)
 	if err != nil {
-		return err
-	}
-	if sdk == "" {
-		sdk = filepath.Dir(toitc)
-	}
-	if sdk, err = filepath.Abs(sdk); err != nil {
 		return err
 	}
 

--- a/tools/toitlsp/cmd/repro.go
+++ b/tools/toitlsp/cmd/repro.go
@@ -80,7 +80,7 @@ func createRepro(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	if !cmd.Flags().Changed("sdk-path") {
-		sdkPath, err = filepath.Abs(filepath.Dir(toitcPath))
+		sdkPath, err = computeSDKPath(nil, toitcPath)
 		if err != nil {
 			return err
 		}

--- a/tools/toitlsp/cmd/toitdoc.go
+++ b/tools/toitlsp/cmd/toitdoc.go
@@ -99,15 +99,8 @@ func runToitdoc(sdkVersion string) func(cmd *cobra.Command, args []string) error
 			}
 		}
 
-		sdk, err := cmd.Flags().GetString("sdk")
+		sdk, err := computeSDKPath(cmd.Flags(), toitc)
 		if err != nil {
-			return err
-		}
-		if sdk == "" {
-			sdk = filepath.Dir(toitc)
-		}
-
-		if sdk, err = filepath.Abs(sdk); err != nil {
 			return err
 		}
 

--- a/tools/toitlsp/cmd/toitlsp.go
+++ b/tools/toitlsp/cmd/toitlsp.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"path/filepath"
 	"runtime"
 	"runtime/pprof"
 	"sync"
@@ -66,14 +65,8 @@ func runToitLSP(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	sdk, err := cmd.Flags().GetString("sdk")
+	sdk, err := computeSDKPath(cmd.Flags(), toitc)
 	if err != nil {
-		return err
-	}
-	if sdk == "" {
-		sdk = filepath.Dir(toitc)
-	}
-	if sdk, err = filepath.Abs(sdk); err != nil {
 		return err
 	}
 

--- a/tools/toitlsp/cmd/util.go
+++ b/tools/toitlsp/cmd/util.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2021 Toitware ApS.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/pflag"
+)
+
+func computeSDKPath(flags *pflag.FlagSet, toitc string) (string, error) {
+	sdk := ""
+	var err error
+	if flags != nil {
+		sdk, err = flags.GetString("sdk")
+
+		if err != nil {
+			return "", err
+		}
+	}
+	if sdk == "" {
+		toitc, err = filepath.EvalSymlinks(toitc)
+		if err != nil {
+			return "", err
+		}
+		sdk = filepath.Dir(toitc)
+		libDir := filepath.Join(sdk, "lib")
+		if _, err := os.Stat(libDir); err != nil {
+			// Try ../lib.
+			sdk = filepath.Join(sdk, "..")
+			libDir = filepath.Join(sdk, "lib")
+			if _, err := os.Stat(libDir); err != nil {
+				return "", fmt.Errorf("SDK's 'lib' directory not found")
+			}
+		}
+	}
+	if sdk, err = filepath.Abs(sdk); err != nil {
+		return "", err
+	}
+	if sdk, err = filepath.EvalSymlinks(sdk); err != nil {
+		return "", err
+	}
+	return sdk, nil
+}

--- a/tools/toitlsp/go.mod
+++ b/tools/toitlsp/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20200429184054-15c2290dcb37
 	github.com/spf13/cobra v1.1.1
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0


### PR DESCRIPTION
The toitc executable might be symlinked, so we need to follow it to find
the lib directory.

Also point the SDK to the actual SDK root (which should contain the 'lib' directory).