### PR TITLE
Fix compilation of new-GC.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,8 +18,11 @@ file(GLOB toit_core_SRC
   "*.cc"
   )
 
+# Exclude files with a main(), and files that are not used in the
+# compiler.
 list(FILTER toit_core_SRC EXCLUDE REGEX "/(toit|toit_run_image|vm).cc$")
 
+# Files that are used in the VM, but not in the compiler.
 file(GLOB toit_vm_runtime_SRC
   "vm.h"
   "vm.cc"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,12 @@ file(GLOB toit_core_SRC
   "*.cc"
   )
 
-list(FILTER toit_core_SRC EXCLUDE REGEX "/(toit|toit_run_image).cc$")
+list(FILTER toit_core_SRC EXCLUDE REGEX "/(toit|toit_run_image|vm).cc$")
+
+file(GLOB toit_vm_runtime_SRC
+  "vm.h"
+  "vm.cc"
+  )
 
 file(GLOB toit_resources_SRC
   "resources/*.h"
@@ -46,7 +51,7 @@ file(GLOB gc_sources_SRC
   "third_party/dartino/two_space_heap.cc"
   )
 
-set(toit_vm_SRC ${toit_resources_SRC} ${toit_event_sources_SRC} ${lwip_on_linux_sources_SRC} ${gc_sources_SRC})
+set(toit_vm_SRC ${toit_vm_runtime_SRC} ${toit_resources_SRC} ${toit_event_sources_SRC} ${lwip_on_linux_sources_SRC} ${gc_sources_SRC})
 
 add_library(
   toit_core

--- a/src/heap.h
+++ b/src/heap.h
@@ -96,7 +96,7 @@ class ObjectHeap : public RawHeap {
 
   static int max_allocation_size() { return Block::max_payload_size(); }
 
-  inline void do_objects(const std::function<void (HeapObject*)>& func) {
+  void do_objects(const std::function<void (HeapObject*)>& func) {
     Iterator iterator(_blocks, _program);
     while (!iterator.eos()) {
       HeapObject* object = iterator.current();

--- a/src/heap.h
+++ b/src/heap.h
@@ -95,6 +95,16 @@ class ObjectHeap : public RawHeap {
   Iterator object_iterator() { return Iterator(_blocks, _program); }
 
   static int max_allocation_size() { return Block::max_payload_size(); }
+
+  inline void do_objects(const std::function<void (HeapObject*)>& func) {
+    Iterator iterator(_blocks, _program);
+    while (!iterator.eos()) {
+      HeapObject* object = iterator.current();
+      func(object);
+      iterator.advance();
+    }
+  }
+
 #else
 class ObjectHeap {
  public:
@@ -103,6 +113,11 @@ class ObjectHeap {
 
   // TODO: In the new heap there is no max allocation size.
   static int max_allocation_size() { return TOIT_PAGE_SIZE - 96; }
+
+  inline void do_objects(const std::function<void (HeapObject*)>& func) {
+    _two_space_heap.do_objects(func);
+  }
+
 #endif
 
   // Shared allocation operations.

--- a/src/primitive_debug.cc
+++ b/src/primitive_debug.cc
@@ -42,9 +42,8 @@ PRIMITIVE(object_histogram) {
   memset(data, 0, size);
 
   // Iterate through the object heap to collect the histogram.
-  for (ObjectHeap::Iterator it = process->object_heap()->object_iterator(); !it.eos(); it.advance()) {
-    HeapObject* object = it.current();
-    if (object == result) continue;  // Don't count the resulting byte array.
+  process->object_heap()->do_objects([&](HeapObject* object) -> void {
+    if (object == result) return;  // Don't count the resulting byte array.
     int class_index = Smi::cast(object->class_id())->value();
     int size = object->size(program);
     if (object->is_byte_array() && ByteArray::cast(object)->has_external_address()) {
@@ -59,7 +58,7 @@ PRIMITIVE(object_histogram) {
     }
     data[class_index * UINT32_PER_ENTRY + 0] += 1;
     data[class_index * UINT32_PER_ENTRY + 1] += size;
-  }
+  });
   return result;
 }
 

--- a/src/printing.cc
+++ b/src/printing.cc
@@ -39,11 +39,6 @@ void print_name_console(String* string) {
   print_name(&p, string);
 }
 
-void print_heap_console(ObjectHeap* heap, const char* title) {
-  ConsolePrinter p(null);
-  print_heap(&p, heap, title);
-}
-
 #define BYTECODE_PRINT(name, length, format, print) print,
 static const char* opcode_print[] { BYTECODES(BYTECODE_PRINT) "Illegal" };
 #undef BYTECODE_PRINT
@@ -453,13 +448,6 @@ void print_object(Printer* printer, Object* object) {
 void print_object_short(Printer* printer, Object* object, bool is_top_level) {
   ShortPrintVisitor p(printer, is_top_level);
   p.accept(object);
-}
-
-void print_heap(Printer* printer, ObjectHeap* heap, const char* title) {
-  printer->printf("%s:\n", title);
-  heap->do_objects([&] (HeapObject* object) -> void {
-    print_object(printer, object);
-  });
 }
 
 void Printer::print_buffer(const uint8_t* s, int len) {

--- a/src/printing.cc
+++ b/src/printing.cc
@@ -457,12 +457,9 @@ void print_object_short(Printer* printer, Object* object, bool is_top_level) {
 
 void print_heap(Printer* printer, ObjectHeap* heap, const char* title) {
   printer->printf("%s:\n", title);
-#ifdef LEGACY_GC
-  // TODO: Do we need this?
-  for (ObjectHeap::Iterator i = heap->object_iterator(); !i.eos(); i.advance()) {
-    print_object(printer, i.current());
-  }
-#endif
+  heap->do_objects([&] void (HeapObject* object) -> {
+    print_object(printer, object);
+  });
 }
 
 void Printer::print_buffer(const uint8_t* s, int len) {

--- a/src/printing.cc
+++ b/src/printing.cc
@@ -457,7 +457,7 @@ void print_object_short(Printer* printer, Object* object, bool is_top_level) {
 
 void print_heap(Printer* printer, ObjectHeap* heap, const char* title) {
   printer->printf("%s:\n", title);
-  heap->do_objects([&] void (HeapObject* object) -> {
+  heap->do_objects([&] (HeapObject* object) -> void {
     print_object(printer, object);
   });
 }

--- a/src/third_party/dartino/two_space_heap.h
+++ b/src/third_party/dartino/two_space_heap.h
@@ -12,6 +12,21 @@
 
 namespace toit {
 
+class HeapObjectFunctionVisitor : public HeapObjectVisitor {
+ public:
+  HeapObjectFunctionVisitor(Program* program, const std::function<void (HeapObject*)>& func)
+    : HeapObjectVisitor(program)
+    , _func(func) {}
+
+  virtual uword visit(HeapObject* object) override {
+    _func(object);
+    return object->size(program_);
+  }
+
+ private:
+  const std::function<void (HeapObject*)>& _func;
+};
+
 // TwoSpaceHeap represents the container for all HeapObjects.
 class TwoSpaceHeap {
  public:
@@ -54,6 +69,11 @@ class TwoSpaceHeap {
   void iterate_objects(HeapObjectVisitor* visitor) {
     semi_space_->iterate_objects(visitor);
     old_space_.iterate_objects(visitor);
+  }
+
+  void do_objects(const std::function<void (HeapObject*)>& func) {
+    HeapObjectFunctionVisitor visitor(program_, func);
+    iterate_objects(&visitor);
   }
 
   // Flush will write cached values back to object memory.

--- a/src/vm.cc
+++ b/src/vm.cc
@@ -21,6 +21,7 @@
 #include "objects_inline.h"
 #include "os.h"
 #include "primitive.h"
+#include "printing.h"
 #include "resource.h"
 #include "scheduler.h"
 #include "vm.h"
@@ -58,5 +59,21 @@ VM::~VM() {
 }
 
 VM* VM::_current = null;
+
+#ifdef DEBUG
+
+void print_heap_console(ObjectHeap* heap, const char* title) {
+  ConsolePrinter p(null);
+  print_heap(&p, heap, title);
+}
+
+void print_heap(Printer* printer, ObjectHeap* heap, const char* title) {
+  printer->printf("%s:\n", title);
+  heap->do_objects([&] (HeapObject* object) -> void {
+    print_object(printer, object);
+  });
+}
+
+#endif
 
 } // namespace toit


### PR DESCRIPTION
The heap histogram was not implemented for the new heap.

There are two ways to iterate heaps.
1) Using ObjectHeap::Iterator (not implemented for the new heap).
2) Using a visitor object, passed to iterate_objects (not implemented
   for the old heap).

We fix this by making a third version that calls one of the others:
3) Passing std::function to a do-like method.