### PR TITLE
Fix Makefile and Cmake file for image dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ build/$(ESP32_CHIP)/programs.bin: build/$(ESP32_CHIP)/program.snapshot tools
 build/$(ESP32_CHIP)/CMakeCache.txt:
 	mkdir -p build/$(ESP32_CHIP)
 	touch build/$(ESP32_CHIP)/$(ESP32_CHIP).image.s
-	(cd build/$(ESP32_CHIP) && IMAGE=build/$(ESP32_CHIP)/$(ESP32_CHIP).image.s cmake ../../ -G Ninja -DTOITC=$(TOITC_BIN) -DTOITPKG=$(TOITPKG_BIN) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DCMAKE_TOOLCHAIN_FILE=../../toolchains/$(ESP32_CHIP)/$(ESP32_CHIP).cmake --no-warn-unused-cli)
+	(cd build/$(ESP32_CHIP) && cmake ../../ -G Ninja -DTOIT_IMAGE=build/$(ESP32_CHIP)/$(ESP32_CHIP).image.s -DTOITC=$(TOITC_BIN) -DTOITPKG=$(TOITPKG_BIN) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DCMAKE_TOOLCHAIN_FILE=../../toolchains/$(ESP32_CHIP)/$(ESP32_CHIP).cmake --no-warn-unused-cli)
 
 build/$(ESP32_CHIP)/include/sdkconfig.h:
 	mkdir -p build/$(ESP32_CHIP)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,13 +175,13 @@ endif()
 #ifdef IMAGE
 enable_language(C ASM)
 
-get_filename_component(TOIT_IMAGE "$ENV{IMAGE}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
+get_filename_component(ABS_TOIT_IMAGE "${TOIT_IMAGE}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
 
 add_library(
   toit_image
   STATIC
   EXCLUDE_FROM_ALL
-  ${TOIT_IMAGE}
+  ${ABS_TOIT_IMAGE}
 )
 
 set_target_properties(toit_image PROPERTIES LINKER_LANGUAGE ASM)


### PR DESCRIPTION
Using the environment variable to set an important parameter of the
cmake file doesn't work, as cmake rebuilds itself when it detects that
its files have changed. At that point the environment isn't set and it
would generate cache files with the wrong arguments.