### PR TITLE
Improve BLE error message.

### DIFF
--- a/src/resources/ble_esp32.cc
+++ b/src/resources/ble_esp32.cc
@@ -491,7 +491,7 @@ PRIMITIVE(init) {
   if (proxy == null) ALLOCATION_FAILED;
 
   int id = ble_pool.any();
-  if (id == kInvalidBLE) OUT_OF_BOUNDS;
+  if (id == kInvalidBLE) ALREADY_IN_USE;
 
   esp_err_t err = esp_nimble_hci_and_controller_init();
 


### PR DESCRIPTION
When the BLE device is already in use, it used to throw an
OUT_OF_BOUNDS. Now the error is "ALREADY_IN_USE".