### PR TITLE
Roll esp-idf to get heap range directly from malloc.

### DIFF
--- a/src/os_esp32.cc
+++ b/src/os_esp32.cc
@@ -47,6 +47,10 @@
 
 namespace toit {
 
+// Flags used to get memory for the Toit heap, which needs to be fast and 8-bit
+// capable.
+static const int TOIT_HEAP_CAPS_FLAGS = MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA;
+
 void panic_put_char(char c) {
   while (((READ_PERI_REG(UART_STATUS_REG(CONFIG_ESP_CONSOLE_UART_NUM)) >> UART_TXFIFO_CNT_S)&UART_TXFIFO_CNT) >= 126) ;
   WRITE_PERI_REG(UART_FIFO_REG(CONFIG_ESP_CONSOLE_UART_NUM), c);
@@ -352,7 +356,7 @@ void OS::free_block(Block* block) {
 void* OS::allocate_pages(uword size) {
   size = Utils::round_up(size, TOIT_PAGE_SIZE);
   HeapTagScope scope(ITERATE_CUSTOM_TAGS + TOIT_HEAP_MALLOC_TAG);
-  void* allocation = heap_caps_aligned_alloc(TOIT_PAGE_SIZE, size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA);
+  void* allocation = heap_caps_aligned_alloc(TOIT_PAGE_SIZE, size, TOIT_HEAP_CAPS_FLAGS);
   return allocation;
 }
 
@@ -382,12 +386,24 @@ bool OS::use_virtual_memory(void* address, uword size) {
 void OS::unuse_virtual_memory(void* address, uword size) {}
 
 OS::HeapMemoryRange OS::get_heap_memory_range() {
-  //                           DRAM range            IRAM range
+  multi_heap_info_t info {};
+  heap_caps_get_info(&info, TOIT_HEAP_CAPS_FLAGS);
+
+  // Older esp-idfs or mallocs other than cmpctmalloc won't set the
+  // lowest_address and highest_address fields.
+  if (info.lowest_address != null) {
+    HeapMemoryRange range;
+    range.address = info.lowest_address;
+    range.size = reinterpret_cast<uword>(info.highest_address) - reinterpret_cast<uword>(info.lowest_address);
+    return range;
+  }
+
   HeapMemoryRange range;
 #ifdef CONFIG_IDF_TARGET_ESP32S3
   range.address = reinterpret_cast<void*>(0x3ffa0000);
   range.size = 512 * KB;
 #else
+  //                           DRAM range            IRAM range
   // Internal SRAM 2 200k 3ffa_e000 - 3ffe_0000
   // Internal SRAM 0 192k 3ffe_0000 - 4000_0000    4007_0000 - 400a_0000
   // Internal SRAM 1 128k                          400a_0000 - 400c_0000

--- a/src/third_party/dartino/gc_metadata.cc
+++ b/src/third_party/dartino/gc_metadata.cc
@@ -24,8 +24,9 @@ void GcMetadata::set_up() { singleton_.set_up_singleton(); }
 void GcMetadata::set_up_singleton() {
   OS::HeapMemoryRange range = OS::get_heap_memory_range();
 
-  lowest_address_ = Utils::round_down(reinterpret_cast<uword>(range.address), TOIT_PAGE_SIZE);
-  uword size = range.size;
+  uword range_address = reinterpret_cast<uword>(range.address);
+  lowest_address_ = Utils::round_down(range_address, TOIT_PAGE_SIZE);
+  uword size = Utils::round_up(range.size + range_address - lowest_address_, TOIT_PAGE_SIZE);
   heap_extent_ = size;
   heap_start_munged_ = (lowest_address_ >> 1) |
                        (static_cast<uword>(1) << (8 * sizeof(uword) - 1));


### PR DESCRIPTION
Also rolls in fix to malloc heap stats.