### PR TITLE
Improve error message for bad static accesses.

### DIFF
--- a/src/compiler/resolver_method.cc
+++ b/src/compiler/resolver_method.cc
@@ -2609,7 +2609,10 @@ void MethodResolver::_visit_potential_call_dot(ast::Dot* ast_dot,
   // We know that this isn't a constructor call, as the `visit_potential_call` would have
   // caught that one.
   auto ast_receiver = ast_dot->receiver();
-  if (ast_receiver->is_Identifier() || scope()->is_prefixed_identifier(ast_receiver)) {
+  // If this is for the LSP just follow the normal path.
+  // We are only interested in `A.foo`/`prefix.A.foo` not `(A).foo`.
+  if (!ast_dot->name()->is_LspSelection() &&
+      (ast_receiver->is_Identifier() || scope()->is_prefixed_identifier(ast_receiver))) {
     auto candidates = _compute_target_candidates(ast_receiver, scope());
     if (!candidates.encountered_error &&
         (candidates.klass != null && candidates.nodes.is_empty())) {

--- a/src/compiler/resolver_method.cc
+++ b/src/compiler/resolver_method.cc
@@ -2615,7 +2615,7 @@ void MethodResolver::_visit_potential_call_dot(ast::Dot* ast_dot,
         (candidates.klass != null && candidates.nodes.is_empty())) {
       auto klass = candidates.klass;
       auto class_interface = klass->is_interface() ? "Interface" : "Class";
-      report_error(ast_dot, "%s '%s' does not have any static member or constructor with name '%s'.",
+      report_error(ast_dot, "%s '%s' does not have any static member or constructor with name '%s'",
                    class_interface,
                    candidates.name.c_str(),
                    ast_dot->name()->data().c_str());

--- a/tests/negative/gold/named_constructor_test.gold
+++ b/tests/negative/gold/named_constructor_test.gold
@@ -1,10 +1,10 @@
 tests/negative/named_constructor_test.toit:12:8: error: Class 'A' only has named constructors
   a := A  // There should not be an implicit constructor.
        ^
-tests/negative/named_constructor_test.toit:13:9: error: Class 'A' does not have any static member or constructor with name 'some_non_existing_static'.
+tests/negative/named_constructor_test.toit:13:9: error: Class 'A' does not have any static member or constructor with name 'some_non_existing_static'
   b := A.some_non_existing_static
         ^
-tests/negative/named_constructor_test.toit:14:14: error: Class 'A' does not have any static member or constructor with name 'some_non_existing_static'.
+tests/negative/named_constructor_test.toit:14:14: error: Class 'A' does not have any static member or constructor with name 'some_non_existing_static'
   c := self.A.some_non_existing_static
              ^
 Compilation failed.

--- a/tests/negative/gold/named_constructor_test.gold
+++ b/tests/negative/gold/named_constructor_test.gold
@@ -1,4 +1,10 @@
-tests/negative/named_constructor_test.toit:10:8: error: Class 'A' only has named constructors
+tests/negative/named_constructor_test.toit:12:8: error: Class 'A' only has named constructors
   a := A  // There should not be an implicit constructor.
        ^
+tests/negative/named_constructor_test.toit:13:9: error: Class 'A' does not have any static member or constructor with name 'some_non_existing_static'.
+  b := A.some_non_existing_static
+        ^
+tests/negative/named_constructor_test.toit:14:14: error: Class 'A' does not have any static member or constructor with name 'some_non_existing_static'.
+  c := self.A.some_non_existing_static
+             ^
 Compilation failed.

--- a/tests/negative/named_constructor_test.toit
+++ b/tests/negative/named_constructor_test.toit
@@ -2,9 +2,13 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the tests/LICENSE file.
 
+import .named_constructor_test as self
+
 class A:
   constructor.foo:
 
 
 main:
   a := A  // There should not be an implicit constructor.
+  b := A.some_non_existing_static
+  c := self.A.some_non_existing_static


### PR DESCRIPTION
We treated `A.foo` as `(A).foo` and complained when `A` didn't have any
unnamed constructor. Now we report that we can't find any 'foo' static
or constructor.