### PR TITLE
Improve GC logs.

### DIFF
--- a/src/heap.cc
+++ b/src/heap.cc
@@ -591,25 +591,25 @@ int ObjectHeap::scavenge() {
   int used_before = before.total_allocated_bytes * 100 / capacity_before;
   int used_after = after.total_allocated_bytes * 100 / capacity_after;
   printf("[gc @ %p%s "
-         "| toit: %zd%s/%zd%s -> %zd%s/%zd%s "
-         "| used: %zd%s/%zd%s@%d%% -> %zd%s/%zd%s@%d%% "
+         "| objects: %zd%s/%zd%s -> %zd%s/%zd%s "
+         "| overall: %zd%s/%zd%s@%d%% -> %zd%s/%zd%s@%d%% "
          "| free: %zd%s/%zd%s -> %zd%s/%zd%s "
          "| %d.%03dms]\n",
       owner(), VM::current()->scheduler()->is_boot_process(owner()) ? "*" : "",
-      FORMAT(external_memory_before), FORMAT(toit_before),                           // toit-before
-      FORMAT(_external_memory), FORMAT(toit_after),                                  // toit-after
-      FORMAT(before.total_allocated_bytes), FORMAT(capacity_before), used_before,    // used-before
-      FORMAT(after.total_allocated_bytes), FORMAT(capacity_after), used_after,       // used-after
+      FORMAT(external_memory_before), FORMAT(toit_before),                           // objects-before
+      FORMAT(_external_memory), FORMAT(toit_after),                                  // objects-after
+      FORMAT(before.total_allocated_bytes), FORMAT(capacity_before), used_before,    // overall-before
+      FORMAT(after.total_allocated_bytes), FORMAT(capacity_after), used_after,       // overall-after
       FORMAT(before.largest_free_block), FORMAT(before.total_free_bytes),            // free-before
       FORMAT(after.largest_free_block), FORMAT(after.total_free_bytes),              // free-after
       static_cast<int>(microseconds / 1000), static_cast<int>(microseconds % 1000)); // time
 #else
   printf("[gc @ %p%s "
-         "| toit: %zd%s/%zd%s -> %zd%s/%zd%s "
+         "| objects: %zd%s/%zd%s -> %zd%s/%zd%s "
          "| %d.%03dms]\n",
       owner(), VM::current()->scheduler()->is_boot_process(owner()) ? "*" : "",
-      FORMAT(external_memory_before), FORMAT(toit_before),                           // toit-before
-      FORMAT(_external_memory), FORMAT(toit_after),                                  // toit-after
+      FORMAT(external_memory_before), FORMAT(toit_before),                           // objects-before
+      FORMAT(_external_memory), FORMAT(toit_after),                                  // objects-after
       static_cast<int>(microseconds / 1000), static_cast<int>(microseconds % 1000)); // time
 #endif // TOIT_FREERTOS
 #endif // TOIT_GC_LOGGING

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -406,9 +406,11 @@ void Scheduler::scavenge(Process* process, bool malloc_failed, bool try_hard) {
     Locker locker(_mutex);
     _gc_cross_processes = false;
 #ifdef TOIT_GC_LOGGING
-    uint64 elapsed = OS::get_monotonic_time() - start;
+    int64 microseconds = OS::get_monotonic_time() - start;
     printf("[cross-process gc: %d scavenges, took %d.%03dms]\n",
-        scavenges + 1, elapsed / 1000, elapsed % 1000);
+        scavenges + 1,
+        static_cast<int>(microseconds / 1000),
+        static_cast<int>(microseconds % 1000));
 #endif
     OS::signal_all(_gc_condition);
   }


### PR DESCRIPTION
Changes the GC logs from:

```
[gc @ 0x3ffc3ad0* | heap: 44kb -> 24kb | external: 0kb -> 0kb | free: 12kb->12kb 2.138ms]
```

to:

```
[gc @ 0x3ffcf9a8* | objects: 28/56K -> 28/28K | overall: 225K/243K@92% -> 225K/243K@92% | free: 4096/18K -> 4096/18K | 2.916ms]
```

to better show the objects (including external stuff before the /), the memory capacity and usage, and the state of the freelists.