### PR TITLE
Don't leave uninitialized objects on the heap

### DIFF
--- a/src/heap.cc
+++ b/src/heap.cc
@@ -66,6 +66,7 @@ Instance* ObjectHeap::allocate_instance(TypeTag class_tag, Smi* class_id, Smi* i
   if (result == null) return null;  // Allocation failure.
   // Initialize object.
   result->_set_header(class_id, class_tag);
+  result->initialize(instance_size->value());
   return result;
 }
 
@@ -79,19 +80,6 @@ Array* ObjectHeap::allocate_array(int length, Object* filler) {
   // Initialize object.
   result->_set_header(_program, _program->array_class_id());
   Array::cast(result)->_initialize_no_write_barrier(length, filler);
-  return Array::cast(result);
-}
-
-Array* ObjectHeap::allocate_array(int length) {
-  ASSERT(length >= 0);
-  ASSERT(length <= Array::max_length_in_process());
-  HeapObject* result = _allocate_raw(Array::allocation_size(length));
-  if (result == null) {
-    return null;  // Allocation failure.
-  }
-  // Initialize object.
-  result->_set_header(_program, _program->array_class_id());
-  Array::cast(result)->_initialize(length);
   return Array::cast(result);
 }
 

--- a/src/heap.h
+++ b/src/heap.h
@@ -124,7 +124,6 @@ class ObjectHeap {
   Instance* allocate_instance(Smi* class_id);
   Instance* allocate_instance(TypeTag class_tag, Smi* class_id, Smi* instance_size);
   Array* allocate_array(int length, Object* filler);
-  Array* allocate_array(int length);
   ByteArray* allocate_external_byte_array(int length, uint8* memory, bool dispose, bool clear_content = true);
   String* allocate_external_string(int length, uint8* memory, bool dispose);
   ByteArray* allocate_internal_byte_array(int length);

--- a/src/messaging.cc
+++ b/src/messaging.cc
@@ -416,7 +416,7 @@ Object* MessageDecoder::decode_string(bool inlined) {
 
 Object* MessageDecoder::decode_array() {
   int length = read_cardinal();
-  Array* result = _process->object_heap()->allocate_array(length);
+  Array* result = _process->object_heap()->allocate_array(length, Smi::zero());
   if (result == null) {
     _allocation_failed = true;
     return null;

--- a/src/objects.cc
+++ b/src/objects.cc
@@ -260,6 +260,13 @@ void Instance::roots_do(int instance_size, RootCallback* cb) {
   cb->do_roots(_root_at(_offset_from(0)), fields);
 }
 
+void Instance::initialize(int instance_size) {
+  int fields = fields_from_size(instance_size);
+  for (int i = 0; i < fields; i++) {
+    at_put(i, Smi::from(0));
+  }
+}
+
 bool Object::encode_on(ProgramOrientedEncoder* encoder) {
   return encoder->encode(this);
 }

--- a/src/objects.h
+++ b/src/objects.h
@@ -1180,6 +1180,9 @@ class Instance : public HeapObject {
   // at_put_no_write_barrier in the compiler instead.
   void at_put(int index, Object* value);
 
+  // Fills instance fields with Smi zero.
+  void initialize(int instance_size);
+
   void roots_do(int instance_size, RootCallback* cb);
 
 #ifndef TOIT_FREERTOS

--- a/src/primitive_core.cc
+++ b/src/primitive_core.cc
@@ -1465,7 +1465,7 @@ PRIMITIVE(array_expand) {
   if (length < 0) OUT_OF_BOUNDS;
   if (length > Array::max_length_in_process()) OUT_OF_RANGE;
   if (old_length < 0 || old_length > old->length() || old_length > length) OUT_OF_RANGE;
-  Object* result = process->object_heap()->allocate_array(length);
+  Object* result = process->object_heap()->allocate_array(length, Smi::from(0));
   if (result == null) ALLOCATION_FAILED;
   Array* new_array = Array::cast(result);
   new_array->copy_from(old, old_length);
@@ -1796,7 +1796,7 @@ PRIMITIVE(task_receive_message) {
     ObjectNotifier* notifier = object_notify->object_notifier();
     if (notifier != null) result = notifier->object();
   } else if (message_type == MESSAGE_SYSTEM) {
-    Array* array = process->object_heap()->allocate_array(4);
+    Array* array = process->object_heap()->allocate_array(4, Smi::from(0));
     if (array == null) ALLOCATION_FAILED;
     SystemMessage* system = static_cast<SystemMessage*>(message);
     MessageDecoder decoder(process, system->data());

--- a/src/resources/ble_esp32.cc
+++ b/src/resources/ble_esp32.cc
@@ -642,7 +642,7 @@ PRIMITIVE(scan_next) {
       }
 
       int uuids = fields.num_uuids16 + fields.num_uuids32 + fields.num_uuids128;
-      Array* service_classes = process->object_heap()->allocate_array(uuids);
+      Array* service_classes = process->object_heap()->allocate_array(uuids, Smi::from(0));
       if (!service_classes) ALLOCATION_FAILED;
 
       int index = 0;


### PR DESCRIPTION
Be a bit more defensive about having uninitialized objects on the heap, that can't be traversed.

With a GC stress test that eagerly puts random objects in the old space we would see
junk in arrays allocated by messaging.cc, then abandoned when deserialization was
restarted after an allocation failure.