### PR TITLE
Provide usage message when arguments fail to parse

### DIFF
--- a/lib/core/entry.toit
+++ b/lib/core/entry.toit
@@ -36,6 +36,14 @@ __entry__task lambda -> none:
 main_arguments_:
   #primitive.core.args
 
+/**
+Returns the name of the toit file, image, or snapshot that the
+  current program was run from.  May return null if this information
+  is not available.
+*/
+program_name -> string?:
+  #primitive.core.command
+
 spawn_method_ -> int:
   #primitive.core.hatch_method
 

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -137,6 +137,8 @@ static void process_argument(const char* argument) {
   FLAGS_DO(PROCESS_DEBUG_FLAG, PROCESS_DEPLOY_FLAG);
 }
 
+const char* Flags::command = null;
+
 int Flags::process_args(int* argc, char** argv) {
   // Compute number of provided flag arguments.
   int number_of_flags = 0;

--- a/src/flags.h
+++ b/src/flags.h
@@ -81,6 +81,8 @@ class Flags {
  public:
   FLAGS_DO(DECLARE_DEBUG_FLAG, DECLARE_DEPLOY_FLAG)
 
+  static const char* command;
+
 #ifndef IOT_DEVICE
   static int process_args(int* argc, char** argv);
 #endif

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -158,6 +158,7 @@ namespace toit {
   PRIMITIVE(object_class_id, 1)              \
   PRIMITIVE(number_to_integer, 1)            \
   PRIMITIVE(float_sqrt, 1)                   \
+  PRIMITIVE(command, 0)                      \
   PRIMITIVE(args, 0)                         \
   PRIMITIVE(hatch, 2)                        \
   PRIMITIVE(hatch_method, 0)                 \

--- a/src/primitive_core.cc
+++ b/src/primitive_core.cc
@@ -15,6 +15,7 @@
 
 #include "encoder.h"
 #include "entropy_mixer.h"
+#include "flags.h"
 #include "heap.h"
 #include "heap_report.h"
 #include "objects_inline.h"
@@ -470,6 +471,14 @@ PRIMITIVE(read_int_little_endian) {
     value |= source.address()[offset + i - 1];
   }
   return Primitive::integer(value, process);
+}
+
+PRIMITIVE(command) {
+  if (Flags::command == null) return process->program()->null_object();
+  Error* error = null;
+  String* arg = process->allocate_string(Flags::command, &error);
+  if (arg == null) return error;
+  return arg;
 }
 
 PRIMITIVE(args) {

--- a/src/toit.cc
+++ b/src/toit.cc
@@ -169,6 +169,7 @@ int main(int argc, char **argv) {
       print_usage(1);
     }
     int bundle_argv_index = with_flag ? 2 : 1;
+    Flags::command = argv[bundle_argv_index];
     char* bundle_file = argv[bundle_argv_index];
     auto bundle = SnapshotBundle::read_from_file(bundle_file);
     if (!bundle.is_valid()) print_usage(1);
@@ -318,6 +319,8 @@ int main(int argc, char **argv) {
         break;
       }
     }
+
+    Flags::command = source_path;
 
     // We break after the first argument that isn't a flag.
     // This means that there is always at most one source-file.

--- a/src/toit_run_image.cc
+++ b/src/toit_run_image.cc
@@ -81,6 +81,7 @@ int main(int argc, char **argv) {
   ObjectMemory::set_up();
 
   char* image_filename = argv[1];
+  Flags::command = image_filename;
   FILE* file = fopen(image_filename, "rb");
   if (file == null) {
     FATAL("Couldn't open file");


### PR DESCRIPTION
Sample output:

```
$ toit.run cli.toit  
Usage:
<toit.run cli.toit [--value|-v=<value>] [--flag] install  <app-name> <image-file>
<toit.run cli.toit [--value|-v=<value>] [--flag] uninstall  <app-name>
<toit.run cli.toit [--value|-v=<value>] [--flag] set-max-offline  <offline-time-in-seconds>
$ toit.run cli.toit install
Too few arguments
Usage:
toit.run cli.toit install  <app-name> <image-file>
```