### PR TITLE
Disable tsl test.

### DIFF
--- a/tests/tls_test_slow.toit
+++ b/tests/tls_test_slow.toit
@@ -54,7 +54,7 @@ run_tests:
     "ecc256.badssl.com",
     "ecc384.badssl.com",
     "rsa2048.badssl.com",
-    "rsa4096.badssl.com",
+    // "rsa4096.badssl.com",
     "extended-validation.badssl.com",
     "mozilla-modern.badssl.com",
     "tls-v1-2.badssl.com:1012",


### PR DESCRIPTION
The certificate has expired.