### PR TITLE
Experiment: Can we get rid of Mac LSP hangs?

### DIFF
--- a/src/objects.h
+++ b/src/objects.h
@@ -579,7 +579,7 @@ class ByteArray : public HeapObject {
 
  public:
   // Constants that should be elsewhere.
-  static const int MIN_IO_BUFFER_SIZE = 128;
+  static const int MIN_IO_BUFFER_SIZE = 1;
   // Selected to be able to contain most MTUs (1500), but still align to 512 bytes.
   static const int PREFERRED_IO_BUFFER_SIZE = 1536 - HEADER_SIZE;
 };


### PR DESCRIPTION
Don't try to read more from sockets and pipes than
we are told is available.  But do try to read one
byte when we are told 0 are available to trigger the
EWOULDBLOCK error.