### PR TITLE
Add pseudo-objects that are put on the heap for GC.

### DIFF
--- a/src/objects.cc
+++ b/src/objects.cc
@@ -177,6 +177,10 @@ int HeapObject::size(Program* program) {
       return Double::allocation_size();
     case TypeTag::LARGE_INTEGER_TAG:
       return LargeInteger::allocation_size();
+    case TypeTag::FREE_LIST_CHUNK_TAG:
+      return FreeListChunk::cast(this)->size();
+    case TypeTag::SINGLE_FREE_WORD_TAG:
+      return WORD_SIZE;
     default:
       FATAL("Unexpected class tag");
       return -1;
@@ -200,7 +204,9 @@ void HeapObject::roots_do(Program* program, RootCallback* cb) {
     case TypeTag::DOUBLE_TAG:
     case TypeTag::LARGE_INTEGER_TAG:
     case TypeTag::BYTE_ARRAY_TAG:
-      // No roots other than class.
+    case TypeTag::FREE_LIST_CHUNK_TAG:
+    case TypeTag::SINGLE_FREE_WORD_TAG:
+      // No roots.
       break;
     default:
       FATAL("Unexpected class tag");
@@ -210,6 +216,21 @@ void HeapObject::roots_do(Program* program, RootCallback* cb) {
 void HeapObject::_set_header(Program* program, Smi* id) {
   TypeTag tag = program->class_tag_for(id);
   _set_header(id, tag);
+}
+
+FreeListChunk* FreeListChunk::create_at(uword start, uword size) {
+  if (size >= MINIMUM_SIZE) {
+    auto self = reinterpret_cast<FreeListChunk*>(start);
+    self->_set_header(Smi::from(FREE_LIST_CHUNK_CLASS_ID), FREE_LIST_CHUNK_TAG);
+    self->_word_at_put(SIZE_OFFSET, size);
+    self->_at_put(NEXT_OFFSET, null);
+    return self;
+  }
+  for (uword i = 0; i < size; i += WORD_SIZE) {
+    auto one_word = reinterpret_cast<FreeListChunk*>(start + i);
+    one_word->_set_header(Smi::from(SINGLE_FREE_WORD_CLASS_ID), SINGLE_FREE_WORD_TAG);
+  }
+  return null;
 }
 
 class PointerRootCallback : public RootCallback {

--- a/src/objects.h
+++ b/src/objects.h
@@ -1201,8 +1201,7 @@ class FreeListChunk : public HeapObject {
     return _word_at(SIZE_OFFSET);
   }
 
-  bool can_be_daisychained() { return class_tag() == FREE_LIST_CHUNK_TAG;
-  }
+  bool can_be_daisychained() { return class_tag() == FREE_LIST_CHUNK_TAG; }
 
   void roots_do(int instance_size, RootCallback* cb) {}
 

--- a/src/program.h
+++ b/src/program.h
@@ -79,6 +79,10 @@ namespace toit {
   ID(large_array_class_id)       \
   ID(lazy_initializer_class_id)  \
 
+static const int FREE_LIST_CHUNK_CLASS_ID = -1;
+static const int SINGLE_FREE_WORD_CLASS_ID = -2;
+static const int PROMOTED_TRACK_CLASS_ID = -3;
+
 // The reflective structure of a program.
 class Program : public FlashAllocation {
  public:

--- a/src/third_party/dartino/gc_metadata.h
+++ b/src/third_party/dartino/gc_metadata.h
@@ -45,7 +45,7 @@ class GcMetadata {
   // One word per uint32 of mark bits, corresponding to 32 words of heap.
   static const int CUMULATIVE_MARK_BITS_SHIFT = 5;
 
-  static void initialize_start_for_chunk(Chunk* chunk, uword only_above = 0) {
+  static void initialize_starts_for_chunk(Chunk* chunk, uword only_above = 0) {
     uword start = chunk->start();
     uword end = chunk->end();
     if (only_above >= end) return;

--- a/src/third_party/dartino/mark_sweep.h
+++ b/src/third_party/dartino/mark_sweep.h
@@ -81,9 +81,9 @@ class FreeList {
   void AddChunk(uword free_start, uword free_size) {
     FreeListChunk* result = FreeListChunk::create_at(free_start, free_size);
     if (!result) {
-      // If the chunk is too small to be turned into an actual
-      // free list chunk we turn it into fillers to be coalesced
-      // with other free chunks later.
+      // Since the chunk was too small to be turned into an actual
+      // free list chunk it was just filled with one-word fillers.
+      // It can be coalesced with other free chunks later.
       return;
     }
     const int WORD_BITS = sizeof(uword) * BYTE_BIT_SIZE;

--- a/src/third_party/dartino/object_memory.cc
+++ b/src/third_party/dartino/object_memory.cc
@@ -127,7 +127,7 @@ void Space::iterate_overflowed_objects(RootCallback* visitor, MarkingStack* stac
             object = HeapObject::from_address(object_address);
             if (GcMetadata::is_grey(object)) {
               GcMetadata::mark_all(object, object->size(program_));
-              object->iterate_pointers(visitor);
+              object->roots_do(program_, visitor);
             }
           }
         }
@@ -159,8 +159,8 @@ void SemiSpace::complete_scavenge(RootCallback* visitor) {
     uword current = chunk->start();
     while (!has_sentinel_at(current)) {
       HeapObject* object = HeapObject::from_address(current);
-      object->iterate_pointers(visitor);
-      current += object->size();
+      object->roots_do(program_, visitor);
+      current += object->size(program_);
       flush();
     }
   }

--- a/src/third_party/dartino/object_memory_copying.cc
+++ b/src/third_party/dartino/object_memory_copying.cc
@@ -176,7 +176,7 @@ bool SemiSpace::complete_scavenge_generational(GenerationalScavengeVisitor* visi
     while (!has_sentinel_at(current)) {
       found_work = true;
       HeapObject* object = HeapObject::from_address(current);
-      object->iterate_pointers(visitor);
+      object->roots_do(program_, visitor);
 
       current += object->size();
     }

--- a/src/third_party/dartino/object_memory_mark_sweep.cc
+++ b/src/third_party/dartino/object_memory_mark_sweep.cc
@@ -318,7 +318,7 @@ void OldSpace::VisitRememberedSet(GenerationalScavengeVisitor* visitor) {
         while (iteration_start < current + GcMetadata::CARD_SIZE) {
           if (has_sentinel_at(iteration_start)) break;
           HeapObject* object = HeapObject::from_address(iteration_start);
-          object->iterate_pointers(visitor);
+          object->roots_do(program_, visitor);
           iteration_start += object->size();
         }
         earliest_iteration_start = iteration_start;
@@ -363,7 +363,7 @@ bool OldSpace::complete_scavenge_generational(
          traverse += obj->size(), obj = HeapObject::from_address(traverse)) {
       visitor->set_record_new_space_pointers(
           GcMetadata::remembered_set_for(obj->address()));
-      obj->iterate_pointers(visitor);
+      obj->roots_do(program_, visitor);
     }
     PromotedTrack* previous = promoted;
     promoted = promoted->next();
@@ -472,8 +472,7 @@ uword CompactingVisitor::visit(HeapObject* object) {
   }
 
   fix_pointers_visitor_->set_source_address(object->address());
-  HeapObject::from_address(dest_.address)
-      ->iterate_pointers(fix_pointers_visitor_);
+  HeapObject::from_address(dest_.address)->roots_do(program_, fix_pointers_visitor_);
   used_ += size;
   dest_.address += size;
   return size;
@@ -553,7 +552,7 @@ void MarkingStack::empty(RootCallback* visitor) {
   while (!is_empty()) {
     HeapObject* object = *--next_;
     GcMetadata::mark_all(object, object->size());
-    object->iterate_pointers(visitor);
+    object->roots_do(program_, visitor);
   }
 }
 


### PR DESCRIPTION
This adds support for some objects that are not
real heap objects, but are placed on the heap to
make it possible to iterate all objects in memory order.

Also renames call sites to roots_do which is the Toit name for
visit_pointers.