### PR TITLE
Remove data type from AT command

### DIFF
--- a/lib/at/session.toit
+++ b/lib/at/session.toit
@@ -30,7 +30,7 @@ class Command:
   name/string
   type/string
   parameters/List ::= []
-  data/ByteArray? ::= null
+  data ::= null
 
   timeout/Duration
 


### PR DESCRIPTION
This makes set work with strings.