### PR TITLE
Remove obsolete OTA initialization code

### DIFF
--- a/src/ota.h
+++ b/src/ota.h
@@ -1,3 +1,17 @@
+// Copyright (C) 2018 Toitware ApS.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
 
 namespace toit {
 

--- a/src/ota.h
+++ b/src/ota.h
@@ -1,0 +1,10 @@
+
+namespace toit {
+
+class Ota {
+ public:
+  static void set_up();
+  static bool is_firmware_updated();
+};
+
+}

--- a/src/ota_esp32.cc
+++ b/src/ota_esp32.cc
@@ -1,0 +1,16 @@
+#ifdef TOIT_FREERTOS
+#include "ota.h"
+
+#include "esp_ota_ops.h"
+
+namespace toit {
+
+bool Ota::is_firmware_updated() {
+  return false;
+}
+
+void Ota::set_up() { }
+
+}  // namespace toit
+
+#endif

--- a/src/ota_esp32.cc
+++ b/src/ota_esp32.cc
@@ -1,7 +1,19 @@
-#ifdef TOIT_FREERTOS
-#include "ota.h"
+// Copyright (C) 2018 Toitware ApS.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
 
-#include "esp_ota_ops.h"
+#include "ota.h"
 
 namespace toit {
 
@@ -12,5 +24,3 @@ bool Ota::is_firmware_updated() {
 void Ota::set_up() { }
 
 }  // namespace toit
-
-#endif


### PR DESCRIPTION
https://github.com/toitlang/toit/commit/746df36f67d563249612d012ab03aa50c9c1664f removed the OTA partitions from the partition table. However, the OTA initialization code was not removed. This PR removes the OTA initialization code which solves https://github.com/toitlang/toit/issues/186.