### PR TITLE
Return leading bytes if buffer is too small

### DIFF
--- a/lib/rmt.toit
+++ b/lib/rmt.toit
@@ -308,6 +308,10 @@ The given $max_returned_bytes specifies the maximum byte size of the returned
   signals. The $max_returned_bytes must be smaller than the configured RX
   buffer size for the $rx channel.
 
+If $max_returned_bytes is not sufficient to store all received signals, then the
+  result is truncated. If it is important to detect this condition, then the user should
+  set $max_returned_bytes to a value greater than the maximum expected signal byte size.
+
 The $rx channel must be configured for receiving (see $Channel.config_rx).
 
 The $tx channel must be configured for transmitting (see $Channel.config_tx).

--- a/src/resources/rmt_esp32.cc
+++ b/src/resources/rmt_esp32.cc
@@ -235,16 +235,12 @@ PRIMITIVE(transmit_and_receive) {
   size_t length = 0;
   void* received_bytes = xRingbufferReceive(rb, &length, receive_timeout);
   if (received_bytes != null) {
-    if (length <= max_output_len) {
-      ByteArray::Bytes bytes(data);
-      memcpy(bytes.address(), received_bytes, length);
-      vRingbufferReturnItem(rb, received_bytes);
-    } else {
-      vRingbufferReturnItem(rb, received_bytes);
-      rmt_rx_stop(rx_channel);
-      data->resize_external(process, 0);
-      OUT_OF_RANGE;
+    if (length > max_output_len) {
+      length = max_output_len;
     }
+    ByteArray::Bytes bytes(data);
+    memcpy(bytes.address(), received_bytes, length);
+    vRingbufferReturnItem(rb, received_bytes);
   }
 
   err = rmt_rx_stop(rx_channel);

--- a/src/resources/rmt_esp32.cc
+++ b/src/resources/rmt_esp32.cc
@@ -28,10 +28,13 @@
 
 namespace toit {
 
+const rmt_channel_t kInvalidChannel = static_cast<rmt_channel_t>(-1);
 
-ResourcePool<int, -1> rmt_channels(
-    RMT_CHANNEL_0, RMT_CHANNEL_1, RMT_CHANNEL_2, RMT_CHANNEL_3,
-    RMT_CHANNEL_4, RMT_CHANNEL_5, RMT_CHANNEL_6, RMT_CHANNEL_7
+ResourcePool<rmt_channel_t, kInvalidChannel> rmt_channels(
+    RMT_CHANNEL_0, RMT_CHANNEL_1, RMT_CHANNEL_2, RMT_CHANNEL_3
+#if SOC_RMT_CHANNELS_NUM > 4
+    , RMT_CHANNEL_4, RMT_CHANNEL_5, RMT_CHANNEL_6, RMT_CHANNEL_7
+#endif
 );
 
 class RMTResourceGroup : public ResourceGroup {
@@ -67,11 +70,12 @@ PRIMITIVE(use) {
   ByteArray* proxy = process->object_heap()->allocate_proxy();
   if (proxy == null) ALLOCATION_FAILED;
 
-  if (!rmt_channels.take(channel_num)) ALREADY_IN_USE;
+  rmt_channel_t requested = static_cast<rmt_channel_t>(channel_num);
+  if (!rmt_channels.take(requested)) ALREADY_IN_USE;
 
   IntResource* resource = resource_group->register_id(channel_num);
   if (!resource) {
-    rmt_channels.put(channel_num);
+    rmt_channels.put(requested);
     MALLOC_FAILED;
   }
   proxy->set_external_address(resource);

--- a/src/resources/rmt_esp32.cc
+++ b/src/resources/rmt_esp32.cc
@@ -243,7 +243,8 @@ PRIMITIVE(transmit_and_receive) {
     }
   }
 
-  rmt_rx_stop(rx_channel);
+  err = rmt_rx_stop(rx_channel);
+  if (err != ESP_OK) return Primitive::os_error(err, process);
   data->resize_external(process, length);
   return data;
 }


### PR DESCRIPTION
If the RMT ring-buffer has too much data, only copy as much as we
want/can handle. If the user wants to know whether there was more data,
they should just request data with a higher `max_output_len` and
look at the size of the returned bytearray.