### PR TITLE
Let the compiler localize file paths.

### DIFF
--- a/src/compiler/compiler.cc
+++ b/src/compiler/compiler.cc
@@ -37,6 +37,7 @@
 #include "filesystem_socket.h"
 #include "goto_definition.h"
 #include "lambda.h"
+#include "list.h"
 #include "lock.h"
 #include "map.h"
 #include "monitor.h"
@@ -505,6 +506,9 @@ bool read_from_pipe(int fd, void* buffer, int requested_bytes) {
 
 void Compiler::analyze(List<const char*> source_paths,
                        const Compiler::Configuration& compiler_config) {
+  // We accept '/' paths on Windows as well.
+  // For simplicity (and consistency) switch to localized ones in the compiler.
+  source_paths = FilesystemLocal::to_local_path(source_paths);
   bool single_source = source_paths.length() == 1;
   FilesystemHybrid fs(single_source ? source_paths[0] : null);
   SourceManager source_manager(&fs);
@@ -616,6 +620,10 @@ SnapshotBundle Compiler::compile(const char* source_path,
                                  char** snapshot_args,
                                  const char* out_path,
                                  const Compiler::Configuration& compiler_config) {
+  // We accept '/' paths on Windows as well.
+  // For simplicity (and consistency) switch to localized ones in the compiler.
+  source_path = FilesystemLocal::to_local_path(source_path);
+  out_path = FilesystemLocal::to_local_path(out_path);
   FilesystemHybrid fs(source_path);
   SourceManager source_manager(&fs);
   CompilationDiagnostics diagnostics(&source_manager, compiler_config.show_package_warnings);

--- a/src/compiler/filesystem_local.cc
+++ b/src/compiler/filesystem_local.cc
@@ -52,6 +52,14 @@ namespace compiler {
 
 char* get_executable_path();
 
+List<const char*> FilesystemLocal::to_local_path(List<const char*> paths) {
+  auto result = ListBuilder<const char*>::allocate(paths.length());
+  for (int i = 0; i < paths.length(); i++) {
+    result[i] = FilesystemLocal::to_local_path(paths[i]);
+  }
+  return result;
+}
+
 bool FilesystemLocal::do_exists(const char* path) {
 #ifdef USE_XSTAT64
   // Use an older version of stat, so that we can run in docker

--- a/src/compiler/filesystem_local.h
+++ b/src/compiler/filesystem_local.h
@@ -17,6 +17,7 @@
 
 #include "../top.h"
 
+#include "list.h"
 #include "filesystem.h"
 
 namespace toit {
@@ -42,6 +43,7 @@ class FilesystemLocal : public Filesystem {
   ///   by the caller with `delete []`.
   static char* get_executable_path();
   static char* to_local_path(const char* path);
+  static List<const char*> to_local_path(List<const char*> paths);
 
  protected:
   bool do_exists(const char* path);

--- a/src/compiler/toitc.cc
+++ b/src/compiler/toitc.cc
@@ -16,7 +16,6 @@
 #include "../top.h"
 #include "../flags.h"
 #include "compiler.h"
-#include "filesystem_local.h"
 
 #include <errno.h>
 #include <libgen.h>
@@ -155,7 +154,7 @@ int main(int argc, char **argv) {
           fprintf(stderr, "Only one '-w' flag is allowed.\n");
           print_usage(1);
         }
-        bundle_filename = FilesystemLocal::to_local_path(argv[processed_args++]);
+        bundle_filename = argv[processed_args++];
       } else if (strcmp(argv[processed_args], "--force") == 0) {
         force = true;
         processed_args++;
@@ -226,7 +225,7 @@ int main(int argc, char **argv) {
           }
           ways_to_run++;
           ASSERT(source_path_count == 0);
-          source_path = FilesystemLocal::to_local_path(argv[processed_args++]);
+          source_path = argv[processed_args++];
           source_path_count = 1;
         }
         break;
@@ -298,16 +297,13 @@ int main(int argc, char **argv) {
       compiler.language_server(compiler_config);
     } else if (for_analysis) {
       compiler::Compiler compiler;
-      List<const char*> paths(source_paths, source_path_count);
-      for (int i = 0; i < paths.length(); i++) {
-        paths[i] = FilesystemLocal::to_local_path(paths[i]);
-      }
-      compiler.analyze(paths, compiler_config);
+      compiler.analyze(List<const char*>(source_paths, source_path_count),
+                       compiler_config);
     } else if (bundle_filename != null) {
       auto compiled = SnapshotBundle::invalid();
       compiler::Compiler compiler;
       auto source_path = source_path_count == 0 ? null : source_paths[0];
-      compiled = compiler.compile(FilesystemLocal::to_local_path(source_path),
+      compiled = compiler.compile(source_path,
                                   direct_script,
                                   args,
                                   bundle_filename,


### PR DESCRIPTION
This way the vm also localizes its filenames.