### PR TITLE
Spelling mistake in TLS test error.

### DIFF
--- a/src/resources/tls.cc
+++ b/src/resources/tls.cc
@@ -66,6 +66,8 @@ int BaseMbedTLSSocket::add_root_certificate(X509Certificate* cert) {
   // Do a shallow copy of the cert.
   *last = _new mbedtls_x509_crt(*(cert->cert()));
   if (*last == null) return MBEDTLS_ERR_PK_ALLOC_FAILED;
+  // By default we don't enable certificate verification in server mode, but if
+  // the user adds a root that indicates that they certainly want verification.
   mbedtls_ssl_conf_authmode(&_conf, MBEDTLS_SSL_VERIFY_REQUIRED);
   return 0;
 }
@@ -140,6 +142,8 @@ void MbedTLSResourceGroup::init_conf(mbedtls_ssl_config* conf) {
   auto transport = MBEDTLS_SSL_TRANSPORT_STREAM;
   auto client_server = (_mode == TLS_SERVER) ? MBEDTLS_SSL_IS_SERVER : MBEDTLS_SSL_IS_CLIENT;
 
+  // This enables certificate verification in client mode, but does not
+  // enable it in server mode.
   if (int ret = mbedtls_ssl_config_defaults(conf,
                                             client_server,
                                             transport,

--- a/tests/tls2_test.toit
+++ b/tests/tls2_test.toit
@@ -122,7 +122,7 @@ working_site host port:
     error = false
   finally:
     if error:
-      load_limiter.log_test_failure "*** Incorrectly failed to connected to $host ***"
+      load_limiter.log_test_failure "*** Incorrectly failed to connect to $host ***"
     load_limiter.dec
 
 connect_to_site host port add_root:

--- a/tests/tls_test_slow.toit
+++ b/tests/tls_test_slow.toit
@@ -143,7 +143,7 @@ working_site host port expected_certificate_name:
     error = false
   finally:
     if error:
-      load_limiter.log_test_failure "*** Incorrectly failed to connected to $host ***"
+      load_limiter.log_test_failure "*** Incorrectly failed to connect to $host ***"
     load_limiter.dec
 
 connect_to_site host port expected_certificate_name:


### PR DESCRIPTION
Also adds clarifying comments to TLS implementation.