### PR TITLE
Change order in which we localize.

### DIFF
--- a/tests/negative/fail.cmake
+++ b/tests/negative/fail.cmake
@@ -18,23 +18,14 @@ set(TOIT_FAILING_TESTS
 
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
   list(APPEND TOIT_FAILING_TESTS
-    tests/negative/import9_test.toit
-    tests/negative/importA_test.toit
-    tests/negative/importB_test.toit
-    tests/negative/importC_test.toit
-    tests/negative/importD_test.toit
-    tests/negative/import_no_exit_test.toit
-    tests/negative/is_test.toit
     tests/negative/lock_sdk_bad/lock_sdk_bad_test.toit
     tests/negative/lock_sdk_bad2/lock_sdk_bad_test.toit
     tests/negative/lock_sdk_empty/lock_sdk_empty_test.toit
     tests/negative/pkg_bad_path/main_test.toit
-    tests/negative/pkg_dot_out/main_test.toit
     tests/negative/pkg_lock_errors/main_test.toit
     tests/negative/pkg_no_src/main_test.toit
     tests/negative/pkg_not_found/main_test.toit
     tests/negative/pkg_not_found/relative_test.toit
     tests/negative/pkg_not_found_error/main_test.toit
-    tests/negative/pkg_rel_not_found/main_test.toit
   )
 endif()

--- a/tests/tools/normalize_gold.cmake
+++ b/tests/tools/normalize_gold.cmake
@@ -19,6 +19,8 @@ function(LOCALIZE_GOLD INPUT OUTPUT)
   # Find all potential paths and replace them.
   string(REGEX MATCHALL "(/?tests[a-zA-Z_0-9/]+)|([a-zA-Z_0-9/]+[.]toit)" PATHS "${INPUT}")
   list(REMOVE_DUPLICATES PATHS)
+  # In case one path is a prefix of the other have the longer one be handled first.
+  list(SORT PATHS ORDER DESCENDING)
   set(RESULT "${INPUT}")
   foreach(PATH ${PATHS})
     string(REPLACE "/" "\\" REPLACEMENT "${PATH}")


### PR DESCRIPTION
This fixes tests like the following:

```
--- D:/a/toit/toit/build/host/tmp/GOLD_nn7R91SLQEQj	2022-01-10 18:07:25.520160400 +0000
+++ D:/a/toit/toit/build/host/tmp/OUTPUT_nn7R91SLQEQj	2022-01-10 18:07:25.520160400 +0000
@@ -1,7 +1,7 @@
 tests\negative\import9_test.toit:3:1: error: Failed to find import '.non_existing'
 import .non_existing show A
 ^~~~~~
-tests\negative\import9_test.toit:3:9: note: Missing library file. Tried 'tests\negative\non_existing.toit' and 'tests\negative\non_existing/non_existing.toit'
+tests\negative\import9_test.toit:3:9: note: Missing library file. Tried 'tests\negative\non_existing.toit' and 'tests\negative\non_existing\non_existing.toit'
 import .non_existing show A
         ^~~~~~~~~~~~
 tests\negative\import9_test.toit:10:5: error: Class 'B' does not have any method 'bar'
CMake Error at tests/negative/run.cmake:72 (message):
  Not equal

```