### PR TITLE
Remove toit telegram channel from readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Watch a short video that shows how you can experience Jaguar on your ESP32 in le
 ## Community
 
 Use this [invite](https://discord.gg/Q7Y9VQ5nh2) to join our Discord server, and follow the development and get help.
-We've a channel in [Telegram](https://t.me/Toitware).
 We're eager to hear of your experience building with Toit.
 
 We also use [GitHub Discussions](https://github.com/toitlang/toit/discussions) to discuss and learn and


### PR DESCRIPTION
It's not really used, and we prefer concentrating on one channel.