### PR TITLE
tls_test_slow be less picky about the error message

### DIFF
--- a/tests/tls_test_slow.toit
+++ b/tests/tls_test_slow.toit
@@ -86,8 +86,8 @@ run_tests:
     //  "dh-composite.badssl.com", // Should we not connect to sites with crappy certs?
     "subdomain.preloaded-hsts.badssl.com/Common Name",
     "captive-portal.badssl.com",
-    "mitm-software.badssl.com/unknown root cert",
-    "sha1-2017.badssl.com/unacceptable hash",
+    "mitm-software.badssl.com",
+    "sha1-2017.badssl.com",
     ]
   working.do: | site |
     test_site site true


### PR DESCRIPTION
The important thing is that wrong sites fail to connect.
By not specifying the exact error message we make the test
less flaky.