### PR TITLE
Build snapshots in Cmake.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,34 @@ jobs:
           git submodule sync --recursive
           git submodule update --init --recursive -j 2
 
+      # Use Go 1.17
+      - name: Switch to Go 1.17
+        run:
+          echo "$GOROOT_1_17_X64"/bin >> $GITHUB_PATH
+
+      # Get values for cache paths to be used in later steps
+      - name: Get Go paths
+        id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
+      # Cache go build cache, used to speedup go test
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-build-
+
+      # Cache go mod cache, used to speedup builds
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-mod-
+
       # We create a new id every second.
       # The 'restore-keys' below will make sure that we continue using earlier versions.
       - name: Create timestamp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,10 @@ else ()
     set(TOIT_LINK_GROUP_END_FLAGS "-Wl,--no-whole-archive")
 endif()
 
+if (NOT DEFINED TOIT_IS_CROSS)
+  set(TOITC "$<TARGET_FILE:toit.compile>")
+endif()
+
 add_custom_target(
   build_toitlsp
   COMMAND make -C ${CMAKE_SOURCE_DIR} toitlsp
@@ -124,7 +128,12 @@ add_custom_target(
   COMMAND echo ${TOIT_GIT_VERSION} > "${CMAKE_BINARY_DIR}/sdk/VERSION"
 )
 
+add_custom_target(
+  build_snapshots
+)
+
 add_subdirectory(src)
+add_subdirectory(tools)
 
 enable_testing()
 add_subdirectory(tests)

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ build/host/CMakeCache.txt:
 	(cd build/host && cmake ../.. -G Ninja -DCMAKE_BUILD_TYPE=Release)
 
 .PHONY: tools
-tools: check-env build/host/CMakeCache.txt
+tools: check-env build/host/CMakeCache.txt $(TOITPKG_BIN) $(TOITLSP_BIN)
 	(cd build/host && ninja build_tools)
 
 .PHONY: snapshots
@@ -113,7 +113,7 @@ all-cross: tools-cross snapshots-cross
 
 check-env-cross:
 ifndef CROSS_ARCH
-	$(error invalid must specify a cross-compilation targt with CROSS_ARCH.  ie: make tools-cross CROSS_ARCH=riscv64)
+	$(error invalid must specify a cross-compilation targt with CROSS_ARCH.  For example: make all-cross CROSS_ARCH=riscv64)
 endif
 ifeq ("$(wildcard ./toolchains/$(CROSS_ARCH).cmake)","")
 	$(error invalid cross-compile target '$(CROSS_ARCH)')
@@ -124,7 +124,7 @@ build/$(CROSS_ARCH)/CMakeCache.txt:
 	(cd build/$(CROSS_ARCH) && cmake ../../ -G Ninja -DTOITC=$(CURDIR)/build/host/sdk/bin/toit.compile -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../../toolchains/$(CROSS_ARCH).cmake --no-warn-unused-cli)
 
 .PHONY: tools-cross
-tools-cross: build/$(CROSS_ARCH)/CMakeCache.txt tools
+tools-cross: check-env-cross build/$(CROSS_ARCH)/CMakeCache.txt tools
 	(cd build/$(CROSS_ARCH) && ninja build_tools)
 
 .PHONY: snapshots-cross

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,13 @@ else
 	EXE_SUFFIX=
 endif
 
+SNAPSHOT_DIR = build/host/sdk/snapshots
+BIN_DIR = build/host/sdk/bin
+TOITPKG_BIN = $(BIN_DIR)/toit.pkg$(EXE_SUFFIX)
+TOITLSP_BIN = $(BIN_DIR)/toit.lsp$(EXE_SUFFIX)
+TOITVM_BIN = $(BIN_DIR)/toit.run$(EXE_SUFFIX)
+TOITC_BIN = $(BIN_DIR)/toit.compile$(EXE_SUFFIX)
+
 VERSION_FILE = build/host/sdk/VERSION
 CROSS_ARCH=
 
@@ -126,13 +133,6 @@ snapshots-cross: tools
 
 
 # ESP32 VARIANTS
-SNAPSHOT_DIR = build/host/sdk/snapshots
-BIN_DIR = build/host/sdk/bin
-TOITPKG_BIN = $(BIN_DIR)/toit.pkg$(EXE_SUFFIX)
-TOITLSP_BIN = $(BIN_DIR)/toit.lsp$(EXE_SUFFIX)
-TOITVM_BIN = $(BIN_DIR)/toit.run$(EXE_SUFFIX)
-TOITC_BIN = $(BIN_DIR)/toit.compile$(EXE_SUFFIX)
-
 .PHONY: esp32
 esp32: check-env build/$(ESP32_CHIP)/toit.bin
 
@@ -181,12 +181,15 @@ clean:
 	rm -rf build/
 
 .PHONY: install-sdk install
-install-sdk: $(TOOLS) $(SNAPSHOTS)
-	install -D --target-directory="$(DESTDIR)$(prefix)"/bin $(TOOLS)
-	install -m 644 -D --target-directory="$(DESTDIR)$(prefix)"/bin $(TOIT_BOOT_SNAPSHOT)
-	cp -R "$(CURDIR)"/lib "$(DESTDIR)$(prefix)"/lib
+install-sdk: all
+	install -D --target-directory="$(DESTDIR)$(prefix)"/bin "$(CURDIR)"/build/host/sdk/bin/*
+	chmod 644 "$(DESTDIR)$(prefix)"/bin/*.snapshot
+	mkdir -p "$(DESTDIR)$(prefix)"/lib
+	cp -R "$(CURDIR)"/lib/* "$(DESTDIR)$(prefix)"/lib
 	find "$(DESTDIR)$(prefix)"/lib -type f -exec chmod 644 {} \;
-	install -m 644 -D --target-directory="$(DESTDIR)$(prefix)"/snapshots $(SNAPSHOTS)
+	mkdir -p "$(DESTDIR)$(prefix)"/snapshots
+	cp "$(CURDIR)"/build/host/sdk/snapshots/* "$(DESTDIR)$(prefix)"/snapshots
+	find "$(DESTDIR)$(prefix)"/snapshots -type f -exec chmod 644 {} \;
 
 install: install-sdk
 

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,6 @@ else
 	EXE_SUFFIX=
 endif
 
-BIN_DIR = build/host/sdk/bin
-TOITPKG_BIN = $(BIN_DIR)/toit.pkg$(EXE_SUFFIX)
-TOITLSP_BIN = $(BIN_DIR)/toit.lsp$(EXE_SUFFIX)
-TOITVM_BIN = $(BIN_DIR)/toit.run$(EXE_SUFFIX)
-TOITC_BIN = $(BIN_DIR)/toit.compile$(EXE_SUFFIX)
 VERSION_FILE = build/host/sdk/VERSION
 CROSS_ARCH=
 
@@ -131,17 +126,25 @@ snapshots-cross: tools
 
 
 # ESP32 VARIANTS
+SNAPSHOT_DIR = build/host/sdk/snapshots
+BIN_DIR = build/host/sdk/bin
+TOITPKG_BIN = $(BIN_DIR)/toit.pkg$(EXE_SUFFIX)
+TOITLSP_BIN = $(BIN_DIR)/toit.lsp$(EXE_SUFFIX)
+TOITVM_BIN = $(BIN_DIR)/toit.run$(EXE_SUFFIX)
+TOITC_BIN = $(BIN_DIR)/toit.compile$(EXE_SUFFIX)
+
 .PHONY: esp32
 esp32: check-env build/$(ESP32_CHIP)/toit.bin
 
-build/$(ESP32_CHIP)/toit.bin build/$(ESP32_CHIP)/toit.elf: tools build/$(ESP32_CHIP)/lib/libtoit_image.a build/config.json
+build/$(ESP32_CHIP)/toit.bin build/$(ESP32_CHIP)/toit.elf: tools snapshots build/$(ESP32_CHIP)/lib/libtoit_image.a build/config.json
 	make -C toolchains/$(ESP32_CHIP)/
 	$(TOITVM_BIN) tools/inject_config.toit build/config.json build/$(ESP32_CHIP)/toit.bin
 
 build/$(ESP32_CHIP)/lib/libtoit_image.a: build/$(ESP32_CHIP)/$(ESP32_CHIP).image.s build/$(ESP32_CHIP)/CMakeCache.txt build/$(ESP32_CHIP)/include/sdkconfig.h
 	(cd build/$(ESP32_CHIP) && ninja toit_image)
 
-build/$(ESP32_CHIP)/$(ESP32_CHIP).image.s: tools snapshots build/snapshot build/$(ESP32_CHIP)/
+build/$(ESP32_CHIP)/$(ESP32_CHIP).image.s: tools snapshots build/snapshot
+	mkdir -p build/$(ESP32_CHIP)
 	$(TOITVM_BIN) $(SNAPSHOT_DIR)/snapshot_to_image.snapshot build/snapshot $@
 
 build/snapshot: $(TOITC_BIN) $(ESP32_ENTRY)

--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,6 @@ TOITC_BIN = $(BIN_DIR)/toit.compile$(EXE_SUFFIX)
 VERSION_FILE = build/host/sdk/VERSION
 CROSS_ARCH=
 
-# Note that the boot snapshot lives in the bin dir.
-TOIT_BOOT_SNAPSHOT = $(BIN_DIR)/run_boot.snapshot
-
-SNAPSHOT_DIR = build/host/sdk/snapshots
-
 prefix ?= /opt/toit-sdk
 
 GO_BUILD_FLAGS ?=
@@ -64,16 +59,9 @@ GO_LINK_FLAGS +=-X main.date=$(BUILD_DATE)
 TOITLSP_SOURCE := $(shell find ./tools/toitlsp/ -name '*.go')
 TOITPKG_VERSION := v0.0.0-20211126161923-c00da039da00
 
-TOOLS = $(TOITPKG_BIN) $(TOITLSP_BIN) $(TOITVM_BIN) $(TOITC_BIN) $(VERSION_FILE)
-SNAPSHOTS = $(SNAPSHOT_DIR)/system_message.snapshot $(SNAPSHOT_DIR)/snapshot_to_image.snapshot $(SNAPSHOT_DIR)/inject_config.snapshot
-
-
 # HOST
 .PHONY: all
-all: tools
-
-.PHONY: tools
-tools: check-env $(TOOLS) snapshots
+all: tools snapshots $(VERSION_FILE)
 
 check-env:
 ifeq ("$(wildcard $(IDF_PATH)/components/mbedtls/mbedtls/LICENSE)","")
@@ -86,6 +74,18 @@ endif
 ifneq ("$(IDF_PATH)", "$(CURDIR)/third_party/esp-idf")
 	$(info -- Not using Toitware ESP-IDF fork.)
 endif
+
+build/host/CMakeCache.txt:
+	mkdir -p build/host
+	(cd build/host && cmake ../.. -G Ninja -DCMAKE_BUILD_TYPE=Release)
+
+.PHONY: tools
+tools: check-env build/host/CMakeCache.txt
+	(cd build/host && ninja build_tools)
+
+.PHONY: snapshots
+snapshots: tools
+	(cd build/host && ninja build_snapshots)
 
 .PHONY: toitpkg
 toitpkg: $(TOITPKG_BIN)
@@ -100,40 +100,14 @@ toitlsp: $(TOITLSP_BIN)
 $(TOITLSP_BIN): $(TOITLSP_SOURCE)
 	cd tools/toitlsp; $(GO_BUILD_FLAGS) go build  -ldflags "$(GO_LINK_FLAGS)" -tags 'netgo osusergo' -o "$(CURDIR)"/$@ .
 
-# We don't track dependencies in the Makefile, so we always have to call out to ninja.
-.PHONY: $(TOITVM_BIN) $(TOITC_BIN) $(TOIT_BOOT_SNAPSHOT)
-$(TOITVM_BIN) $(TOITC_BIN) $(TOIT_BOOT_SNAPSHOT): build/host/CMakeCache.txt
-	(cd build/host && ninja build_tools)
-
-build/host/CMakeCache.txt: build/host/
-	(cd build/host && cmake ../.. -G Ninja -DCMAKE_BUILD_TYPE=Release)
-
-build/host/:
-	mkdir -p $@
-
 .PHONY: $(VERSION_FILE)
 $(VERSION_FILE):
 	(cd build/host && ninja build_version_file)
 
-.PHONY: snapshots
-snapshots: $(SNAPSHOTS)
-
-$(SNAPSHOT_DIR)/snapshot_to_image.snapshot: tools/snapshot_to_image.toit $(TOITC_BIN) $(SNAPSHOT_DIR)
-	$(TOITC_BIN) -w $@ $<
-
-$(SNAPSHOT_DIR)/system_message.snapshot: tools/system_message.toit $(TOITC_BIN) $(SNAPSHOT_DIR)
-	$(TOITC_BIN) -w $@ $<
-
-$(SNAPSHOT_DIR)/inject_config.snapshot: tools/inject_config.toit $(TOITC_BIN) $(SNAPSHOT_DIR)
-	$(TOITC_BIN) -w $@ $<
-
-$(SNAPSHOT_DIR):
-	mkdir -p $@
-
 
 # CROSS-COMPILE
-.PHONY: tools-cross
-tools-cross: check-env check-env-cross tools build/$(CROSS_ARCH)/sdk/bin/toit.run build/$(CROSS_ARCH)/sdk/bin/toit.compile build/$(CROSS_ARCH)/sdk/bin/run_boot.snapshot
+.PHONY: all-cross
+all-cross: tools-cross snapshots-cross
 
 check-env-cross:
 ifndef CROSS_ARCH
@@ -143,44 +117,42 @@ ifeq ("$(wildcard ./toolchains/$(CROSS_ARCH).cmake)","")
 	$(error invalid cross-compile target '$(CROSS_ARCH)')
 endif
 
-.PHONY: build/$(CROSS_ARCH)/sdk/bin/toit.run build/$(CROSS_ARCH)/sdk/bin/toit.compile
-build/$(CROSS_ARCH)/sdk/bin/toit.run build/$(CROSS_ARCH)/sdk/bin/toit.compile: build/$(CROSS_ARCH)/CMakeCache.txt
+build/$(CROSS_ARCH)/CMakeCache.txt:
+	mkdir -p build/$(CROSS_ARCH)
+	(cd build/$(CROSS_ARCH) && cmake ../../ -G Ninja -DTOITC=$(CURDIR)/build/host/sdk/bin/toit.compile -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../../toolchains/$(CROSS_ARCH).cmake --no-warn-unused-cli)
+
+.PHONY: tools-cross
+tools-cross: build/$(CROSS_ARCH)/CMakeCache.txt tools
 	(cd build/$(CROSS_ARCH) && ninja build_tools)
 
-build/$(CROSS_ARCH)/CMakeCache.txt: build/$(CROSS_ARCH)/
-	(cd build/$(CROSS_ARCH) && cmake ../../ -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../../toolchains/$(CROSS_ARCH).cmake --no-warn-unused-cli)
-
-build/$(CROSS_ARCH)/:
-	mkdir -p $@
-
-build/$(CROSS_ARCH)/sdk/bin/run_boot.snapshot:
-	(cp $(TOIT_BOOT_SNAPSHOT) build/$(CROSS_ARCH)/sdk/bin/)
+.PHONY: snapshots-cross
+snapshots-cross: tools
+	(cd build/$(CROSS_ARCH) && ninja build_snapshots)
 
 
 # ESP32 VARIANTS
 .PHONY: esp32
 esp32: check-env build/$(ESP32_CHIP)/toit.bin
 
-build/$(ESP32_CHIP)/toit.bin build/$(ESP32_CHIP)/toit.elf: build/$(ESP32_CHIP)/lib/libtoit_image.a build/config.json
+build/$(ESP32_CHIP)/toit.bin build/$(ESP32_CHIP)/toit.elf: tools build/$(ESP32_CHIP)/lib/libtoit_image.a build/config.json
 	make -C toolchains/$(ESP32_CHIP)/
 	$(TOITVM_BIN) tools/inject_config.toit build/config.json build/$(ESP32_CHIP)/toit.bin
 
 build/$(ESP32_CHIP)/lib/libtoit_image.a: build/$(ESP32_CHIP)/$(ESP32_CHIP).image.s build/$(ESP32_CHIP)/CMakeCache.txt build/$(ESP32_CHIP)/include/sdkconfig.h
 	(cd build/$(ESP32_CHIP) && ninja toit_image)
 
-build/$(ESP32_CHIP)/$(ESP32_CHIP).image.s: build/$(ESP32_CHIP)/ build/snapshot $(TOITVM_BIN) $(SNAPSHOT_DIR)/snapshot_to_image.snapshot
+build/$(ESP32_CHIP)/$(ESP32_CHIP).image.s: tools snapshots build/snapshot build/$(ESP32_CHIP)/
 	$(TOITVM_BIN) $(SNAPSHOT_DIR)/snapshot_to_image.snapshot build/snapshot $@
 
 build/snapshot: $(TOITC_BIN) $(ESP32_ENTRY)
 	$(TOITC_BIN) -w $@ $(ESP32_ENTRY)
 
-build/$(ESP32_CHIP)/CMakeCache.txt: build/$(ESP32_CHIP)/
+build/$(ESP32_CHIP)/CMakeCache.txt:
+	mkdir -p build/$(ESP32_CHIP)
 	(cd build/$(ESP32_CHIP) && IMAGE=build/$(ESP32_CHIP)/$(ESP32_CHIP).image.s cmake ../../ -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../../toolchains/$(ESP32_CHIP)/$(ESP32_CHIP).cmake --no-warn-unused-cli)
 
-build/$(ESP32_CHIP)/:
-	mkdir -p $@
-
-build/$(ESP32_CHIP)/include/sdkconfig.h: build/$(ESP32_CHIP)/
+build/$(ESP32_CHIP)/include/sdkconfig.h:
+	mkdir -p build/$(ESP32_CHIP)
 	make -C toolchains/$(ESP32_CHIP) -s "$(CURDIR)"/$@
 
 .PHONY: build/config.json

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ fatal: remote error: want 7f8c86e501e690301630029fa9bae22424adf618 not valid
 Fetched in submodule path 'esp-idf/components/coap/libcoap/ext/tinydtls', but it did not contain 7f8c86e501e690301630029fa9bae22424adf618. Direct fetching of that commit failed.
 ```
 
-try following the steps outlined [here](https://github.com/toitlang/toit/issues/88). It is an issue in the upstream ESP-IDF repository 
+try following the steps outlined [here](https://github.com/toitlang/toit/issues/88). It is an issue in the upstream ESP-IDF repository
 caused by the `tinydtls` component having changed its remote URL.
 
 To use the [offical ESP-IDF](https://github.com/espressif/esp-idf), or [any other variation](https://github.com/espressif/esp-idf/network/members), make sure it is available in your file system and point IDF_PATH to its path instead before building.
@@ -168,7 +168,7 @@ Make sure the required build tools are installed as described in dependency sect
 Then run the following commands at the root of your checkout.
 
 ``` sh
-make tools
+make all
 ```
 
 ---

--- a/README_OTHERPLATFORMS.md
+++ b/README_OTHERPLATFORMS.md
@@ -25,7 +25,7 @@ apt update
 apt install git build-essential bc cmake python3 python3-pip python-is-python3 libffi-dev libssl-dev cargo golang ninja-build
 ```
 
-## 3) Clone sources 
+## 3) Clone sources
 ``` sh
 #Toit
 git clone https://github.com/toitlang/toit.git
@@ -37,10 +37,7 @@ git submodule update --init --recursive
 
 ## 4) Compile Toit SDK
 ``` sh
-#Add IDF path to environment
-export IDF_PATH=`pwd`/third_party/esp-idf
-
-make tools
+make all
 ```
 
 ## 5) Run examples
@@ -53,10 +50,12 @@ build/host/bin/toit.run examples/mandelbrot.toit
 </br>
 
 # Cross-compiling
-How to compile the Toit binaries (toit.compile and toit.run) for another architecture (ie. RISC-V) from an amd64 host
+This section describes how to compile the Toit binaries (toit.compile and toit.run) for another
+architecture (like RISC-V).
 
-## 1) Compile host tools
->Note: This is necessary to generate run_boot.snapshot, a dependency for the toit.run runtime. </br> 
+## 1) Prepare host tools
+>Note: This is necessary to generate the snapshots that are part of the SDK.
+
 Follow [steps 2-4 above](README_OTHERPLATFORMS.md#2-install-dependencies) on the host.
 
 ## 2) Install cross-compile dependencies
@@ -82,19 +81,24 @@ apt install g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64
 ## 3) Cross-compile Toit SDK
 ``` sh
 #Substitute <TARGET> with one of [arm32, arm64, riscv64, win32, win64]
-make tools-cross CROSS_ARCH=<TARGET>
+make all-cross CROSS_ARCH=<TARGET>
 ```
 
 ## 4) Deploy
 A complete Toit environment should now be ready for use on the target architecture
 ``` sh
-ubuntu@ubuntu:~/git/toit$ ls -l build/riscv64/sdk/bin/
-total 4112
-lrwxrwxrwx 1 ubuntu ubuntu      31 Dec  4 07:48 lib -> /home/ubuntu/git/toit/lib
-drwxrwxr-x 7 ubuntu ubuntu    4096 Dec  4 11:19 mbedtls
--rwxrwxr-x 1 ubuntu ubuntu 1806496 Dec  4 07:49 toit.compile
--rwxrwxr-x 1 ubuntu ubuntu 2189584 Dec  4 07:49 toit.run
--rw-rw-r-- 1 ubuntu ubuntu  202320 Dec  4 11:19 run_boot.snapshot
+ᐅ find build/win64/sdk
+build/win64/sdk
+build/win64/sdk/bin
+build/win64/sdk/bin/toit.run.exe
+build/win64/sdk/bin/toit.compile.exe
+build/win64/sdk/bin/run_boot.snapshot
+build/win64/sdk/lib
+build/win64/sdk/snapshots
+build/win64/sdk/snapshots/inject_config.snapshot
+build/win64/sdk/snapshots/snapshot_to_image.snapshot
+build/win64/sdk/snapshots/system_message.snapshot
 ```
-</br>
-</br>
+
+>Note: The `sdk/lib` directory is, by default, only a symlink to the 'lib' directory.
+  For deployment the SDK needs to have the symlink replaced by a copy of the 'lib' directory.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,6 +133,8 @@ add_custom_target(
   DEPENDS ${BOOT_SNAPSHOT}
 )
 
+add_dependencies(build_snapshots build_boot_snapshot)
+
 if (NOT DEFINED TOIT_IS_CROSS)
   add_dependencies(build_tools build_boot_snapshot)
 endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright (C) 2022 Toitware ApS.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; version
+# 2.1 only.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# The license can be found in the file `LICENSE` in the top level
+# directory of this repository.
+
+include(toit.cmake)
+
+set(TOOLS system_message snapshot_to_image inject_config)
+
+foreach (TOOL ${TOOLS})
+  set(TOOL_SNAPSHOT ${CMAKE_BINARY_DIR}/sdk/snapshots/${TOOL}.snapshot)
+
+  ADD_TOIT_TARGET(
+    ${CMAKE_CURRENT_SOURCE_DIR}/${TOOL}.toit
+    ${TOOL_SNAPSHOT}
+    ${CMAKE_CURRENT_BINARY_DIR}/${TOOL}.dep
+    ""
+  )
+
+  set(SNAPSHOTS ${TOOL_SNAPSHOT} ${SNAPSHOTS})
+endforeach ()
+
+add_custom_target(
+  build_tool_snapshots
+  DEPENDS ${SNAPSHOTS}
+)
+add_dependencies(build_snapshots build_tool_snapshots)

--- a/tools/toit.cmake
+++ b/tools/toit.cmake
@@ -15,7 +15,14 @@
 
 # Creates a custom command to build ${TARGET} with correct dependencies.
 function(ADD_TOIT_TARGET SOURCE TARGET DEP_FILE ENV)
-  set(TOITC "$<TARGET_FILE:toit.compile>")
+  if (NOT DEFINED TOITC)
+    set(TOITC "$ENV{TOITC}")
+    if ("${TOITC}" STREQUAL "")
+      # TOITC is normally set to the toit.compile executable.
+      # However, for cross-compilation the compiler must be provided manually.
+      message(FATAL_ERROR "TOITC not provided")
+    endif()
+  endif()
   if(POLICY CMP0116)
     cmake_policy(SET CMP0116 NEW)
   endif()


### PR DESCRIPTION
This has the advantage of keeping track of the dependencies.

It also simplifies the Makefile.