### PR TITLE
Don't use blocks to find process from object.

### DIFF
--- a/src/objects.cc
+++ b/src/objects.cc
@@ -340,20 +340,20 @@ void Stack::transfer_from_interpreter(Interpreter* interpreter) {
   ASSERT(top() > 0 && top() <= length());
 }
 
-bool HeapObject::is_at_block_top() {
+bool HeapObject::is_at_block_top(Program* program) {
   Block* block = Block::from(this);
-  return _raw_at(size(block->process()->program())) == block->top();
+  return _raw_at(size(program)) == block->top();
 }
 
-void ByteArray::resize(int new_length) {
+void ByteArray::resize(Program* program, int new_length) {
   ASSERT(!has_external_address());
   ASSERT(new_length <= raw_length());
-  ASSERT(is_at_block_top());
+  ASSERT(is_at_block_top(program));
   if (new_length != raw_length()) {
     int new_size = ByteArray::internal_allocation_size(new_length);
     Block::from(this)->shrink_top(size() - new_size);
     _word_at_put(LENGTH_OFFSET, new_length);
-    ASSERT(is_at_block_top());
+    ASSERT(is_at_block_top(program));
   }
 }
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -292,7 +292,7 @@ class HeapObject : public Object {
   int64 _int64_at(int offset) { return *reinterpret_cast<int64*>(_raw_at(offset)); }
   void _int64_at_put(int offset, int64 value) { *reinterpret_cast<int64*>(_raw_at(offset)) = value; }
 
-  bool is_at_block_top();
+  bool is_at_block_top(Program* program);
 
   static int _align(int byte_size) { return (byte_size + (WORD_SIZE - 1)) & ~(WORD_SIZE - 1); }
 
@@ -483,7 +483,7 @@ class ByteArray : public HeapObject {
      return static_cast<ByteArray*>(byte_array);
   }
 
-  void resize(int new_length);
+  void resize(Program* program, int new_length);
 
   template<typename T> void set_external_address(T* value) {
     _set_external_address(reinterpret_cast<uint8*>(value));

--- a/src/resources/pipe.cc
+++ b/src/resources/pipe.cc
@@ -267,12 +267,13 @@ PRIMITIVE(read) {
 
   int read = ::read(fd, ByteArray::Bytes(array).address(), available);
   if (read == -1) {
-    if (errno == EWOULDBLOCK) return Smi::from(-1);
+    Smi* would_block = Smi::from(-1);
+    if (errno == EWOULDBLOCK) return would_block;
     return Primitive::os_error(errno, process);
   }
   if (read == 0) return process->program()->null_object();
 
-  array->resize(read);
+  array->resize(process->program(), read);
 
   return array;
 }

--- a/src/resources/tcp_bsd.cc
+++ b/src/resources/tcp_bsd.cc
@@ -309,12 +309,13 @@ PRIMITIVE(read)  {
 
   int read = recv(fd, ByteArray::Bytes(array).address(), available, 0);
   if (read == -1) {
-    if (errno == EWOULDBLOCK) return Smi::from(-1);
+    Smi* would_block = Smi::from(-1);
+    if (errno == EWOULDBLOCK) return would_block;
     return Primitive::os_error(errno, process);
   }
   if (read == 0) return process->program()->null_object();
 
-  array->resize(read);
+  array->resize(process->program(), read);
 
   return array;
 }

--- a/src/resources/tcp_linux.cc
+++ b/src/resources/tcp_linux.cc
@@ -293,12 +293,13 @@ PRIMITIVE(read)  {
 
   int read = recv(fd, ByteArray::Bytes(array).address(), available, 0);
   if (read == -1) {
-    if (errno == EWOULDBLOCK) return Smi::from(-1);
+    Smi* would_block = Smi::from(-1);
+    if (errno == EWOULDBLOCK) return would_block;
     return Primitive::os_error(errno, process);
   }
   if (read == 0) return process->program()->null_object();
 
-  array->resize(read);
+  array->resize(process->program(), read);
 
   return array;
 }

--- a/src/resources/tls.cc
+++ b/src/resources/tls.cc
@@ -437,7 +437,7 @@ PRIMITIVE(read)  {
     return tls_error(null, process, read);
   }
 
-  array->resize(read);
+  array->resize(process->program(), read);
   return array;
 }
 

--- a/src/resources/udp_linux.cc
+++ b/src/resources/udp_linux.cc
@@ -168,6 +168,7 @@ PRIMITIVE(receive)  {
   // TODO: Support IPv6.
   ByteArray* address = null;
   if (output->is_array()) {
+    if (Array::cast(output)->length() != 3) INVALID_ARGUMENT;
     Error* error = null;
     address = process->allocate_byte_array(4, &error);
     if (address == null) return error;
@@ -195,7 +196,7 @@ PRIMITIVE(receive)  {
   if (read == 0) return process->program()->null_object();
 
   // Please note that the array might change length so no ByteArray::Bytes variables can pass this point.
-  array->resize(read);
+  array->resize(process->program(), read);
 
   if (output->is_array()) {
     Array* out = Array::cast(output);


### PR DESCRIPTION
Also a few misc cleanups around the use of ByteArray::resize.
In the longer run we may want to get rid of this function
as it complicates GC and we could use external byte arrays
instead.