### PR TITLE
Further reduce the stack size for OTA updates.

### DIFF
--- a/src/primitive_esp32.cc
+++ b/src/primitive_esp32.cc
@@ -186,6 +186,10 @@ PRIMITIVE(ota_end) {
   uint8* buffer = allocation.alloc(BLOCK);
   if (buffer == null) ALLOCATION_FAILED;
 
+  Sha256* sha256 = _new Sha256(null);
+  if (sha256 == null) ALLOCATION_FAILED;
+  DeferDelete<Sha256> d(sha256);
+
   if (size != 0) {
     if (ota_partition == null) {
       ESP_LOGE("Toit", "Cannot end OTA session before starting it");
@@ -218,15 +222,14 @@ PRIMITIVE(ota_end) {
     Blob checksum_bytes;
     if (expected->byte_content(process->program(), &checksum_bytes, STRINGS_OR_BYTE_ARRAYS)) {
       if (checksum_bytes.length() != Sha256::HASH_LENGTH) INVALID_ARGUMENT;
-      Sha256 sha(null);
       for (int i = 0; i < size; i += BLOCK) {
         int chunk = Utils::min(BLOCK, size - i);
         err = esp_partition_read(ota_partition, i, buffer, chunk);
         if (err != ESP_OK) OUT_OF_BOUNDS;
-        sha.add(buffer, chunk);
+        sha256->add(buffer, chunk);
       }
       uint8 calculated[Sha256::HASH_LENGTH];
-      sha.get(calculated);
+      sha256->get(calculated);
       int diff = 0;
       for (int i = 0; i < Sha256::HASH_LENGTH; i++) {
         diff |= calculated[i] ^ checksum_bytes.address()[i];

--- a/src/utils.h
+++ b/src/utils.h
@@ -403,4 +403,14 @@ struct Defer {
   ~Defer() { fun(); }
 };
 
+template <typename T>
+class DeferDelete {
+ public:
+  DeferDelete(T* obj) : _obj(obj) {}
+  ~DeferDelete() { delete _obj; }
+
+ private:
+  T* _obj;
+};
+
 } // namespace toit

--- a/src/utils.h
+++ b/src/utils.h
@@ -406,11 +406,11 @@ struct Defer {
 template <typename T>
 class DeferDelete {
  public:
-  DeferDelete(T* obj) : _obj(obj) {}
-  ~DeferDelete() { delete _obj; }
+  DeferDelete(T* object) : _object(object) {}
+  ~DeferDelete() { delete _object; }
 
  private:
-  T* _obj;
+  T* _object;
 };
 
 } // namespace toit


### PR DESCRIPTION
This change moves the SHA256 state onto the malloc heap,
instead of having it on top of the stack during OTA
commit.