### PR TITLE
Remove warning in debug mode.

### DIFF
--- a/src/top.cc
+++ b/src/top.cc
@@ -72,9 +72,12 @@ void* tracing_malloc(size_t size, const char* file, int line) {
 #undef realloc
 void* tracing_realloc(void* ptr, size_t size, const char* file, int line) {
   void* result = realloc(ptr, size);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuse-after-free"
   if (Flags::cheap) {
     printf("%s:%d: realloc [%p] %zd [%p]\n", file, line, ptr, size, result);
   }
+#pragma GCC diagnostic pop
   return result;
 }
 

--- a/src/top.cc
+++ b/src/top.cc
@@ -71,13 +71,13 @@ void* tracing_malloc(size_t size, const char* file, int line) {
 
 #undef realloc
 void* tracing_realloc(void* ptr, size_t size, const char* file, int line) {
+  // Store the old pointer in a word, so that the compiler doesn't detect a
+  // use-after-free.
+  word old_ptr = reinterpret_cast<word>(ptr);
   void* result = realloc(ptr, size);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuse-after-free"
   if (Flags::cheap) {
-    printf("%s:%d: realloc [%p] %zd [%p]\n", file, line, ptr, size, result);
+    printf("%s:%d: realloc [%p] %zd [%p]\n", file, line, reinterpret_cast<void*>(old_ptr), size, result);
   }
-#pragma GCC diagnostic pop
   return result;
 }
 


### PR DESCRIPTION
The warning correctly sees that we are using a pointer that might not
exist anymore. But this is just for debugging where we want to see
whether the pointer has changed.