### PR TITLE
Change submodule URL to public repository.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 	ignore = untracked
 [submodule "tools/tpkg"]
 	path = tools/tpkg
-	url = ../tpkg
+	url = https://github.com/toitlang/tpkg.git


### PR DESCRIPTION
The relative path for git submodules is only really convenient when the
repository is private.