### PR TITLE
Remove ScavengeVisitor.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,12 @@ file(GLOB lwip_on_linux_sources_SRC
 file(GLOB gc_sources_SRC
   #"third_party/dartino/object_memory.h"
   #"third_party/dartino/object_memory.cc"
+  #"third_party/dartino/object_memory_copying.cc"
+  #"third_party/dartino/object_memory_mark_sweep.cc"
+  #"third_party/dartino/gc_metadata.h"
+  #"third_party/dartino/gc_metadata.cc"
+  #"third_party/dartino/two_space_heap.h"
+  #"third_party/dartino/two_space_heap.cc"
   )
 
 set(toit_vm_SRC ${toit_resources_SRC} ${toit_event_sources_SRC} ${lwip_on_linux_sources_SRC} ${gc_sources_SRC})

--- a/src/third_party/dartino/two_space_heap.h
+++ b/src/third_party/dartino/two_space_heap.h
@@ -166,36 +166,6 @@ class TwoSpaceHeap : public Heap {
 };
 
 // Helper class for copying HeapObjects.
-class ScavengeVisitor : public PointerVisitor {
- public:
-  ScavengeVisitor(SemiSpace* from, SemiSpace* to) : from_(from), to_(to) {}
-
-  virtual void visit(Object** p) { scavenge_pointer(p); }
-
-  virtual void visit_block(Object** start, Object** end) {
-    // Copy all HeapObject pointers in [start, end)
-    for (Object** p = start; p < end; p++) scavenge_pointer(p);
-  }
-
- private:
-  void scavenge_pointer(Object** p) {
-    Object* object = *p;
-    if (!object->is_heap_object()) return;
-    if (!from_->includes(reinterpret_cast<uword>(object))) return;
-    HeapObject* heap_object = reinterpret_cast<HeapObject*>(object);
-    if (heap_object->has_forwarding_address()) {
-      *p = heap_object->forwarding_address();
-    } else {
-      *p = reinterpret_cast<HeapObject*>(object)->clone_in_to_space(to_);
-    }
-    ASSERT(*p != NULL);  // No-allocation scope should ensure this.
-  }
-
-  SemiSpace* from_;
-  SemiSpace* to_;
-};
-
-// Helper class for copying HeapObjects.
 class GenerationalScavengeVisitor : public PointerVisitor {
  public:
   explicit GenerationalScavengeVisitor(TwoSpaceHeap* heap)


### PR DESCRIPTION
This class was only used for single-space heaps.
We will be using only two-space generational heaps.