### PR TITLE
Make mbedtls compile into `build/host`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,14 +119,20 @@ add_custom_target(
   COMMAND echo ${TOIT_GIT_VERSION} > "${CMAKE_BINARY_DIR}/sdk/VERSION"
 )
 
+add_subdirectory(src)
+
+enable_testing()
+add_subdirectory(tests)
+
 set(CMAKE_POLICY_DEFAULT_CMP0076 OLD)
+# There is no prefix, so this variable might be interfere with other libraries.
+# Eventually, we need to import mbedtls differently.
+set(ENABLE_TESTING CACHE BOOL OFF)
+set(ENABLE_PROGRAMS CACHE BOOL OFF)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 add_subdirectory(
   "${IDF_PATH}/components/mbedtls/mbedtls"
   "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mbedtls"
   )
 
 set(CMAKE_POLICY_DEFAULT_CMP0076 NEW)
-add_subdirectory(src)
-
-enable_testing()
-add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,10 +125,13 @@ enable_testing()
 add_subdirectory(tests)
 
 set(CMAKE_POLICY_DEFAULT_CMP0076 OLD)
-# There is no prefix, so this variable might be interfere with other libraries.
+# The 'ENABLE_TESTING' and 'ENABLE_PROGRAMS' variables (used by mbedtls) have no prefix. As
+# such they might interfere with other libraries.
 # Eventually, we need to import mbedtls differently.
 set(ENABLE_TESTING CACHE BOOL OFF)
 set(ENABLE_PROGRAMS CACHE BOOL OFF)
+# Resetting the 'CMAKE_RUNTIME_OUTPUT_DIRECTORY' so that mbedtls doesn't pollute the
+# 'sdk/bin' directory.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 add_subdirectory(
   "${IDF_PATH}/components/mbedtls/mbedtls"


### PR DESCRIPTION
Also don't enable programs and tests for mbedtls.