### PR TITLE
Fix multiply on win64 architecture.

### DIFF
--- a/src/primitive_core.cc
+++ b/src/primitive_core.cc
@@ -500,8 +500,8 @@ PRIMITIVE(smi_multiply) {
   ARGS(word, receiver, Object, arg);
   if (arg->is_smi()) {
     word other = Smi::cast(arg)->value();
-    long result;
-    if (__builtin_smull_overflow(receiver, other << 1, &result)) goto overflow;
+    word result;
+    if (__builtin_mul_overflow(receiver, other << 1, &result)) goto overflow;
     Smi* r = reinterpret_cast<Smi*>(result);
     ASSERT(r == Smi::from(result >> 1));
     return r;

--- a/tests/fail.cmake
+++ b/tests/fail.cmake
@@ -33,7 +33,6 @@ if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
     tests/file_test.toit
     tests/interface_address_test.toit
     tests/keepalive_test.toit
-    tests/number_test.toit
     tests/pipe2_test.toit
     tests/pipe_test.toit
     tests/regress/issue3_test.toit


### PR DESCRIPTION
The primitive was using `long`, but that's not 64 bits on Windows.
Switched to `word` and `builtin_mul_overflow`.