### PR TITLE
Remove support for first-segment prefixes.

### DIFF
--- a/src/compiler/resolver.h
+++ b/src/compiler/resolver.h
@@ -105,19 +105,16 @@ class Resolver {
                            Module* entry_module,
                            Module* core_module);
   void resolve_fill_toplevel_methods(Module* module,
-                                     Scope* scope,
                                      Module* entry_module,
                                      Module* core_module);
   void resolve_fill_classes(Module* module,
-                            Scope* scope,
                             Module* entry_module,
                             Module* core_module);
   void resolve_fill_class(ir::Class* klass,
-                          Scope* scope,
+                          ModuleScope* module_scope,
                           Module* entry_module,
                           Module* core_module);
   void resolve_fill_globals(Module* module,
-                            Scope* scope,
                             Module* entry_module,
                             Module* core_module);
   void resolve_fill_method(ir::Method* method,

--- a/tests/negative/deprecated_first_segment_test.toit
+++ b/tests/negative/deprecated_first_segment_test.toit
@@ -1,7 +1,0 @@
-// Copyright (C) 2021 Toitware ApS. All rights reserved.
-
-import encoding.json
-
-main:
-  print (encoding.stringify "foo")
-  unresolved

--- a/tests/negative/gold/deprecated_first_segment_test.gold
+++ b/tests/negative/gold/deprecated_first_segment_test.gold
@@ -1,7 +1,0 @@
-tests/negative/deprecated_first_segment_test.toit:3:8: warning: Deprecated first-segment prefix
-import encoding.json
-       ^~~~~~~~
-tests/negative/deprecated_first_segment_test.toit:7:3: error: Unresolved identifier: 'unresolved'
-  unresolved
-  ^~~~~~~~~~
-Compilation failed.


### PR DESCRIPTION
This removes the deprecation warning and simply uses the last segment.