### PR TITLE
Fix many compile errors in new heap.

### DIFF
--- a/src/objects_inline.h
+++ b/src/objects_inline.h
@@ -73,4 +73,13 @@ inline bool HeapObject::on_program_heap(Process* process) {
   return process->on_program_heap(this);
 }
 
+inline void PromotedTrack::zap() {
+  uword header = SINGLE_FREE_WORD_CLASS_ID;
+  header = (header << CLASS_TAG_BIT_SIZE) | SINGLE_FREE_WORD_TAG;
+  Object* filler = Smi::from(header);
+  for (uword p = _raw(); p < _raw() + HEADER_SIZE; p += WORD_SIZE) {
+    *reinterpret_cast<Object**>(p) = filler;
+  }
+}
+
 } // namespace toit

--- a/src/third_party/dartino/object_memory.h
+++ b/src/third_party/dartino/object_memory.h
@@ -119,7 +119,7 @@ class Chunk : public ChunkList::Element {
 // Abstract base class for visiting all objects in a space.
 class HeapObjectVisitor {
  public:
-  HeapObjectVisitor(Program* program) : program_(program) {}
+  explicit HeapObjectVisitor(Program* program) : program_(program) {}
   virtual ~HeapObjectVisitor() {}
   // Visit the heap object. Must return the size of the heap
   // object.
@@ -340,7 +340,7 @@ class SemiSpace : public Space {
 
 class OldSpace : public Space {
  public:
-  explicit OldSpace(TwoSpaceHeap* heap);
+  OldSpace(Program* program, TwoSpaceHeap* heap);
 
   virtual ~OldSpace();
 
@@ -362,7 +362,7 @@ class OldSpace : public Space {
 
   void clear_free_list();
   void mark_chunk_ends_free();
-  void zap_obejct_starts();
+  void zap_object_starts();
 
   // Find pointers to young-space.
   void visit_remembered_set(GenerationalScavengeVisitor* visitor);

--- a/src/third_party/dartino/object_memory_copying.cc
+++ b/src/third_party/dartino/object_memory_copying.cc
@@ -175,7 +175,7 @@ bool SemiSpace::complete_scavenge_generational(GenerationalScavengeVisitor* visi
       HeapObject* object = HeapObject::from_address(current);
       object->roots_do(program_, visitor);
 
-      current += object->size();
+      current += object->size(program_);
     }
     // Set up the already-scanned pointer for next round.
     chunk->set_scavenge_pointer(current);


### PR DESCRIPTION
In Toit we need a reference to the program in order
to determine the size and layout of objects.  Some of
this change is threading that pointer through to the
places that need it.

In the long run we might want to find a way to avoid
this issue - probably the GC will be faster if the
size/layout information is more self-contained in the
heap objects.