### PR TITLE
Allow parallel init of WiFi module.

### DIFF
--- a/lib/net/impl.toit
+++ b/lib/net/impl.toit
@@ -23,11 +23,11 @@ open -> Interface:
     catch --unwind=(: it != WIFI_ALREADY_STARTED_EXCEPTION_):
       return wifi.connect
     // Temporary work-around for two processes opening the network at the same time.
-    // The `WIFI_ALREAD_STARTED_EXCEPTION_` is thrown when another thread already
+    // The `WIFI_ALREADY_STARTED_EXCEPTION_` is thrown when another thread already
     // opened the network. However, at this point we aren't sure whether the
     // the network is already connected. We therefore look at the stored IP address.
     // As soon as that one is available we know that we can use the network.
-    with_timeout --ms=5_000:
+    with_timeout --ms=26_000:
       while true:
         // Wait for the other thread to store the IP.
         if stored_ip_ != "": break
@@ -67,7 +67,6 @@ class SystemInterface_ extends Interface:
       return socket.local_address.ip
     finally:
       socket.close
-
 
   close -> none:
     // Do nothing yet.

--- a/lib/net/impl.toit
+++ b/lib/net/impl.toit
@@ -22,6 +22,11 @@ open -> Interface:
     // the WiFi and it really shouldn't while this process is still using it.
     catch --unwind=(: it != WIFI_ALREADY_STARTED_EXCEPTION_):
       return wifi.connect
+    // Temporary work-around for two processes opening the network at the same time.
+    // The `WIFI_ALREAD_STARTED_EXCEPTION_` is thrown when another thread already
+    // opened the network. However, at this point we aren't sure whether the
+    // the network is already connected. We therefore look at the stored IP address.
+    // As soon as that one is available we know that we can use the network.
     with_timeout --ms=5_000:
       while true:
         // Wait for the other thread to store the IP.

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -290,6 +290,7 @@ namespace toit {
   PRIMITIVE(disconnect, 2)                   \
   PRIMITIVE(disconnect_reason, 1)            \
   PRIMITIVE(get_ip, 1)                       \
+  PRIMITIVE(get_stored_ip, 0)                \
   PRIMITIVE(get_rssi, 1)                     \
 
 #define MODULE_ETHERNET(PRIMITIVE)           \

--- a/src/resources/wifi_esp32.cc
+++ b/src/resources/wifi_esp32.cc
@@ -337,6 +337,8 @@ PRIMITIVE(disconnect_reason) {
   }
 }
 
+static char local_address[17] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
 PRIMITIVE(get_ip) {
   ARGS(IPEvents, ip);
   if (local_address[0] == 0) {
@@ -344,8 +346,6 @@ PRIMITIVE(get_ip) {
   }
   return process->allocate_string_or_error(ip->ip());
 }
-
-static char local_address[17] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 // Temporary primitive to support parallel access to the WiFi module.
 // The `local_address` global would need to be protected by a lock to be safe.

--- a/src/resources/wifi_esp32.cc
+++ b/src/resources/wifi_esp32.cc
@@ -339,7 +339,21 @@ PRIMITIVE(disconnect_reason) {
 
 PRIMITIVE(get_ip) {
   ARGS(IPEvents, ip);
+  if (local_address[0] == 0) {
+    memcpy(local_address, ip->ip(), 16);
+  }
   return process->allocate_string_or_error(ip->ip());
+}
+
+static char local_address[17] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+// Temporary primitive to support parallel access to the WiFi module.
+// The `local_address` global would need to be protected by a lock to be safe.
+// Currently, we read the address to know whether the device is online, and at that
+// time we don't care for the actual value as long as it's not 0.
+// Before the next call to `get_stored_ip` the memcpy from `get_ip` should have finished.
+PRIMITIVE(get_stored_ip) {
+  return process->allocate_string_or_error(local_address);
 }
 
 PRIMITIVE(get_rssi) {

--- a/src/resources/wifi_esp32.cc
+++ b/src/resources/wifi_esp32.cc
@@ -337,12 +337,12 @@ PRIMITIVE(disconnect_reason) {
   }
 }
 
-static char local_address[17] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+static char local_address[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 PRIMITIVE(get_ip) {
   ARGS(IPEvents, ip);
   if (local_address[0] == 0) {
-    memcpy(local_address, ip->ip(), 16);
+    memcpy(local_address, ip->ip(), 15);
   }
   return process->allocate_string_or_error(ip->ip());
 }

--- a/src/resources/wifi_esp32.cc
+++ b/src/resources/wifi_esp32.cc
@@ -337,7 +337,7 @@ PRIMITIVE(disconnect_reason) {
   }
 }
 
-static char local_address[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+static char local_address[16] = { 0, };
 
 PRIMITIVE(get_ip) {
   ARGS(IPEvents, ip);


### PR DESCRIPTION
When two processes are trying to connect to the WiFi at the same time,
then the second one falls back to using the System network.
However, at that time the network might not yet be online. We now wait
for it to be online by waiting for the IP-address to be available.

Fixes #570 