### PR TITLE
Allocate initial chunks for new GC heap early.

### DIFF
--- a/src/heap.cc
+++ b/src/heap.cc
@@ -258,7 +258,7 @@ class ScavengeState : public RootCallback {
 
 #endif  // def LEGACY_GC
 
-bool InitialMemoryManager::Allocate() {
+bool InitialMemoryManager::allocate() {
 #ifdef LEGACY_GC
   initial_memory = VM::current()->heap_memory()->allocate_initial_block();
   return initial_memory != null;

--- a/src/heap.cc
+++ b/src/heap.cc
@@ -258,6 +258,29 @@ class ScavengeState : public RootCallback {
 
 #endif  // def LEGACY_GC
 
+bool InitialMemoryManager::Allocate() {
+#ifdef LEGACY_GC
+  initial_memory = VM::current()->heap_memory()->allocate_initial_block();
+  return initial_memory != null;
+#else
+  chunks.chunk_1 = ObjectMemory::allocate_chunk(null, TOIT_PAGE_SIZE);
+  chunks.chunk_2 = ObjectMemory::allocate_chunk(null, TOIT_PAGE_SIZE);
+  return chunks.chunk_1 != null && chunks.chunk_2 != null;
+#endif
+}
+
+InitialMemoryManager::~InitialMemoryManager() {
+  delete process_group;
+#ifdef LEGACY_GC
+  if (initial_memory) {
+    VM::current()->heap_memory()->free_unused_block(initial_memory);
+  }
+#else
+  if (chunks.chunk_1) ObjectMemory::free_chunk(chunks.chunk_1);
+  if (chunks.chunk_2) ObjectMemory::free_chunk(chunks.chunk_2);
+#endif
+}
+
 #ifdef LEGACY_GC
 ObjectHeap::ObjectHeap(Program* program, Process* owner, Block* block)
     : RawHeap(owner)
@@ -266,10 +289,10 @@ ObjectHeap::ObjectHeap(Program* program, Process* owner, Block* block)
   if (block == null) return;
   _blocks.append(block);
 #else
-ObjectHeap::ObjectHeap(Program* program, Process* owner)
+ObjectHeap::ObjectHeap(Program* program, Process* owner, InitialMemory* initial_memory)
     : _program(program)
     , _owner(owner)
-    , _two_space_heap(program, this)
+    , _two_space_heap(program, this, initial_memory->chunk_1, initial_memory->chunk_2)
     , _external_memory(0) {
 #endif
   _task = allocate_task();

--- a/src/heap.h
+++ b/src/heap.h
@@ -64,7 +64,7 @@ class InitialMemoryManager {
   }
 
   // Allocates initial pages for heap.  Returns success.
-  bool Allocate();
+  bool allocate();
 
   // Frees any of the fields that are not null.
   ~InitialMemoryManager();

--- a/src/primitive_core.cc
+++ b/src/primitive_core.cc
@@ -106,8 +106,9 @@ PRIMITIVE(hatch) {
   int method_id = Smi::cast(entry)->value();
   ASSERT(method_id != -1);
   Method method(process->program()->bytecodes, method_id);
-  Block* block = VM::current()->heap_memory()->allocate_initial_block();
-  if (!block) ALLOCATION_FAILED;
+
+  InitialMemoryManager manager;
+  if (!manager.Allocate()) ALLOCATION_FAILED;
 
   int length = 0;
   { MessageEncoder size_encoder(process, null);
@@ -117,26 +118,20 @@ PRIMITIVE(hatch) {
 
   HeapTagScope scope(ITERATE_CUSTOM_TAGS + EXTERNAL_BYTE_ARRAY_MALLOC_TAG);
   uint8* buffer = unvoid_cast<uint8*>(malloc(length));
-  if (buffer == null) {
-    VM::current()->heap_memory()->free_unused_block(block);
-    MALLOC_FAILED;
-  }
+  if (buffer == null) MALLOC_FAILED;
 
   MessageEncoder encoder(process, buffer);
   if (!encoder.encode(arguments)) {
-    VM::current()->heap_memory()->free_unused_block(block);
     encoder.free_copied();
     free(buffer);
     if (encoder.malloc_failed()) MALLOC_FAILED;
     OTHER_ERROR;
   }
 
-  Process* child = VM::current()->scheduler()->hatch(process->program(), process->group(), method, buffer, block);
-  if (!child) {
-    VM::current()->heap_memory()->free_unused_block(block);
-    MALLOC_FAILED;
-  }
+  Process* child = VM::current()->scheduler()->hatch(process->program(), process->group(), method, buffer, manager.initial_memory);
+  if (!child) MALLOC_FAILED;
 
+  manager.dont_auto_free();
   return Smi::from(child->id());
 }
 

--- a/src/primitive_core.cc
+++ b/src/primitive_core.cc
@@ -108,7 +108,7 @@ PRIMITIVE(hatch) {
   Method method(process->program()->bytecodes, method_id);
 
   InitialMemoryManager manager;
-  if (!manager.Allocate()) ALLOCATION_FAILED;
+  if (!manager.allocate()) ALLOCATION_FAILED;
 
   int length = 0;
   { MessageEncoder size_encoder(process, null);

--- a/src/primitive_programs_registry.cc
+++ b/src/primitive_programs_registry.cc
@@ -40,21 +40,18 @@ PRIMITIVE(spawn) {
 
   if (!program->is_valid(offset, OS::image_uuid())) OUT_OF_BOUNDS;
 
+  InitialMemoryManager manager;
+  if (!manager.Allocate()) ALLOCATION_FAILED;
+
   ProcessGroup* process_group = ProcessGroup::create(group_id, program);
   if (!process_group) MALLOC_FAILED;
 
-  Block* initial_block = VM::current()->heap_memory()->allocate_initial_block();
-  if (!initial_block) {
-    delete process_group;
-    ALLOCATION_FAILED;
-  }
-
-  int pid = VM::current()->scheduler()->run_program(program, {}, process_group, initial_block);
+  int pid = VM::current()->scheduler()->run_program(program, {}, manager.process_group, manager.initial_memory);
   if (pid == Scheduler::INVALID_PROCESS_ID) {
     delete process_group;
-    VM::current()->heap_memory()->free_unused_block(initial_block);
     MALLOC_FAILED;
   }
+  manager.dont_auto_free();
   return Smi::from(pid);
 }
 

--- a/src/primitive_programs_registry.cc
+++ b/src/primitive_programs_registry.cc
@@ -41,7 +41,7 @@ PRIMITIVE(spawn) {
   if (!program->is_valid(offset, OS::image_uuid())) OUT_OF_BOUNDS;
 
   InitialMemoryManager manager;
-  if (!manager.Allocate()) ALLOCATION_FAILED;
+  if (!manager.allocate()) ALLOCATION_FAILED;
 
   ProcessGroup* process_group = ProcessGroup::create(group_id, program);
   if (!process_group) MALLOC_FAILED;

--- a/src/process.h
+++ b/src/process.h
@@ -53,13 +53,14 @@ class Process : public ProcessListFromProcessGroup::Element,
 
   static const char* StateName[];
 
-  Process(Program* program, ProcessGroup* group, SystemMessage* termination, char** args, Block* initial_block);
+  Process(Program* program, ProcessGroup* group, SystemMessage* termination, char** args, InitialMemory* initial_memory);
 #ifndef TOIT_FREERTOS
-  Process(Program* program, ProcessGroup* group, SystemMessage* termination, SnapshotBundle bundle, char** args, Block* initial_block);
+  Process(Program* program, ProcessGroup* group, SystemMessage* termination, SnapshotBundle bundle, char** args, InitialMemory* initial_memory);
 #endif
-  Process(Program* program, ProcessGroup* group, SystemMessage* termination, Method method, uint8* arguments, Block* initial_block);
+  Process(Program* program, ProcessGroup* group, SystemMessage* termination, Method method, uint8* arguments, InitialMemory* initial_memory);
   ~Process();
 
+  // Constructor for an external process (no Toit code).
   Process(ProcessRunner* runner, ProcessGroup* group, SystemMessage* termination);
 
   int id() const { return _id; }
@@ -229,7 +230,7 @@ class Process : public ProcessListFromProcessGroup::Element,
   }
 
  private:
-  Process(Program* program, ProcessRunner* runner, ProcessGroup* group, SystemMessage* termination, Block* initial_block);
+  Process(Program* program, ProcessRunner* runner, ProcessGroup* group, SystemMessage* termination, InitialMemory* initial_memory);
   void _append_message(Message* message);
   void _ensure_random_seeded();
 

--- a/src/resources/primitive_snapshot.cc
+++ b/src/resources/primitive_snapshot.cc
@@ -34,7 +34,7 @@ PRIMITIVE(launch) {
   ARGS(Blob, bytes, int, gid, bool, pass_args);
 
   InitialMemoryManager manager;
-  bool ok = manager.Allocate();
+  bool ok = manager.allocate();
   USE(ok);
   ASSERT(ok);
 

--- a/src/resources/primitive_snapshot.cc
+++ b/src/resources/primitive_snapshot.cc
@@ -17,6 +17,7 @@
 
 #ifndef TOIT_FREERTOS
 
+#include "../heap.h"
 #include "../objects_inline.h"
 #include "../primitive.h"
 #include "../process.h"
@@ -32,24 +33,23 @@ MODULE_IMPLEMENTATION(snapshot, MODULE_SNAPSHOT)
 PRIMITIVE(launch) {
   ARGS(Blob, bytes, int, gid, bool, pass_args);
 
-  Block* initial_block = VM::current()->heap_memory()->allocate_initial_block();
-  if (!initial_block) ALLOCATION_FAILED;
+  InitialMemoryManager manager;
+  bool ok = manager.Allocate();
+  USE(ok);
+  ASSERT(ok);
 
   Snapshot snapshot(bytes.address(), bytes.length());
   auto image = snapshot.read_image();
   Program* program = image.program();
   ProcessGroup* process_group = ProcessGroup::create(gid, program, image.memory());
-  if (process_group == NULL) {
-    VM::current()->heap_memory()->free_unused_block(initial_block);
-    image.release();
-    MALLOC_FAILED;
-  }
+  ASSERT(process_group);  // Allocations only fail on devices.
 
   int pid = pass_args
-     ? VM::current()->scheduler()->run_program(program, process->args(), process_group, initial_block)
-     : VM::current()->scheduler()->run_program(program, {}, process_group, initial_block);
+     ? VM::current()->scheduler()->run_program(program, process->args(), process_group, manager.initial_memory)
+     : VM::current()->scheduler()->run_program(program, {}, process_group, manager.initial_memory);
   // We don't use snapshots on devices so we assume malloc/new cannot fail.
   ASSERT(pid != Scheduler::INVALID_PROCESS_ID);
+  manager.dont_auto_free();
   return Smi::from(pid);
 }
 

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -94,7 +94,7 @@ SystemMessage* Scheduler::new_termination_message(int gid) {
 Scheduler::ExitState Scheduler::run_boot_program(Program* program, char** args, int group_id) {
   // Allocation takes the memory lock which must happen before taking the scheduler lock.
   InitialMemoryManager manager;
-  bool ok = manager.Allocate();
+  bool ok = manager.allocate();
   USE(ok);
   // We assume that allocate_initial_block succeeds since we can't run out of
   // memory while booting.
@@ -116,7 +116,7 @@ Scheduler::ExitState Scheduler::run_boot_program(
   ProcessGroup* group = ProcessGroup::create(group_id, boot_program);
   // Allocation takes the memory lock which must happen before taking the scheduler lock.
   InitialMemoryManager manager;
-  bool ok = manager.Allocate();
+  bool ok = manager.allocate();
   USE(ok);
   // We assume that allocate_initial_block succeeds since we can't run out of
   // memory while booting.

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -92,14 +92,19 @@ SystemMessage* Scheduler::new_termination_message(int gid) {
 }
 
 Scheduler::ExitState Scheduler::run_boot_program(Program* program, char** args, int group_id) {
+  // Allocation takes the memory lock which must happen before taking the scheduler lock.
+  InitialMemoryManager manager;
+  bool ok = manager.Allocate();
+  USE(ok);
   // We assume that allocate_initial_block succeeds since we can't run out of
   // memory while booting.
-  // Allocation takes the memory lock which must happen before taking the scheduler lock.
-  Block* initial_block = VM::current()->heap_memory()->allocate_initial_block();
+  ASSERT(ok);
   Locker locker(_mutex);
   ProcessGroup* group = ProcessGroup::create(group_id, program);
   SystemMessage* termination = new_termination_message(group_id);
-  return launch_program(locker, _new Process(program, group, termination, args, initial_block));
+  Process* process = _new Process(program, group, termination, args, manager.initial_memory);
+  manager.dont_auto_free();
+  return launch_program(locker, process);
 }
 
 #ifndef TOIT_FREERTOS
@@ -109,13 +114,17 @@ Scheduler::ExitState Scheduler::run_boot_program(
     char** args,
     int group_id) {
   ProcessGroup* group = ProcessGroup::create(group_id, boot_program);
+  // Allocation takes the memory lock which must happen before taking the scheduler lock.
+  InitialMemoryManager manager;
+  bool ok = manager.Allocate();
+  USE(ok);
   // We assume that allocate_initial_block succeeds since we can't run out of
   // memory while booting.
-  // Allocation takes the memory lock which must happen before taking the scheduler lock.
-  Block* initial_block = VM::current()->heap_memory()->allocate_initial_block();
+  ASSERT(ok);
   Locker locker(_mutex);
   SystemMessage* termination = new_termination_message(group_id);
-  Process* process = _new Process(boot_program, group, termination, application_bundle, args, initial_block);
+  Process* process = _new Process(boot_program, group, termination, application_bundle, args, manager.initial_memory);
+  manager.dont_auto_free();
   return launch_program(locker, process);
 }
 #endif
@@ -186,13 +195,13 @@ int Scheduler::next_group_id() {
   return _next_group_id++;
 }
 
-int Scheduler::run_program(Program* program, char** args, ProcessGroup* group, Block* initial_block) {
+int Scheduler::run_program(Program* program, char** args, ProcessGroup* group, InitialMemory* initial_memory) {
   Locker locker(_mutex);
   SystemMessage* termination = new_termination_message(group->id());
   if (termination == null) {
     return INVALID_PROCESS_ID;
   }
-  Process* process = _new Process(program, group, termination, args, initial_block);
+  Process* process = _new Process(program, group, termination, args, initial_memory);
   if (process == null) {
     delete termination;
     return INVALID_PROCESS_ID;
@@ -289,12 +298,12 @@ bool Scheduler::signal_process(Process* sender, int target_id, Process::Signal s
   return true;
 }
 
-Process* Scheduler::hatch(Program* program, ProcessGroup* process_group, Method method, uint8* arguments, Block* initial_block) {
+Process* Scheduler::hatch(Program* program, ProcessGroup* process_group, Method method, uint8* arguments, InitialMemory* initial_memory) {
   Locker locker(_mutex);
 
   SystemMessage* termination = new_termination_message(process_group->id());
   if (!termination) return null;
-  Process* process = _new Process(program, process_group, termination, method, arguments, initial_block);
+  Process* process = _new Process(program, process_group, termination, method, arguments, initial_memory);
   if (!process) {
     delete termination;
     return null;

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "heap.h"
 #include "linked.h"
 #include "messaging.h"
 #include "os.h"
@@ -83,7 +84,7 @@ class Scheduler {
 #endif  // TOIT_FREERTOS
 
   // Run a new program. Returns the process ID of the root process.
-  int run_program(Program* program, char** args, ProcessGroup* group, Block* initial_block);
+  int run_program(Program* program, char** args, ProcessGroup* group, InitialMemory* initial_memory);
 
   // Run a new external program. Returns the process.
   Process* run_external(ProcessRunner* runner);
@@ -101,7 +102,7 @@ class Scheduler {
   // deliver the signal.
   bool signal_process(Process* sender, int target_id, Process::Signal signal);
 
-  Process* hatch(Program* program, ProcessGroup* process_group, Method method, uint8* arguments, Block* initial_block);
+  Process* hatch(Program* program, ProcessGroup* process_group, Method method, uint8* arguments, InitialMemory* initial_memory);
 
   // Returns a new process id (only called from Process constructor).
   int next_process_id();

--- a/src/third_party/dartino/object_memory.cc
+++ b/src/third_party/dartino/object_memory.cc
@@ -216,8 +216,6 @@ void Chunk::find(uword word, const char* name) {
 #endif
 
 Chunk* ObjectMemory::allocate_chunk(Space* owner, uword size) {
-  ASSERT(owner != null);
-
   size = Utils::round_up(size, TOIT_PAGE_SIZE);
   void* memory = OS::allocate_pages(size);
   uword lowest = GcMetadata::lowest_old_space_address();
@@ -240,9 +238,16 @@ Chunk* ObjectMemory::allocate_chunk(Space* owner, uword size) {
 #ifdef DEBUG
   chunk->scramble();
 #endif
-  GcMetadata::mark_pages_for_chunk(chunk, owner->page_type());
+  if (owner) {
+    GcMetadata::mark_pages_for_chunk(chunk, owner->page_type());
+  }
   allocated_ += size;
   return chunk;
+}
+
+void Chunk::set_owner(Space* value) {
+  owner_ = value;
+  GcMetadata::mark_pages_for_chunk(this, value->page_type());
 }
 
 void ObjectMemory::free_chunk(Chunk* chunk) {

--- a/src/third_party/dartino/object_memory.h
+++ b/src/third_party/dartino/object_memory.h
@@ -58,6 +58,7 @@ class Chunk : public ChunkList::Element {
  public:
   // The space owning this chunk.
   Space* owner() const { return owner_; }
+  void set_owner(Space* value);
 
   // Returns the first address in this chunk.
   uword start() const { return start_; }
@@ -107,8 +108,6 @@ class Chunk : public ChunkList::Element {
 
   Chunk(Space* owner, uword start, uword size, bool external = false);
   ~Chunk();
-
-  void set_owner(Space* value) { owner_ = value; }
 
   friend class ObjectMemory;
   friend class SemiSpace;
@@ -289,7 +288,7 @@ class Space {
 
 class SemiSpace : public Space {
  public:
-  SemiSpace(Program* program, Resizing resizeable, PageType page_type, uword maximum_initial_size);
+  SemiSpace(Program* program, Chunk* chunk);
 
   // Returns the total size of allocated objects.
   virtual uword used();

--- a/src/third_party/dartino/object_memory_copying.cc
+++ b/src/third_party/dartino/object_memory_copying.cc
@@ -28,18 +28,12 @@ Space::Space(Program* program, Space::Resizing resizeable, PageType page_type)
       resizeable_(resizeable == CAN_RESIZE),
       page_type_(page_type) {}
 
-SemiSpace::SemiSpace(Program* program, Space::Resizing resizeable, PageType page_type,
-                     uword maximum_initial_size)
-    : Space(program, resizeable, page_type) {
-  if (resizeable_ && maximum_initial_size > 0) {
-    uword size = Utils::min(
-        Utils::round_up(maximum_initial_size, TOIT_PAGE_SIZE),
-        DEFAULT_MAXIMUM_CHUNK_SIZE);
-    Chunk* chunk = ObjectMemory::allocate_chunk(this, size);
-    if (chunk == null) FATAL("Failed to allocate %d bytes.\n", size);
-    append(chunk);
-    update_base_and_limit(chunk, chunk->start());
-  }
+SemiSpace::SemiSpace(Program* program, Chunk* chunk)
+    : Space(program, CANNOT_RESIZE, NEW_SPACE_PAGE) {
+  ASSERT(chunk);
+  append(chunk);
+  chunk->set_owner(this);
+  update_base_and_limit(chunk, chunk->start());
 }
 
 bool SemiSpace::is_flushed() {

--- a/src/third_party/dartino/two_space_heap.cc
+++ b/src/third_party/dartino/two_space_heap.cc
@@ -11,12 +11,12 @@
 
 namespace toit {
 
-TwoSpaceHeap::TwoSpaceHeap(Program* program, ObjectHeap* process_heap)
+TwoSpaceHeap::TwoSpaceHeap(Program* program, ObjectHeap* process_heap, Chunk* chunk_1, Chunk* chunk_2)
     : program_(program),
       process_heap_(process_heap),
       old_space_(program, this),
-      semi_space_a_(program, Space::CANNOT_RESIZE, NEW_SPACE_PAGE, 0),
-      semi_space_b_(program, Space::CANNOT_RESIZE, NEW_SPACE_PAGE, 0),
+      semi_space_a_(program, chunk_1),
+      semi_space_b_(program, chunk_2),
       semi_space_(&semi_space_a_),
       unused_semi_space_(&semi_space_b_) {
   semi_space_size_ = TOIT_PAGE_SIZE;

--- a/src/third_party/dartino/two_space_heap.h
+++ b/src/third_party/dartino/two_space_heap.h
@@ -15,7 +15,7 @@ namespace toit {
 // TwoSpaceHeap represents the container for all HeapObjects.
 class TwoSpaceHeap {
  public:
-  TwoSpaceHeap(Program* program, ObjectHeap* process_heap);
+  TwoSpaceHeap(Program* program, ObjectHeap* process_heap, Chunk* chunk_1, Chunk* chunk_2);
   ~TwoSpaceHeap();
 
   // Allocate raw object. Returns null if a garbage collection is


### PR DESCRIPTION
A new heap must immediately have some space to
allocate, since some allocations happen immediately
and can't trigger a GC.

But in Toit any allocation can fail, and that includes the
initial pages for a new heap for a new process.  We handle
this by allocating the first page in the primitive before
trying to create the new process.  This way we can report
back allocation failures to the primitive machinery that
retries the primitive.

This CL extends that logic to the new GC.  In the case of the
new GC we start each two-space heap off with a page per
semispace, which means we will be able to perform a young
space GC.