### PR TITLE
Merge Heap and ObjectHeap classes into one.

### DIFF
--- a/src/heap.cc
+++ b/src/heap.cc
@@ -51,36 +51,13 @@ class ScavengeScope : public Locker {
   RawHeap* _heap;
 };
 
-#ifdef LEGACY_GC
-Heap::Heap(Process* owner, Program* program, Block* initial_block)
-    : RawHeap(owner)
-    , _program(program) {
-  if (initial_block == null) return;
-  _blocks.append(initial_block);
-}
-#else
-Heap::Heap(Process* owner, Program* program)
-    : _program(program)
-    , _owner(owner)
-    , _two_space_heap(program) {}
-#endif
-
-Heap::~Heap() {
-#ifdef LEGACY_GC
-  // TODO: Heap deletion in new GC.
-  // Deleting a heap is like a scavenge where nothing survives.
-  ScavengeScope scope(VM::current()->heap_memory(), this);
-  _blocks.free_blocks(this);
-#endif
-}
-
-Instance* Heap::allocate_instance(Smi* class_id) {
+Instance* ObjectHeap::allocate_instance(Smi* class_id) {
   int size = program()->instance_size_for(class_id);
   TypeTag class_tag = program()->class_tag_for(class_id);
   return allocate_instance(class_tag, class_id, Smi::from(size));
 }
 
-Instance* Heap::allocate_instance(TypeTag class_tag, Smi* class_id, Smi* instance_size) {
+Instance* ObjectHeap::allocate_instance(TypeTag class_tag, Smi* class_id, Smi* instance_size) {
   Instance* result = unvoid_cast<Instance*>(_allocate_raw(instance_size->value()));
   if (result == null) return null;  // Allocation failure.
   // Initialize object.
@@ -88,7 +65,7 @@ Instance* Heap::allocate_instance(TypeTag class_tag, Smi* class_id, Smi* instanc
   return result;
 }
 
-Array* Heap::allocate_array(int length, Object* filler) {
+Array* ObjectHeap::allocate_array(int length, Object* filler) {
   ASSERT(length >= 0);
   ASSERT(length <= Array::max_length_in_process());
   HeapObject* result = _allocate_raw(Array::allocation_size(length));
@@ -101,7 +78,7 @@ Array* Heap::allocate_array(int length, Object* filler) {
   return Array::cast(result);
 }
 
-Array* Heap::allocate_array(int length) {
+Array* ObjectHeap::allocate_array(int length) {
   ASSERT(length >= 0);
   ASSERT(length <= Array::max_length_in_process());
   HeapObject* result = _allocate_raw(Array::allocation_size(length));
@@ -114,7 +91,7 @@ Array* Heap::allocate_array(int length) {
   return Array::cast(result);
 }
 
-ByteArray* Heap::allocate_internal_byte_array(int length) {
+ByteArray* ObjectHeap::allocate_internal_byte_array(int length) {
   ASSERT(length >= 0);
   // Byte array should fit within one heap block.
   ASSERT(length <= ByteArray::max_internal_size_in_process());
@@ -126,7 +103,7 @@ ByteArray* Heap::allocate_internal_byte_array(int length) {
   return result;
 }
 
-Double* Heap::allocate_double(double value) {
+Double* ObjectHeap::allocate_double(double value) {
   HeapObject* result = _allocate_raw(Double::allocation_size());
   if (result == null) return null;  // Allocation failure.
   // Initialize object.
@@ -135,7 +112,7 @@ Double* Heap::allocate_double(double value) {
   return Double::cast(result);
 }
 
-LargeInteger* Heap::allocate_large_integer(int64 value) {
+LargeInteger* ObjectHeap::allocate_large_integer(int64 value) {
   HeapObject* result = _allocate_raw(LargeInteger::allocation_size());
   if (result == null) return null;  // Allocation failure.
   // Initialize object.
@@ -144,15 +121,7 @@ LargeInteger* Heap::allocate_large_integer(int64 value) {
   return LargeInteger::cast(result);
 }
 
-int Heap::payload_size() {
-#ifdef LEGACY_GC
-  return _blocks.payload_size();
-#else
-  return _two_space_heap.used();
-#endif
-}
-
-String* Heap::allocate_internal_string(int length) {
+String* ObjectHeap::allocate_internal_string(int length) {
   ASSERT(length >= 0);
   ASSERT(length <= String::max_internal_size_in_process());
   HeapObject* result = _allocate_raw(String::internal_allocation_size(length));
@@ -170,7 +139,7 @@ String* Heap::allocate_internal_string(int length) {
 
 #ifdef LEGACY_GC
 
-HeapObject* Heap::_allocate_raw(int byte_size) {
+HeapObject* ObjectHeap::_allocate_raw(int byte_size) {
   ASSERT(byte_size > 0);
   ASSERT(byte_size <= max_allocation_size());
   HeapObject* result = _blocks.last()->allocate_raw(byte_size);
@@ -185,14 +154,7 @@ HeapObject* Heap::_allocate_raw(int byte_size) {
   return result;
 }
 
-Heap::AllocationResult Heap::_expand() {
-  Block* block = VM::current()->heap_memory()->allocate_block(this);
-  if (block == null) return ALLOCATION_OUT_OF_MEMORY;
-  _blocks.append(block);
-  return ALLOCATION_SUCCESS;
-}
-
-Heap::AllocationResult ObjectHeap::_expand() {
+ObjectHeap::AllocationResult ObjectHeap::_expand() {
   word used = (_blocks.length() << TOIT_PAGE_SIZE_LOG2) + _external_memory;
   if (_limit != 0 && used >= _limit) {
 #ifdef TOIT_GC_LOGGING
@@ -202,12 +164,15 @@ Heap::AllocationResult ObjectHeap::_expand() {
 #endif
     return ALLOCATION_HIT_LIMIT;
   }
-  return Heap::_expand();
+  Block* block = VM::current()->heap_memory()->allocate_block(this);
+  if (block == null) return ALLOCATION_OUT_OF_MEMORY;
+  _blocks.append(block);
+  return ALLOCATION_SUCCESS;
 }
 
 class ScavengeState : public RootCallback {
  public:
-  explicit ScavengeState(Heap* heap)
+  explicit ScavengeState(ObjectHeap* heap)
       : _heap(heap), _process(heap->owner()), _scope(VM::current()->heap_memory(), heap) {
     blocks.append(VM::current()->heap_memory()->allocate_block_during_scavenge(heap));
   }
@@ -266,7 +231,7 @@ class ScavengeState : public RootCallback {
     }
   }
 
-  void process_to_objects(Heap::Iterator& objects) {
+  void process_to_objects(ObjectHeap::Iterator& objects) {
     while (!objects.eos()) {
       if (Flags::tracegc && Flags::verbose) printf(" - process object %p\n", objects.current());
       objects.current()->roots_do(_heap->program(), this);
@@ -275,14 +240,14 @@ class ScavengeState : public RootCallback {
   }
 
   void process_to_space() {
-    Heap::Iterator objects(blocks, _heap->program());
+    ObjectHeap::Iterator objects(blocks, _heap->program());
     while (!objects.eos()) process_to_objects(objects);
     ASSERT(objects.eos());
   }
 
   BlockList blocks;
  private:
-  Heap* _heap;
+  ObjectHeap* _heap;
   Process* _process;
   ScavengeScope _scope;
 };
@@ -291,14 +256,17 @@ class ScavengeState : public RootCallback {
 
 #ifdef LEGACY_GC
 ObjectHeap::ObjectHeap(Program* program, Process* owner, Block* block)
-    : Heap(owner, program, block)
+    : RawHeap(owner)
+    , _program(program)
+    , _external_memory(0) {
+  if (block == null) return;
+  _blocks.append(block);
 #else
 ObjectHeap::ObjectHeap(Program* program, Process* owner)
-    : Heap(owner, program)
-#endif
+    : _program(program)
+    , _owner(owner)
+    , _two_space_heap(program, this)
     , _external_memory(0) {
-#ifdef LEGACY_GC
-  if (block == null) return;
 #endif
   _task = allocate_task();
   _global_variables = program->global_variables.copy();
@@ -325,6 +293,13 @@ ObjectHeap::~ObjectHeap() {
   delete _finalizer_notifier;
 
   ASSERT(_object_notifiers.is_empty());
+
+#ifdef LEGACY_GC
+  // TODO: ObjectHeap deletion in new GC.
+  // Deleting a heap is like a scavenge where nothing survives.
+  ScavengeScope scope(VM::current()->heap_memory(), this);
+  _blocks.free_blocks(this);
+#endif
 }
 
 #ifdef LEGACY_GC
@@ -383,12 +358,7 @@ void ObjectHeap::unregister_external_allocation(word size) {
   ASSERT(old_external_memory >= external_memory);
 }
 
-int ObjectHeap::payload_size() {
-  int base = Heap::payload_size();
-  return base + sizeof(Object*) * (program()->global_variables.length());
-}
-
-ByteArray* Heap::allocate_external_byte_array(int length, uint8* memory, bool dispose, bool clear_content) {
+ByteArray* ObjectHeap::allocate_external_byte_array(int length, uint8* memory, bool dispose, bool clear_content) {
   ByteArray* result = unvoid_cast<ByteArray*>(_allocate_raw(ByteArray::external_allocation_size()));
   if (result == null) return null;  // Allocation failure.
   // Initialize object.
@@ -407,7 +377,7 @@ ByteArray* Heap::allocate_external_byte_array(int length, uint8* memory, bool di
   return result;
 }
 
-String* Heap::allocate_external_string(int length, uint8* memory, bool dispose) {
+String* ObjectHeap::allocate_external_string(int length, uint8* memory, bool dispose) {
   String* result = unvoid_cast<String*>(_allocate_raw(String::external_allocation_size()));
   if (result == null) return null;  // Allocation failure.
   // Initialize object.
@@ -471,6 +441,20 @@ static const char* format_unit(word n) {
 #define FORMAT(n) format(n), format_unit(n)
 #endif
 
+void ObjectHeap::iterate_roots(RootCallback* callback) {
+  // Process the roots in the object heap.
+  callback->do_root(reinterpret_cast<Object**>(&_task));
+  callback->do_roots(_global_variables, program()->global_variables.length());
+  for (auto root : _external_roots) callback->do_roots(root->slot(), 1);
+
+  // Process roots in the _object_notifiers list.
+  for (ObjectNotifier* n : _object_notifiers) n->roots_do(callback);
+  // Process roots in the _runnable_finalizers.
+  for (FinalizerNode* node : _runnable_finalizers) {
+    node->roots_do(callback);
+  }
+}
+
 #ifdef LEGACY_GC
 
 int ObjectHeap::gc() {
@@ -498,17 +482,7 @@ int ObjectHeap::gc() {
 
   { ScavengeState ss(this);
 
-    // Process the roots in the object heap.
-    ss.do_root(reinterpret_cast<Object**>(&_task));
-    ss.do_roots(_global_variables, program()->global_variables.length());
-    for (auto root : _external_roots) ss.do_roots(root->slot(), 1);
-
-    // Process roots in the _object_notifiers list.
-    for (ObjectNotifier* n : _object_notifiers) n->roots_do(&ss);
-    // Process roots in the _runnable_finalizers.
-    for (FinalizerNode* node : _runnable_finalizers) {
-      node->roots_do(&ss);
-    }
+    iterate_roots(&ss);
 
     // Process the to space.
     Iterator objects(ss.blocks, program());
@@ -687,21 +661,21 @@ void ObjectHeap::set_finalizer_notifier(ObjectNotifier* notifier) {
 
 // We initialize lazily - this is because the number of objects can grow during
 // iteration.
-Heap::Iterator::Iterator(BlockList& list, Program* program)
+ObjectHeap::Iterator::Iterator(BlockList& list, Program* program)
   : _list(list)
   , _iterator(list.end())  // Set to null.
   , _block(null)
   , _current(null)
   , _program(program) {}
 
-bool Heap::Iterator::eos() {
+bool ObjectHeap::Iterator::eos() {
   return _list.is_empty()
       || (_block == null
           ? _list.first()->is_empty()
           :  (_current >= _block->top() && _block == _list.last()));
 }
 
-void Heap::Iterator::ensure_started() {
+void ObjectHeap::Iterator::ensure_started() {
   ASSERT(!eos());
   if (_block == null) {
      _iterator = _list.begin();
@@ -710,7 +684,7 @@ void Heap::Iterator::ensure_started() {
   }
 }
 
-HeapObject* Heap::Iterator::current() {
+HeapObject* ObjectHeap::Iterator::current() {
   ensure_started();
   if (_current >= _block->top() && _block != _list.last()) {
     _block = *++_iterator;
@@ -720,7 +694,7 @@ HeapObject* Heap::Iterator::current() {
   return HeapObject::cast(_current);
 }
 
-void Heap::Iterator::advance() {
+void ObjectHeap::Iterator::advance() {
   ensure_started();
 
   ASSERT(HeapObject::cast(_current)->header()->is_smi());  // Header is not a forwarding pointer.
@@ -734,7 +708,7 @@ void Heap::Iterator::advance() {
 
 #else  // def LEGACY_GC
 
-Usage Heap::usage(const char* name) {
+Usage ObjectHeap::usage(const char* name) {
   return Usage(name, 0, 0);  // TODO: Usage report.
 }
 

--- a/src/memory.h
+++ b/src/memory.h
@@ -22,7 +22,7 @@
 namespace toit {
 
 class Block;
-class Heap;
+class ObjectHeap;
 class RawHeap;
 
 // A class used for printing usage of a memory area.
@@ -101,7 +101,6 @@ class Block : public BlockLinkedList::Element {
 
   void* _top;
   friend class BlockList;
-  friend class Heap;
   friend class HeapMemory;
   friend class OS;
   friend class RawMemory;

--- a/src/objects.h
+++ b/src/objects.h
@@ -318,7 +318,6 @@ class HeapObject : public Object {
   friend class Space;
   friend class SemiSpace;
   friend class OldSpace;
-  friend class Heap;
   friend class ProgramHeap;
   friend class TwoSpaceHeap;
   friend class BaseSnapshotWriter;
@@ -402,7 +401,6 @@ class Array : public HeapObject {
   }
 
   friend class ObjectHeap;
-  friend class Heap;
   friend class ProgramHeap;
 
  protected:
@@ -599,7 +597,6 @@ class ByteArray : public HeapObject {
   }
 
   friend class ObjectHeap;
-  friend class Heap;
   friend class ProgramHeap;
   friend class ShortPrintVisitor;
   friend class VMFinalizerNode;
@@ -643,7 +640,7 @@ class LargeInteger : public HeapObject {
     ASSERT(!Smi::is_valid(value));
     _int64_at_put(VALUE_OFFSET, value);
   }
-  friend class Heap;
+  friend class ObjectHeap;
   friend class ProgramHeap;
   friend class SnapshotReader;
 };
@@ -740,7 +737,6 @@ class Stack : public HeapObject {
 
   static int _array_offset_from(int index) { return HEADER_SIZE + index  * WORD_SIZE; }
   friend class ObjectHeap;
-  friend class Heap;
   friend class ProgramHeap;
 };
 
@@ -771,7 +767,7 @@ class Double : public HeapObject {
 
   void _initialize(double value) { _set_value(value); }
   void _set_value(double value) { _double_at_put(VALUE_OFFSET, value); }
-  friend class Heap;
+  friend class ObjectHeap;
   friend class ProgramHeap;
 };
 
@@ -1032,9 +1028,8 @@ class String : public HeapObject {
 
   bool _is_valid_utf8();
 
-  friend class Heap;
-  friend class ProgramHeap;
   friend class ObjectHeap;
+  friend class ProgramHeap;
   friend class VMFinalizerNode;
 };
 
@@ -1195,7 +1190,7 @@ class Instance : public HeapObject {
 
   static int _offset_from(int index) { return HEADER_SIZE + index  * WORD_SIZE; }
 
-  friend class Heap;
+  friend class ObjectHeap;
   friend class ProgramHeap;
 };
 

--- a/src/objects_inline.h
+++ b/src/objects_inline.h
@@ -28,7 +28,7 @@ extern "C" uword toit_image;
 extern "C" uword toit_image_size;
 
 int Array::max_length_in_process() {
-  return (Heap::max_allocation_size() - HEADER_SIZE) / WORD_SIZE;
+  return (ObjectHeap::max_allocation_size() - HEADER_SIZE) / WORD_SIZE;
 }
 
 int Array::max_length_in_program() {
@@ -36,11 +36,11 @@ int Array::max_length_in_program() {
 }
 
 int Stack::max_length() {
-  return (Heap::max_allocation_size() - HEADER_SIZE) / WORD_SIZE;
+  return (ObjectHeap::max_allocation_size() - HEADER_SIZE) / WORD_SIZE;
 }
 
 word ByteArray::max_internal_size_in_process() {
-  return Heap::max_allocation_size() - HEADER_SIZE;
+  return ObjectHeap::max_allocation_size() - HEADER_SIZE;
 }
 
 word ByteArray::max_internal_size_in_program() {
@@ -48,7 +48,7 @@ word ByteArray::max_internal_size_in_program() {
 }
 
 word String::max_internal_size_in_process() {
-  word result = Heap::max_allocation_size() - OVERHEAD;
+  word result = ObjectHeap::max_allocation_size() - OVERHEAD;
   return result;
 }
 

--- a/src/printing.cc
+++ b/src/printing.cc
@@ -39,7 +39,7 @@ void print_name_console(String* string) {
   print_name(&p, string);
 }
 
-void print_heap_console(Heap* heap, const char* title) {
+void print_heap_console(ObjectHeap* heap, const char* title) {
   ConsolePrinter p(null);
   print_heap(&p, heap, title);
 }
@@ -455,9 +455,9 @@ void print_object_short(Printer* printer, Object* object, bool is_top_level) {
   p.accept(object);
 }
 
-void print_heap(Printer* printer, Heap* heap, const char* title) {
+void print_heap(Printer* printer, ObjectHeap* heap, const char* title) {
   printer->printf("%s:\n", title);
-  for (Heap::Iterator i = heap->object_iterator(); !i.eos(); i.advance()) {
+  for (ObjectHeap::Iterator i = heap->object_iterator(); !i.eos(); i.advance()) {
     print_object(printer, i.current());
   }
 }

--- a/src/printing.h
+++ b/src/printing.h
@@ -72,7 +72,7 @@ class BufferPrinter : public Printer {
 void print_object(Printer* printer, Object* object);
 void print_object_short(Printer* printer, Object* object, bool is_top_level = true);
 void print_name(Printer* printer, String* string);
-void print_heap(Printer* printer, Heap* heap, const char* title);
+void print_heap(Printer* printer, ObjectHeap* heap, const char* title);
 void print_bytecode(Printer* printer, uint8* bcp, int bci);
 void print_bytecode(Printer* printer, Method method, int bci);
 
@@ -81,7 +81,7 @@ void print_method_console(int method_id, Program* program, int bytecode_size);
 void print_method_console(Smi* method_id, Program* program, int bytecode_size);
 void print_object_short_console(Object* object, bool is_top_level = true);
 void print_name_console(String* string);
-void print_heap_console(Heap* heap, const char* title);
+void print_heap_console(ObjectHeap* heap, const char* title);
 void print_bytecode_console(uint8* bcp);
 
 #endif

--- a/src/process.h
+++ b/src/process.h
@@ -169,7 +169,7 @@ class Process : public ProcessListFromProcessGroup::Element,
 
   bool should_allow_external_allocation(word size) {
     bool result = _object_heap.should_allow_external_allocation(size);
-    _object_heap.set_last_allocation_result(result ? Heap::ALLOCATION_SUCCESS : Heap::ALLOCATION_HIT_LIMIT);
+    _object_heap.set_last_allocation_result(result ? ObjectHeap::ALLOCATION_SUCCESS : ObjectHeap::ALLOCATION_HIT_LIMIT);
     return result;
   }
 
@@ -314,7 +314,7 @@ class AllocationManager {
     // with realloc.
     _ptr = malloc(length);
     if (_ptr == null) {
-      _process->object_heap()->set_last_allocation_result(Heap::ALLOCATION_OUT_OF_MEMORY);
+      _process->object_heap()->set_last_allocation_result(ObjectHeap::ALLOCATION_OUT_OF_MEMORY);
     } else {
       _process->register_external_allocation(length);
       _size = length;

--- a/src/third_party/dartino/object_memory.h
+++ b/src/third_party/dartino/object_memory.h
@@ -19,7 +19,6 @@ namespace toit {
 class Chunk;
 class FreeList;
 class GenerationalScavengeVisitor;
-class Heap;
 class HeapObject;
 class HeapObjectVisitor;
 class MarkingStack;
@@ -366,7 +365,7 @@ class OldSpace : public Space {
   // For the objects promoted to the old space during scavenge.
   inline void start_scavenge() { start_tracking_allocations(); }
   bool complete_scavenge_generational(GenerationalScavengeVisitor* visitor);
-  inline void EndScavenge() { end_tracking_allocations(); }
+  inline void end_scavenge() { end_tracking_allocations(); }
 
   void start_tracking_allocations();
   void end_tracking_allocations();

--- a/src/third_party/dartino/two_space_heap.h
+++ b/src/third_party/dartino/two_space_heap.h
@@ -15,7 +15,7 @@ namespace toit {
 // TwoSpaceHeap represents the container for all HeapObjects.
 class TwoSpaceHeap {
  public:
-  explicit TwoSpaceHeap(Program* program);
+  TwoSpaceHeap(Program* program, ObjectHeap* process_heap);
   ~TwoSpaceHeap();
 
   // Allocate raw object. Returns null if a garbage collection is
@@ -86,6 +86,7 @@ class TwoSpaceHeap {
 
   void collect_new_space();
   void collect_old_space();
+  void collect_old_space_if_needed(bool force);
   void perform_shared_garbage_collection();
   void sweep_shared_heap();
   void compact_shared_heap();
@@ -96,6 +97,7 @@ class TwoSpaceHeap {
   friend class GenerationalScavengeVisitor;
 
   Program* program_;
+  ObjectHeap* process_heap_;
   SemiSpace* semi_space_;
   OldSpace* old_space_;
   SemiSpace* unused_semispace_;

--- a/src/top.h
+++ b/src/top.h
@@ -296,7 +296,6 @@ class Block;
 class ProgramBlock;
 class ConditionVariable;
 class Encoder;
-class Heap;
 class ProgramHeap;
 class HeapMemory;
 class ProgramHeapMemory;


### PR DESCRIPTION
This also means their constructors, destructors and
_expand methods are merged.  In this CL we don't reorder
the .h file, so private and public parts are not cleanly
separated.  That will be done in a subsequent moving-only
CL.

Also takes iterate_roots out of the gc() function and
makes it an independent method on ObjectHeap.

Removes Heap::payload_size() which was unused.

Moves NoGC class.