### PR TITLE
Fix way of how environment is passed to command.

### DIFF
--- a/tests/toit_run_image/CMakeLists.txt
+++ b/tests/toit_run_image/CMakeLists.txt
@@ -32,15 +32,16 @@ foreach(file ${TOIT_RUN_IMAGE_TESTS})
   set(dep ${TOIT_RUN_IMAGE_TEST_DIR}/${test_name}_input.dep)
 
   ADD_TOIT_TARGET(
-    ${input}
-    ${snap}
-    ${dep}
+    "${input}"
+    "${snap}"
+    "${dep}"
     "")
 
   add_custom_command(
-    OUTPUT ${image}
-    DEPENDS ${snap}
-    COMMAND ASAN_OPTIONS=detect_leaks=false $<TARGET_FILE:toit.compile> -i ${image} ${snap}
+    OUTPUT "${image}"
+    DEPENDS "${snap}"
+    COMMAND "${CMAKE_COMMAND}" -E env ASAN_OPTIONS=detect_leaks=false
+        $<TARGET_FILE:toit.compile> -i "${image}" "${snap}"
   )
 
   set(build_img tests-toit_run_image-build_${test_name}_input)


### PR DESCRIPTION
Under windows we can't just prefix the environment options.