### PR TITLE
Remove process_weak_pointers().

### DIFF
--- a/src/third_party/dartino/object_memory.h
+++ b/src/third_party/dartino/object_memory.h
@@ -310,8 +310,6 @@ class SemiSpace : public Space {
 
   virtual void append(Chunk* chunk);
 
-  void process_weak_pointers(SemiSpace* to_space, OldSpace* old_space);
-
   inline void swap(SemiSpace& other) {
     static_cast<Space&>(*this).swap(static_cast<Space&>(other));
   }
@@ -470,8 +468,6 @@ class OldSpace : public Space {
   void unlink_promoted_track();
 
   void use_whole_chunk(Chunk* chunk);
-
-  void process_weak_pointers();
 
   void compute_compaction_destinations();
 

--- a/src/third_party/dartino/object_memory_copying.cc
+++ b/src/third_party/dartino/object_memory_copying.cc
@@ -191,10 +191,6 @@ bool SemiSpace::complete_scavenge(ScavengeVisitor* visitor) {
   return found_work;
 }
 
-void SemiSpace::process_weak_pointers(SemiSpace* to_space, OldSpace* old_space) {
-  // TODO(erik): Process finalizers.
-}
-
 }  // namespace toit
 
 #endif  // LEGACY_GC

--- a/src/third_party/dartino/object_memory_mark_sweep.cc
+++ b/src/third_party/dartino/object_memory_mark_sweep.cc
@@ -543,10 +543,6 @@ uword SweepingVisitor::visit(HeapObject* object) {
   return size;
 }
 
-void OldSpace::process_weak_pointers() {
-  // TODO(erik): Process finalizers.
-}
-
 #ifdef DEBUG
 void OldSpace::validate() {
   // Verify that the object starts table contains only legitimate object start

--- a/src/third_party/dartino/two_space_heap.cc
+++ b/src/third_party/dartino/two_space_heap.cc
@@ -342,8 +342,6 @@ void TwoSpaceHeap::sweep_heap() {
 
   old_space()->set_compacting(false);
 
-  old_space()->process_weak_pointers();
-
   // Sweep over the old-space and rebuild the freelist.
   SweepingVisitor sweeping_visitor(program_, old_space());
   old_space()->iterate_objects(&sweeping_visitor);
@@ -388,10 +386,6 @@ void TwoSpaceHeap::compact_heap() {
   old_space()->compute_compaction_destinations();
 
   old_space()->clear_free_list();
-
-  // Weak processing when the destination addresses have been calculated, but
-  // before they are moved (which ruins the liveness data).
-  old_space()->process_weak_pointers();
 
   old_space()->zap_object_starts();
 


### PR DESCRIPTION
This is a Dartino remnant.  We handle this elsewhere in
Toit.