### PR TITLE
Change `is_type` checks of heap objects.

### DIFF
--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -107,7 +107,7 @@ class EncodeVisitor : public Visitor {
 
   void visit_instance(Instance* instance) {
     Smi* class_id = instance->class_id();
-    if (class_id == _encoder->program()->list_class_id() && instance->at(0)->is_array()) {
+    if (class_id == _encoder->program()->list_class_id() && is_array(instance->at(0))) {
       // The backing storage in a list can be either an array -- or a
       // large array. Only optimize if it isn't large.
       // We use the same layout assumptions for List_ as the interpreter.

--- a/src/heap_roots.cc
+++ b/src/heap_roots.cc
@@ -32,7 +32,7 @@ void VMFinalizerNode::roots_do(RootCallback* cb) {
 void VMFinalizerNode::free_external_memory(Process* process) {
   uint8* memory = null;
   word accounting_size = 0;
-  if (key()->is_byte_array()) {
+  if (is_byte_array(key())) {
     ByteArray* byte_array = ByteArray::cast(key());
     if (byte_array->external_tag() == MappedFileTag) return;  // TODO(erik): release mapped file, so flash storage can be reclaimed.
     ASSERT(byte_array->has_external_address());
@@ -42,7 +42,7 @@ void VMFinalizerNode::free_external_memory(Process* process) {
     // Accounting size is 0 if the byte array is tagged, since we don't account
     // memory for Resources etc.
     ASSERT(byte_array->external_tag() == RawByteTag || byte_array->external_tag() == NullStructTag);
-  } else if (key()->is_string()) {
+  } else if (is_string(key())) {
     String* string = String::cast(key());
     memory = string->as_external();
     // Add one because the strings are allocated with a null termination byte.

--- a/src/interpreter_run.cc
+++ b/src/interpreter_run.cc
@@ -29,10 +29,10 @@ namespace toit {
 
 inline bool are_smis(Object* a, Object* b) {
   uword bits = reinterpret_cast<uword>(a) | reinterpret_cast<uword>(b);
-  bool result = reinterpret_cast<Object*>(bits)->is_smi();
+  bool result = is_smi(reinterpret_cast<Object*>(bits));
   // The or-trick only works if smis are tagged with a zero-bit.
   // The following ASSERT makes sure we catch any change to this scheme.
-  ASSERT(!result || (a->is_smi() && b->is_smi()));
+  ASSERT(!result || (is_smi(a) && is_smi(b)));
   return result;
 }
 
@@ -54,7 +54,7 @@ inline bool Interpreter::typecheck_class(Program* program,
   if (is_nullable && value == program->null_object()) {
     return true;
   } else {
-    Smi* class_id = value->is_smi()
+    Smi* class_id = is_smi(value)
         ? program->smi_class_id()
         : HeapObject::cast(value)->class_id();
     int value_class_id = class_id->value();
@@ -76,7 +76,7 @@ inline bool Interpreter::typecheck_interface(Program* program,
 }
 
 Method Program::find_method(Object* receiver, int offset) {
-  Smi* class_id = receiver->is_smi() ? smi_class_id() : HeapObject::cast(receiver)->class_id();
+  Smi* class_id = is_smi(receiver) ? smi_class_id() : HeapObject::cast(receiver)->class_id();
   int index = class_id->value() + offset;
   int entry_id = dispatch_table[index];
   if (entry_id == -1) return Method::invalid();
@@ -436,7 +436,7 @@ Interpreter::Result Interpreter::run() {
   OPCODE_BEGIN_WITH_WIDE(LOAD_GLOBAL_VAR_LAZY, global_index);
     Object** global_variables = _process->object_heap()->global_variables();
     Object* value = global_variables[global_index];
-    if (value->is_instance()) {
+    if (is_instance(value)) {
       Instance* instance = Instance::cast(value);
       if (instance->class_id() == program->lazy_initializer_class_id()) {
         PUSH(Smi::from(global_index));
@@ -737,7 +737,7 @@ Interpreter::Result Interpreter::run() {
     Object* a1 = STACK_AT(0);
     if (a0 == a1) {
       // All identical objects, except for NaNs, are equal to themselves.
-      STACK_AT_PUT(1, boolean(program, !(a0->is_double() && isnan(Double::cast(a0)->value()))));
+      STACK_AT_PUT(1, boolean(program, !(is_double(a0) && isnan(Double::cast(a0)->value()))));
       DROP1();
       DISPATCH(INVOKE_EQ_LENGTH);
     } else if (a0 == program->null_object() || a1 == program->null_object()) {
@@ -928,7 +928,7 @@ Interpreter::Result Interpreter::run() {
     Method target(program->bytecodes, Smi::cast(receiver->at(0))->value());
     int captured_size = 1;
     Object* argument = receiver->at(1);
-    if (argument->is_array()) {
+    if (is_array(argument)) {
       captured_size = Array::cast(argument)->length();
     }
     int user_arity = target.arity() - captured_size;
@@ -953,7 +953,7 @@ Interpreter::Result Interpreter::run() {
         STACK_AT_PUT(i, STACK_AT(i - 1));
       }
       DROP(extra + 1);
-      if (argument->is_array()) {
+      if (is_array(argument)) {
         Array* arguments = Array::cast(argument);
         for (int i = 0; i < captured_size; i++) {
           PUSH(arguments->at(i));
@@ -1279,9 +1279,9 @@ Interpreter::Result Interpreter::run() {
       ASSERT(return_code == 3);
       Object* duration = POP();
       int64 value = 0;
-      if (duration->is_smi()) {
+      if (is_smi(duration)) {
         value = Smi::cast(duration)->value();
-      } else if (duration->is_large_integer()) {
+      } else if (is_large_integer(duration)) {
         value = LargeInteger::cast(duration)->value();
       } else {
         FATAL("Cannot handle non-numeric deep sleep argument");
@@ -1409,7 +1409,7 @@ Interpreter::Result Interpreter::run() {
     if (program->true_object() == STACK_AT(parameter_offset + REVERSED)) step = -step;
     Object* entry;
     Object* return_value = hash_do(program, STACK_AT(STATE), backing, step, STACK_AT(parameter_offset + BLOCK), &entry);
-    if (return_value->is_smi() && Smi::cast(return_value)->value() < 0) {
+    if (is_smi(return_value) && Smi::cast(return_value)->value() < 0) {
       // Negative Smi means call the block.
       word c = -(Smi::cast(return_value)->value() + 1);
       STACK_AT_PUT(STATE, Smi::from(c));
@@ -1541,9 +1541,9 @@ Interpreter::Result Interpreter::run() {
       Method not_found_target = Method(program->bytecodes, Smi::cast(not_found_block)->value());
       Method rebuild_target   = Method(program->bytecodes, Smi::cast(rebuild_block)->value());
       Method compare_target   = Method(program->bytecodes, Smi::cast(compare_block)->value());
-      if (!index_spaces_left_object->is_smi()
-       || !hash_object->is_smi()
-       || !size_object->is_smi()
+      if (!is_smi(index_spaces_left_object)
+       || !is_smi(hash_object)
+       || !is_smi(size_object)
        || not_found_target.arity() != 1
        || rebuild_target.arity() != 2
        || compare_target.arity() != 3) {
@@ -1558,14 +1558,14 @@ Interpreter::Result Interpreter::run() {
     }
     Object* index_object = collection->at(2);
     word index_mask;
-    if (index_object->is_array()) {
+    if (is_array(index_object)) {
       index_mask = Array::cast(index_object)->length() - 1;
       ASSERT(Array::ARRAYLET_SIZE < (Smi::MAX_SMI_VALUE >> HASH_SHIFT_));
     } else {
       bool bail = true;
-      if (index_object->is_instance() && HeapObject::cast(index_object)->class_id() == program->large_array_class_id()) {
+      if (is_instance(index_object) && HeapObject::cast(index_object)->class_id() == program->large_array_class_id()) {
         Object* size_object = Instance::cast(index_object)->at(0);
-        if (size_object->is_smi()) {
+        if (is_smi(size_object)) {
           index_mask = Smi::cast(size_object)->value() - 1;
           bail = false;
         }
@@ -1588,7 +1588,7 @@ Interpreter::Result Interpreter::run() {
     if (state == STATE_NOT_FOUND) {
       Object* append_position = block_result;
       STACK_AT_PUT(parameter_offset + APPEND_POSITION, append_position);
-      ASSERT(append_position->is_smi());
+      ASSERT(is_smi(append_position));
       // Update free position in index with new entry.
       word new_hash_and_position = ((Smi::cast(append_position)->value() + 1) << HASH_SHIFT_) | (hash & HASH_MASK_);
       ASSERT(Smi::is_valid(new_hash_and_position));
@@ -1606,7 +1606,7 @@ Interpreter::Result Interpreter::run() {
         index_position = deleted_slot & index_mask;
       }
       Object* entry = Smi::from(new_hash_and_position);
-      if (index_object->is_array()) {
+      if (is_array(index_object)) {
         Array::cast(index_object)->at_put(index_position, entry);
       } else {
         bool success = fast_at(_process, index_object, Smi::from(index_position), true, &entry);
@@ -1624,7 +1624,7 @@ Interpreter::Result Interpreter::run() {
         result = Smi::from(APPEND_);
       } else {
         Object* append_position = STACK_AT(parameter_offset + APPEND_POSITION);
-        if (append_position->is_smi()) {
+        if (is_smi(append_position)) {
           result = Smi::from(APPEND_);
         } else {
           result = STACK_AT(POSITION);
@@ -1680,13 +1680,13 @@ Interpreter::Result Interpreter::run() {
       }
       increment = true;
       word hash_and_position;
-      if (index_object->is_array()) {
+      if (is_array(index_object)) {
         hash_and_position = Smi::cast(Array::cast(index_object)->at(slot))->value();
       } else {
         Object* hap;
         bool success = fast_at(_process, index_object, Smi::from(slot), false, &hap);
         ASSERT(success);
-        ASSERT(hap->is_smi());
+        ASSERT(is_smi(hap));
         hash_and_position = Smi::cast(hap)->value();
       }
       if (hash_and_position == 0 || exhausted) {
@@ -1702,7 +1702,7 @@ Interpreter::Result Interpreter::run() {
           STACK_AT_PUT(STATE, Smi::from(STATE_NOT_FOUND)); // Go there if not_found returns.
         }
         Object* append_position = STACK_AT(parameter_offset + APPEND_POSITION);
-        if (!append_position->is_smi()) {  // If it is null we haven't called not_found yet.
+        if (!is_smi(append_position)) {  // If it is null we haven't called not_found yet.
           Smi* not_found_block = Smi::cast(STACK_AT(parameter_offset + NOT_FOUND));
           Method not_found_target =
               Method(program->bytecodes, Smi::cast(*from_block(not_found_block))->value());
@@ -1729,11 +1729,11 @@ Interpreter::Result Interpreter::run() {
       ASSERT(success);
       word deleted_slot = Smi::cast(STACK_AT(DELETED_SLOT))->value();
       // if deleted_slot is invalid and k is Tombstone_
-      if (deleted_slot == INVALID_SLOT && !k->is_smi() && HeapObject::cast(k)->class_id() == program->tombstone_class_id()) {
+      if (deleted_slot == INVALID_SLOT && !is_smi(k) && HeapObject::cast(k)->class_id() == program->tombstone_class_id()) {
         STACK_AT_PUT(DELETED_SLOT, Smi::from(slot));
       }
       if ((hash_and_position & HASH_MASK_) == (hash & HASH_MASK_)) {
-        if (k->is_smi() || HeapObject::cast(k)->class_id() != program->tombstone_class_id()) {
+        if (is_smi(k) || HeapObject::cast(k)->class_id() != program->tombstone_class_id()) {
           // Found hash match.
           // TODO: Handle string and number cases here.
           STACK_AT_PUT(STATE, Smi::from(STATE_AFTER_COMPARE)); // Go there afterwards.

--- a/src/messaging.cc
+++ b/src/messaging.cc
@@ -101,7 +101,7 @@ bool MessageEncoder::encode(Object* object) {
     return false;
   }
 
-  if (object->is_smi()) {
+  if (is_smi(object)) {
     word value = Smi::cast(object)->value();
     if (value >= 0) {
       write_uint8(TAG_POSITIVE_SMI);
@@ -111,12 +111,12 @@ bool MessageEncoder::encode(Object* object) {
       write_cardinal(-value);
     }
     return true;
-  } else if (object->is_instance()) {
+  } else if (is_instance(object)) {
     Instance* instance = Instance::cast(object);
     Smi* class_id = instance->class_id();
     if (class_id == _program->list_class_id()) {
       Object* backing = instance->at(0);
-      if (backing->is_array()) {
+      if (is_array(backing)) {
         Array* array = Array::cast(backing);
         return encode_array(array, Smi::cast(instance->at(1))->value());
       }
@@ -137,22 +137,22 @@ bool MessageEncoder::encode(Object* object) {
   } else if (object == _program->false_object()) {
     write_uint8(TAG_FALSE);
     return true;
-  } else if (object->is_byte_array()) {
+  } else if (is_byte_array(object)) {
     return encode_byte_array(ByteArray::cast(object));
-  } else if (object->is_double()) {
+  } else if (is_double(object)) {
     write_uint8(TAG_DOUBLE);
     write_uint64(bit_cast<uint64>(Double::cast(object)->value()));
     return true;
-  } else if (object->is_string()) {
+  } else if (is_string(object)) {
     return encode_copy(object, TAG_STRING);
-  } else if (object->is_array()) {
+  } else if (is_array(object)) {
     Array* array = Array::cast(object);
     return encode_array(array, array->length());
-  } else if (object->is_large_integer()) {
+  } else if (is_large_integer(object)) {
     write_uint8(TAG_LARGE_INTEGER);
     write_uint64(bit_cast<uint64>(Double::cast(object)->value()));
     return true;
-  } else if (object->is_heap_object()) {
+  } else if (is_heap_object(object)) {
     printf("[message encoder: cannot encode object with class tag = %d]\n", HeapObject::cast(object)->class_tag());
   }
   return false;
@@ -285,7 +285,7 @@ bool MessageDecoder::decode_process_message(uint8* buffer, int* value) {
   MessageDecoder decoder(null, buffer);
   // TODO(kasper): Make this more robust. We don't know the content.
   Object* object = decoder.decode();
-  if (object->is_smi()) {
+  if (is_smi(object)) {
     *value = Smi::cast(object)->value();
     return true;
   }

--- a/src/objects.cc
+++ b/src/objects.cc
@@ -26,13 +26,13 @@
 namespace toit {
 
 bool Object::byte_content(Program* program, const uint8** content, int* length, BlobKind strings_only) {
-  if (is_string()) {
+  if (is_string(this)) {
     String::Bytes bytes(String::cast(this));
     *length = bytes.length();
     *content = bytes.address();
     return true;
   }
-  if (strings_only == STRINGS_OR_BYTE_ARRAYS && is_byte_array()) {
+  if (strings_only == STRINGS_OR_BYTE_ARRAYS && is_byte_array(this)) {
     ByteArray* byte_array = ByteArray::cast(this);
     // External byte arrays can have structs in them. This is captured in the external tag.
     // We only allow extracting the byte content from an external byte arrays iff it is tagged with RawByteType.
@@ -42,7 +42,7 @@ bool Object::byte_content(Program* program, const uint8** content, int* length, 
     *content = bytes.address();
     return true;
   }
-  if (is_instance()) {
+  if (is_instance(this)) {
     auto instance = Instance::cast(this);
     auto class_id = instance->class_id();
     if (strings_only == STRINGS_OR_BYTE_ARRAYS && class_id == program->byte_array_cow_class_id()) {
@@ -52,10 +52,10 @@ bool Object::byte_content(Program* program, const uint8** content, int* length, 
       auto wrapped = instance->at(0);
       auto from = instance->at(1);
       auto to = instance->at(2);
-      if (!wrapped->is_heap_object()) return false;
+      if (!is_heap_object(wrapped)) return false;
       // TODO(florian): we could eventually accept larger integers here.
-      if (!from->is_smi()) return false;
-      if (!to->is_smi()) return false;
+      if (!is_smi(from)) return false;
+      if (!is_smi(to)) return false;
       int from_value = Smi::cast(from)->value();
       int to_value = Smi::cast(to)->value();
       bool inner_success = HeapObject::cast(wrapped)->byte_content(program, content, length, strings_only);
@@ -356,7 +356,7 @@ char* String::cstr_dup() {
 
 bool String::equals(Object* other) {
   if (this == other) return true;
-  if (!other->is_string()) return false;
+  if (!is_string(other)) return false;
   String* other_string = String::cast(other);
   if (hash_code() != other_string->hash_code()) return false;
   Bytes bytes(this);

--- a/src/objects.h
+++ b/src/objects.h
@@ -34,6 +34,20 @@ enum BlobKind {
   STRINGS_ONLY
 };
 
+// Type testers.
+INLINE bool is_smi(Object* o);
+INLINE bool is_heap_object(Object* o);
+INLINE bool is_double(Object* o);
+INLINE bool is_task(Object* o);
+INLINE bool is_instance(Object* o);
+INLINE bool is_array(Object* o);
+INLINE bool is_byte_array(Object* o);
+INLINE bool is_stack(Object* o);
+INLINE bool is_string(Object* o);
+INLINE bool is_large_integer(Object* o);
+INLINE bool is_free_list_region(Object* o);
+INLINE bool is_promoted_track(Object* o);
+
 class Object {
  public:
   static const int SMI_TAG_SIZE = 1;
@@ -45,20 +59,6 @@ class Object {
   static const uword NON_SMI_TAG_MASK = (1 << NON_SMI_TAG_SIZE) - 1;
   static const int HEAP_TAG = 0x1;
   static const int MARKED_TAG = 0x3;
-
-  // Type testers.
-  INLINE bool is_smi() const { return (reinterpret_cast<uword>(this) & SMI_TAG_MASK) == SMI_TAG; }
-  INLINE bool is_heap_object() const { return (reinterpret_cast<uword>(this) & NON_SMI_TAG_MASK) == HEAP_TAG; }
-  INLINE bool is_double();
-  INLINE bool is_instance();
-  INLINE bool is_array();
-  INLINE bool is_byte_array();
-  INLINE bool is_stack();
-  INLINE bool is_string();
-  INLINE bool is_task();
-  INLINE bool is_large_integer();
-  INLINE bool is_free_list_region();
-  INLINE bool is_promoted_track();
 
   static Object* cast(Object* obj) { return obj; }
 
@@ -152,7 +152,7 @@ class Smi : public Object {
   }
 
   static Smi* cast(Object* obj) {
-    ASSERT(obj->is_smi());
+    ASSERT(is_smi(obj));
     return static_cast<Smi*>(obj);
   }
 
@@ -196,7 +196,7 @@ class HeapObject : public Object {
  public:
   INLINE Smi* header() {
     Object* result = _at(HEADER_OFFSET);
-    ASSERT(result->is_smi());
+    ASSERT(is_smi(result));
     return Smi::cast(result);
   }
   INLINE Smi* class_id() {
@@ -207,7 +207,7 @@ class HeapObject : public Object {
   }
 
   INLINE bool has_forwarding_address() {
-    return _at(HEADER_OFFSET)->is_heap_object();
+    return is_heap_object(_at(HEADER_OFFSET));
   }
 
   // During GC the header can be a heap object (a forwarding pointer).
@@ -258,7 +258,7 @@ class HeapObject : public Object {
   }
 
   static HeapObject* cast(Object* obj) {
-    ASSERT(obj->is_heap_object());
+    ASSERT(is_heap_object(obj));
     return static_cast<HeapObject*>(obj);
   }
 
@@ -387,7 +387,7 @@ class Array : public HeapObject {
 #endif
 
   static Array* cast(Object* array) {
-     ASSERT(array->is_array());
+     ASSERT(is_array(array));
      return static_cast<Array*>(array);
   }
 
@@ -524,7 +524,7 @@ class ByteArray : public HeapObject {
 #endif
 
   static ByteArray* cast(Object* byte_array) {
-     ASSERT(byte_array->is_byte_array());
+     ASSERT(is_byte_array(byte_array));
      return static_cast<ByteArray*>(byte_array);
   }
 
@@ -643,7 +643,7 @@ class LargeInteger : public HeapObject {
   int64 value() { return _int64_at(VALUE_OFFSET); }
 
   static LargeInteger* cast(Object* value) {
-     ASSERT(value->is_large_integer());
+     ASSERT(is_large_integer(value));
      return static_cast<LargeInteger*>(value);
   }
 
@@ -699,7 +699,7 @@ class Stack : public HeapObject {
   static INLINE int max_length();
 
   static Stack* cast(Object* stack) {
-    ASSERT(stack->is_stack());
+    ASSERT(is_stack(stack));
     return static_cast<Stack*>(stack);
   }
 
@@ -760,7 +760,7 @@ class Double : public HeapObject {
   int64 bits() { return _int64_at(VALUE_OFFSET); }
 
   static Double* cast(Object* value) {
-     ASSERT(value->is_double());
+     ASSERT(is_double(value));
      return static_cast<Double*>(value);
   }
 
@@ -871,7 +871,7 @@ class String : public HeapObject {
   char* cstr_dup();
 
   static String* cast(Object* object) {
-     ASSERT(object->is_string());
+     ASSERT(is_string(object));
      return static_cast<String*>(object);
   }
 
@@ -1198,7 +1198,7 @@ class Instance : public HeapObject {
   }
 
   static Instance* cast(Object* value) {
-    ASSERT(value->is_instance() || value->is_task());
+    ASSERT(is_instance(value) || is_task(value));
     return static_cast<Instance*>(value);
   }
 
@@ -1235,7 +1235,7 @@ class FreeListRegion : public HeapObject {
   void roots_do(int instance_size, RootCallback* cb) {}
 
   static FreeListRegion* cast(Object* value) {
-    ASSERT(value->is_free_list_region());
+    ASSERT(is_free_list_region(value));
     return static_cast<FreeListRegion*>(value);
   }
 
@@ -1290,7 +1290,7 @@ class PromotedTrack : public HeapObject {
   void roots_do(int instance_size, RootCallback* cb) {}
 
   static PromotedTrack* cast(Object* value) {
-    ASSERT(value->is_promoted_track());
+    ASSERT(is_promoted_track(value));
     return static_cast<PromotedTrack*>(value);
   }
 
@@ -1340,7 +1340,7 @@ class Task : public Instance {
   inline void set_result(Object* value);
 
   static Task* cast(Object* value) {
-    ASSERT(value->is_task());
+    ASSERT(is_task(value));
     return static_cast<Task*>(value);
   }
 
@@ -1349,7 +1349,7 @@ class Task : public Instance {
   }
 
   bool has_stack() {
-    return at(STACK_INDEX)->is_stack();
+    return is_stack(at(STACK_INDEX));
   }
 
  private:
@@ -1362,45 +1362,53 @@ inline Task* Stack::task() {
   return Task::cast(_at(TASK_OFFSET));
 }
 
-inline bool Object::is_double() {
-  return is_heap_object() && HeapObject::cast(this)->class_tag() == DOUBLE_TAG;
+inline bool is_smi(Object* o) {
+  return (reinterpret_cast<uword>(o) & Object::SMI_TAG_MASK) == Object::SMI_TAG;
 }
 
-inline bool Object::is_task() {
-  return is_heap_object() && HeapObject::cast(this)->class_tag() == TASK_TAG;
+inline bool is_heap_object(Object* o) {
+  return (reinterpret_cast<uword>(o) & Object::NON_SMI_TAG_MASK) == Object::HEAP_TAG;
 }
 
-inline bool Object::is_instance() {
-  return is_heap_object() && HeapObject::cast(this)->class_tag() == INSTANCE_TAG;
+inline bool is_double(Object* o) {
+  return is_heap_object(o) && HeapObject::cast(o)->class_tag() == DOUBLE_TAG;
 }
 
-inline bool Object::is_array() {
-  return is_heap_object() && HeapObject::cast(this)->class_tag() == ARRAY_TAG;
+inline bool is_task(Object* o) {
+  return is_heap_object(o) && HeapObject::cast(o)->class_tag() == TASK_TAG;
 }
 
-inline bool Object::is_byte_array() {
-  return is_heap_object() && HeapObject::cast(this)->class_tag() == BYTE_ARRAY_TAG;
+inline bool is_instance(Object* o) {
+  return is_heap_object(o) && HeapObject::cast(o)->class_tag() == INSTANCE_TAG;
 }
 
-inline bool Object::is_stack() {
-  return is_heap_object() && HeapObject::cast(this)->class_tag() == STACK_TAG;
+inline bool is_array(Object* o) {
+  return is_heap_object(o) && HeapObject::cast(o)->class_tag() == ARRAY_TAG;
 }
 
-inline bool Object::is_string() {
-  return is_heap_object() && HeapObject::cast(this)->class_tag() == STRING_TAG;
+inline bool is_byte_array(Object* o) {
+  return is_heap_object(o) && HeapObject::cast(o)->class_tag() == BYTE_ARRAY_TAG;
 }
 
-inline bool Object::is_large_integer() {
-  return is_heap_object() && HeapObject::cast(this)->class_tag() == LARGE_INTEGER_TAG;
+inline bool is_stack(Object* o) {
+  return is_heap_object(o) && HeapObject::cast(o)->class_tag() == STACK_TAG;
 }
 
-inline bool Object::is_free_list_region() {
-  return is_heap_object() && (HeapObject::cast(this)->class_tag() == FREE_LIST_REGION_TAG ||
-                              HeapObject::cast(this)->class_tag() == SINGLE_FREE_WORD_TAG);
+inline bool is_string(Object* o) {
+  return is_heap_object(o) && HeapObject::cast(o)->class_tag() == STRING_TAG;
 }
 
-inline bool Object::is_promoted_track() {
-  return is_heap_object() && HeapObject::cast(this)->class_tag() == PROMOTED_TRACK_TAG;
+inline bool is_large_integer(Object* o) {
+  return is_heap_object(o) && HeapObject::cast(o)->class_tag() == LARGE_INTEGER_TAG;
+}
+
+inline bool is_free_list_region(Object* o) {
+  return is_heap_object(o) && (HeapObject::cast(o)->class_tag() == FREE_LIST_REGION_TAG ||
+                               HeapObject::cast(o)->class_tag() == SINGLE_FREE_WORD_TAG);
+}
+
+inline bool is_promoted_track(Object* o) {
+  return is_heap_object(o) && HeapObject::cast(o)->class_tag() == PROMOTED_TRACK_TAG;
 }
 
 inline HeapObject* Object::unmark() {

--- a/src/objects_runtime.cc
+++ b/src/objects_runtime.cc
@@ -22,7 +22,7 @@
 namespace toit {
 
 bool Object::mutable_byte_content(Process* process, uint8** content, int* length, Error** error) {
-  if (is_byte_array()) {
+  if (is_byte_array(this)) {
     auto byte_array = ByteArray::cast(this);
     // External byte arrays can have structs in them. This is captured in the external tag.
     // We only allow extracting the byte content from an external byte arrays iff it is tagged with RawByteType.
@@ -32,7 +32,7 @@ bool Object::mutable_byte_content(Process* process, uint8** content, int* length
     *content = bytes.address();
     return true;
   }
-  if (!is_instance()) return false;
+  if (!is_instance(this)) return false;
 
   auto program = process->program();
   auto instance = Instance::cast(this);
@@ -69,10 +69,10 @@ bool Object::mutable_byte_content(Process* process, uint8** content, int* length
     auto byte_array = instance->at(0);
     auto from = instance->at(1);
     auto to = instance->at(2);
-    if (!byte_array->is_heap_object()) return false;
+    if (!is_heap_object(byte_array)) return false;
     // TODO(florian): we could eventually accept larger integers here.
-    if (!from->is_smi()) return false;
-    if (!to->is_smi()) return false;
+    if (!is_smi(from)) return false;
+    if (!is_smi(to)) return false;
     int from_value = Smi::cast(from)->value();
     int to_value = Smi::cast(to)->value();
     bool inner_success = HeapObject::cast(byte_array)->mutable_byte_content(process, content, length, error);

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -626,7 +626,7 @@ namespace toit {
 
 #define __ARG__(N, name, type, test)    \
   Object* _raw_##name = __args[-(N)];   \
-  if (!_raw_##name->test()) WRONG_TYPE; \
+  if (!test(_raw_##name)) WRONG_TYPE; \
   type* name = type::cast(_raw_##name);
 
 #define _A_T_Array(N, name)         __ARG__(N, name, Array, is_array)
@@ -641,8 +641,8 @@ namespace toit {
 // Covers the range of int or Smi, whichever is smaller.
 #define _A_T_int(N, name)                               \
   Object* _raw_##name = __args[-(N)];                   \
-  if (!_raw_##name->is_smi()) {                         \
-    if (_raw_##name->is_large_integer()) OUT_OF_RANGE;  \
+  if (!is_smi(_raw_##name)) {                           \
+    if (is_large_integer(_raw_##name)) OUT_OF_RANGE;    \
     else WRONG_TYPE;                                    \
   }                                                     \
   word _word_##name = Smi::cast(_raw_##name)->value();  \
@@ -651,8 +651,8 @@ namespace toit {
 
 #define _A_T_uint8(N, name)                                           \
   Object* _raw_##name = __args[-(N)];                                 \
-  if (!_raw_##name->is_smi()) {                                       \
-    if (_raw_##name->is_large_integer()) OUT_OF_RANGE;                \
+  if (!is_smi(_raw_##name)) {                                         \
+    if (is_large_integer(_raw_##name)) OUT_OF_RANGE;                  \
     else WRONG_TYPE;                                                  \
   }                                                                   \
   word _value_##name = Smi::cast(_raw_##name)->value();               \
@@ -661,8 +661,8 @@ namespace toit {
 
 #define _A_T_int16(N, name)                                                  \
   Object* _raw_##name = __args[-(N)];                                        \
-  if (!_raw_##name->is_smi()) {                                              \
-    if (_raw_##name->is_large_integer()) OUT_OF_RANGE;                       \
+  if (!is_smi(_raw_##name)) {                                                \
+    if (is_large_integer(_raw_##name)) OUT_OF_RANGE;                         \
     else WRONG_TYPE;                                                         \
   }                                                                          \
   word _value_##name = Smi::cast(_raw_##name)->value();                      \
@@ -671,8 +671,8 @@ namespace toit {
 
 #define _A_T_uint16(N, name)                                          \
   Object* _raw_##name = __args[-(N)];                                 \
-  if (!_raw_##name->is_smi()) {                                       \
-    if (_raw_##name->is_large_integer()) OUT_OF_RANGE;                \
+  if (!is_smi(_raw_##name)) {                                         \
+    if (is_large_integer(_raw_##name)) OUT_OF_RANGE;                  \
     else WRONG_TYPE;                                                  \
   }                                                                   \
   word _value_##name = Smi::cast(_raw_##name)->value();               \
@@ -682,9 +682,9 @@ namespace toit {
 #define _A_T_int32(N, name)                                                  \
   Object* _raw_##name = __args[-(N)];                                        \
   int64 _value_##name;                                                       \
-  if (_raw_##name->is_smi()) {                                               \
+  if (is_smi(_raw_##name)) {                                                 \
     _value_##name = Smi::cast(_raw_##name)->value();                         \
-  } else if (_raw_##name->is_large_integer()) {                              \
+  } else if (is_large_integer(_raw_##name))   {                              \
     _value_##name = LargeInteger::cast(_raw_##name)->value();                \
   } else {                                                                   \
     WRONG_TYPE;                                                              \
@@ -695,9 +695,9 @@ namespace toit {
 #define _A_T_uint32(N, name)                                                 \
   Object* _raw_##name = __args[-(N)];                                        \
   int64 _value_##name;                                                       \
-  if (_raw_##name->is_smi()) {                                               \
+  if (is_smi(_raw_##name)) {                                                 \
     _value_##name = Smi::cast(_raw_##name)->value();                         \
-  } else if (_raw_##name->is_large_integer()) {                              \
+  } else if (is_large_integer(_raw_##name)) {                                \
     _value_##name = LargeInteger::cast(_raw_##name)->value();                \
   } else {                                                                   \
     WRONG_TYPE;                                                              \
@@ -709,9 +709,9 @@ namespace toit {
 #define _A_T_int64(N, name)                             \
   Object* _raw_##name = __args[-(N)];                   \
   int64 name;                                           \
-  if (_raw_##name->is_smi()) {                          \
+  if (is_smi(_raw_##name)) {                            \
     name = (int64) Smi::cast(_raw_##name)->value();     \
-  } else if (_raw_##name->is_large_integer()) {         \
+  } else if (is_large_integer(_raw_##name)) {           \
     name = LargeInteger::cast(_raw_##name)->value();    \
   } else {                                              \
     WRONG_TYPE;                                         \
@@ -719,24 +719,24 @@ namespace toit {
 
 #define _A_T_word(N, name)                \
   Object* _raw_##name = __args[-(N)];     \
-  if (!_raw_##name->is_smi()) WRONG_TYPE; \
+  if (!is_smi(_raw_##name)) WRONG_TYPE;   \
   word name = Smi::cast(_raw_##name)->value();
 
 #define _A_T_double(N, name)                 \
   Object* _raw_##name = __args[-(N)];        \
-  if (!_raw_##name->is_double()) WRONG_TYPE; \
+  if (!is_double(_raw_##name)) WRONG_TYPE;   \
   double name = Double::cast(_raw_##name)->value();
 
 #define _A_T_to_double(N, name)                                \
   Object* _raw_##name = __args[-(N)];                          \
   double name;                                                 \
-  if (_raw_##name->is_smi()) {                                 \
+  if (is_smi(_raw_##name)) {                                   \
     name = (double) Smi::cast(_raw_##name)->value();           \
   }                                                            \
-  else if (_raw_##name->is_large_integer()) {                  \
+  else if (is_large_integer(_raw_##name)) {                    \
     name = (double) LargeInteger::cast(_raw_##name)->value();  \
   }                                                            \
-  else if (_raw_##name->is_double()) {                         \
+  else if (is_double(_raw_##name)) {                           \
     name = Double::cast(_raw_##name)->value();                 \
   } else WRONG_TYPE;
 
@@ -770,7 +770,7 @@ namespace toit {
   uword name##_length = 0;                                              \
   const uint8* name = 0;                                                \
   uint8* _freed_##name = 0;                                             \
-  if (_raw_##name->is_string()) {                                       \
+  if (is_string(_raw_##name)) {                                         \
     /* Avoid copying */                                                 \
     auto str = String::cast(_raw_##name);                               \
     name = unsigned_cast(str->as_cstr());                               \

--- a/src/primitive_core.cc
+++ b/src/primitive_core.cc
@@ -102,7 +102,7 @@ PRIMITIVE(hatch_args) {
 
 PRIMITIVE(hatch) {
   ARGS(Object, entry, Object, arguments)
-  if (!entry->is_smi()) WRONG_TYPE;
+  if (!is_smi(entry)) WRONG_TYPE;
 
   int method_id = Smi::cast(entry)->value();
   ASSERT(method_id != -1);
@@ -159,7 +159,7 @@ PRIMITIVE(current_process_id) {
 
 PRIMITIVE(object_class_id) {
   ARGS(Object, arg);
-  return arg->is_smi()
+  return is_smi(arg)
      ? process->program()->smi_class_id()
      : HeapObject::cast(arg)->class_id();
 }
@@ -186,8 +186,8 @@ PRIMITIVE(min_special_compare_to) {
 
 #define SMI_COMPARE(op) { \
   ARGS(word, receiver, Object, arg); \
-  if (arg->is_smi()) return BOOL(receiver op Smi::cast(arg)->value()); \
-  if (!arg->is_large_integer()) WRONG_TYPE; \
+  if (is_smi(arg)) return BOOL(receiver op Smi::cast(arg)->value()); \
+  if (!is_large_integer(arg)) WRONG_TYPE; \
   return BOOL(((int64) receiver) op LargeInteger::cast(arg)->value()); \
 }
 
@@ -198,8 +198,8 @@ PRIMITIVE(min_special_compare_to) {
 
 #define LARGE_INTEGER_COMPARE(op) { \
   ARGS(LargeInteger, receiver, Object, arg); \
-  if (arg->is_smi()) return BOOL(receiver->value() op (int64) Smi::cast(arg)->value()); \
-  if (!arg->is_large_integer()) WRONG_TYPE; \
+  if (is_smi(arg)) return BOOL(receiver->value() op (int64) Smi::cast(arg)->value()); \
+  if (!is_large_integer(arg)) WRONG_TYPE; \
   return BOOL(receiver->value() op LargeInteger::cast(arg)->value()); \
 }
 
@@ -508,35 +508,35 @@ PRIMITIVE(args) {
 
 PRIMITIVE(smi_add) {
   ARGS(word, receiver, Object, arg);
-  if (arg->is_smi()) {
+  if (is_smi(arg)) {
     word other = Smi::cast(arg)->value();
     if ((receiver > 0) && (other > Smi::MAX_SMI_VALUE - receiver)) goto overflow;
     if ((receiver < 0) && (other < Smi::MIN_SMI_VALUE - receiver)) goto overflow;
     return Smi::from(receiver + other);
   }
-  if (!arg->is_large_integer()) WRONG_TYPE;
+  if (!is_large_integer(arg)) WRONG_TYPE;
   overflow:
-  int64 other = arg->is_smi() ? (int64) Smi::cast(arg)->value() : LargeInteger::cast(arg)->value();
+  int64 other = is_smi(arg) ? (int64) Smi::cast(arg)->value() : LargeInteger::cast(arg)->value();
   return Primitive::integer((int64) receiver + other, process);
 }
 
 PRIMITIVE(smi_subtract) {
   ARGS(word, receiver, Object, arg);
-  if (arg->is_smi()) {
+  if (is_smi(arg)) {
     word other = Smi::cast(arg)->value();
     if ((receiver < 0) && (other > Smi::MAX_SMI_VALUE + receiver)) goto overflow;
     if ((receiver > 0) && (other < Smi::MIN_SMI_VALUE + receiver)) goto overflow;
     return Smi::from(receiver - other);
   }
-  if (!arg->is_large_integer()) WRONG_TYPE;
+  if (!is_large_integer(arg)) WRONG_TYPE;
   overflow:
-  int64 other = arg->is_smi() ? (int64) Smi::cast(arg)->value() : LargeInteger::cast(arg)->value();
+  int64 other = is_smi(arg) ? (int64) Smi::cast(arg)->value() : LargeInteger::cast(arg)->value();
   return Primitive::integer((int64) receiver - other, process);
 }
 
 PRIMITIVE(smi_multiply) {
   ARGS(word, receiver, Object, arg);
-  if (arg->is_smi()) {
+  if (is_smi(arg)) {
     word other = Smi::cast(arg)->value();
     word result;
     if (__builtin_mul_overflow(receiver, other << 1, &result)) goto overflow;
@@ -544,34 +544,34 @@ PRIMITIVE(smi_multiply) {
     ASSERT(r == Smi::from(result >> 1));
     return r;
   }
-  if (!arg->is_large_integer()) WRONG_TYPE;
+  if (!is_large_integer(arg)) WRONG_TYPE;
   overflow:
-  int64 other = arg->is_smi() ? (int64) Smi::cast(arg)->value() : LargeInteger::cast(arg)->value();
+  int64 other = is_smi(arg) ? (int64) Smi::cast(arg)->value() : LargeInteger::cast(arg)->value();
   return Primitive::integer((int64) receiver * other, process);
 }
 
 PRIMITIVE(smi_divide) {
   ARGS(word, receiver, Object, arg);
-  if (arg->is_smi()) {
+  if (is_smi(arg)) {
     word other = Smi::cast(arg)->value();
     if (other == 0) return Primitive::mark_as_error(process->program()->division_by_zero());
     return Smi::from(receiver / other);
   }
-  if (!arg->is_large_integer()) WRONG_TYPE;
-  int64 other = arg->is_smi() ? (int64) Smi::cast(arg)->value() : LargeInteger::cast(arg)->value();
+  if (!is_large_integer(arg)) WRONG_TYPE;
+  int64 other = is_smi(arg) ? (int64) Smi::cast(arg)->value() : LargeInteger::cast(arg)->value();
   return Primitive::integer((int64) receiver / other, process);
 }
 
 PRIMITIVE(smi_mod) {
   ARGS(word, receiver, Object, arg);
   if (arg == 0) return Primitive::mark_as_error(process->program()->division_by_zero());
-  if (arg->is_smi()) {
+  if (is_smi(arg)) {
     word other = Smi::cast(arg)->value();
     if (other == 0) return Primitive::mark_as_error(process->program()->division_by_zero());
     return Smi::from(receiver % other);
   }
-  if (!arg->is_large_integer()) WRONG_TYPE;
-  int64 other = arg->is_smi() ? (int64) Smi::cast(arg)->value() : LargeInteger::cast(arg)->value();
+  if (!is_large_integer(arg)) WRONG_TYPE;
+  int64 other = is_smi(arg) ? (int64) Smi::cast(arg)->value() : LargeInteger::cast(arg)->value();
   return Primitive::integer((int64) receiver % other, process);
 }
 
@@ -636,8 +636,8 @@ PRIMITIVE(int64_to_string) {
 PRIMITIVE(large_integer_add) {
   ARGS(LargeInteger, receiver, Object, arg);
   int64 result = receiver->value();
-  if (arg->is_smi()) result += Smi::cast(arg)->value();
-  else if (arg->is_large_integer()) result += LargeInteger::cast(arg)->value();
+  if (is_smi(arg)) result += Smi::cast(arg)->value();
+  else if (is_large_integer(arg)) result += LargeInteger::cast(arg)->value();
   else WRONG_TYPE;
   return Primitive::integer(result, process);
 }
@@ -645,8 +645,8 @@ PRIMITIVE(large_integer_add) {
 PRIMITIVE(large_integer_subtract) {
   ARGS(LargeInteger, receiver, Object, arg);
   int64 result = receiver->value();
-  if (arg->is_smi()) result -= Smi::cast(arg)->value();
-  else if (arg->is_large_integer()) result -= LargeInteger::cast(arg)->value();
+  if (is_smi(arg)) result -= Smi::cast(arg)->value();
+  else if (is_large_integer(arg)) result -= LargeInteger::cast(arg)->value();
   else WRONG_TYPE;
   return Primitive::integer(result, process);
 }
@@ -654,8 +654,8 @@ PRIMITIVE(large_integer_subtract) {
 PRIMITIVE(large_integer_multiply) {
   ARGS(LargeInteger, receiver, Object, arg);
   int64 result = receiver->value();
-  if (arg->is_smi()) result *= Smi::cast(arg)->value();
-  else if (arg->is_large_integer()) result *= LargeInteger::cast(arg)->value();
+  if (is_smi(arg)) result *= Smi::cast(arg)->value();
+  else if (is_large_integer(arg)) result *= LargeInteger::cast(arg)->value();
   else WRONG_TYPE;
   return Primitive::integer(result, process);
 }
@@ -663,10 +663,10 @@ PRIMITIVE(large_integer_multiply) {
 PRIMITIVE(large_integer_divide) {
   ARGS(LargeInteger, receiver, Object, arg);
   int64 result = receiver->value();
-  if (arg->is_smi()) {
+  if (is_smi(arg)) {
     if (Smi::cast(arg)->value() == 0) return Primitive::mark_as_error(process->program()->division_by_zero());
     result /= Smi::cast(arg)->value();
-  } else if (arg->is_large_integer()) {
+  } else if (is_large_integer(arg)) {
     ASSERT(LargeInteger::cast(arg)->value() != 0LL);
     result /= LargeInteger::cast(arg)->value();
   } else WRONG_TYPE;
@@ -676,10 +676,10 @@ PRIMITIVE(large_integer_divide) {
 PRIMITIVE(large_integer_mod) {
   ARGS(LargeInteger, receiver, Object, arg);
   int64 result = receiver->value();
-  if (arg->is_smi()) {
+  if (is_smi(arg)) {
     if (Smi::cast(arg)->value() == 0) return Primitive::mark_as_error(process->program()->division_by_zero());
     result %= Smi::cast(arg)->value();
-  } else if (arg->is_large_integer()) {
+  } else if (is_large_integer(arg)) {
     ASSERT(LargeInteger::cast(arg)->value() != 0LL);
     result %= LargeInteger::cast(arg)->value();
   } else WRONG_TYPE;
@@ -699,9 +699,9 @@ PRIMITIVE(large_integer_not) {
 PRIMITIVE(large_integer_and) {
   ARGS(LargeInteger, receiver, Object, arg);
   int64 result = receiver->value();
-  if (arg->is_smi()) {
+  if (is_smi(arg)) {
     result &= Smi::cast(arg)->value();
-  } else if (arg->is_large_integer()) {
+  } else if (is_large_integer(arg)) {
     result &= LargeInteger::cast(arg)->value();
   } else WRONG_TYPE;
   return Primitive::integer(result, process);
@@ -710,9 +710,9 @@ PRIMITIVE(large_integer_and) {
 PRIMITIVE(large_integer_or) {
   ARGS(LargeInteger, receiver, Object, arg);
   int64 result = receiver->value();
-  if (arg->is_smi()) {
+  if (is_smi(arg)) {
     result |= Smi::cast(arg)->value();
-  } else if (arg->is_large_integer()) {
+  } else if (is_large_integer(arg)) {
     result |= LargeInteger::cast(arg)->value();
   } else WRONG_TYPE;
   return Primitive::integer(result, process);
@@ -721,9 +721,9 @@ PRIMITIVE(large_integer_or) {
 PRIMITIVE(large_integer_xor) {
   ARGS(LargeInteger, receiver, Object, arg);
   int64 result = receiver->value();
-  if (arg->is_smi()) {
+  if (is_smi(arg)) {
     result ^= Smi::cast(arg)->value();
-  } else if (arg->is_large_integer()) {
+  } else if (is_large_integer(arg)) {
     result ^= LargeInteger::cast(arg)->value();
   } else WRONG_TYPE;
   return Primitive::integer(result, process);
@@ -828,7 +828,7 @@ PRIMITIVE(float_parse) {
   if (isspace(*from_ptr)) OTHER_ERROR;
   bool needs_free = false;
   char* copied;
-  if (!_raw_input->is_string() || to != input.length()) {  // Strings are null-terminated.
+  if (!is_string(_raw_input) || to != input.length()) {  // Strings are null-terminated.
     // There is no way to tell strtod to stop early.
     // We have to copy the area we are interested in.
     copied = reinterpret_cast<char*>(malloc(to - from + 1));
@@ -982,11 +982,11 @@ PRIMITIVE(bytes_allocated_delta) {
 PRIMITIVE(process_stats) {
   ARGS(Object, list_object, int, group, int, id);
   Array* result = null;
-  if (list_object->is_instance()) {
+  if (is_instance(list_object)) {
     Instance* list = Instance::cast(list_object);
     if (list->class_id() == process->program()->list_class_id()) {
       Object* array_object;
-      if ((array_object = list->at(0))->is_array()) {
+      if (is_array(array_object = list->at(0))) {
         result = Array::cast(array_object);
       } else {
         OUT_OF_RANGE;  // List is so big it uses arraylets.
@@ -1137,7 +1137,7 @@ PRIMITIVE(size_of_json_number) {
 // comparing strings with byte arrays.
 PRIMITIVE(blob_equals) {
   ARGS(Object, receiver, Object, other)
-  if (receiver->is_string() && other->is_string()) {
+  if (is_string(receiver) && is_string(other)) {
     // We can make use of hash code here.
     return BOOL(String::cast(receiver)->equals(other));
   }
@@ -1223,17 +1223,17 @@ PRIMITIVE(object_equals) {
 PRIMITIVE(identical) {
   ARGS(Object, a, Object, b)
   if (a == b) return BOOL(true);
-  if (a->is_double() && b->is_double()) {
+  if (is_double(a) && is_double(b)) {
     auto double_a = Double::cast(a);
     auto double_b = Double::cast(b);
     return BOOL(double_a->bits() == double_b->bits());
   }
-  if (a->is_large_integer() && b->is_large_integer()) {
+  if (is_large_integer(a) && is_large_integer(b)) {
     auto large_a = LargeInteger::cast(a);
     auto large_b = LargeInteger::cast(b);
     return BOOL(large_a->value() == large_b->value());
   }
-  if (a->is_string() && b->is_string()) {
+  if (is_string(a) && is_string(b)) {
     return BOOL(String::cast(a)->compare(String::cast(b)) == 0);
   }
   return BOOL(false);
@@ -1299,8 +1299,8 @@ PRIMITIVE(float_to_string) {
     format = "%.*lg";
   } else {
     format = "%.*lf";
-    if (precision->is_large_integer()) OUT_OF_BOUNDS;
-    if (!precision->is_smi()) WRONG_TYPE;
+    if (is_large_integer(precision)) OUT_OF_BOUNDS;
+    if (!is_smi(precision)) WRONG_TYPE;
     prec = Smi::cast(precision)->value();
     if (prec < 0 || prec > 64) OUT_OF_BOUNDS;
   }
@@ -1340,8 +1340,8 @@ PRIMITIVE(float_is_finite) {
 
 PRIMITIVE(number_to_integer) {
   ARGS(Object, receiver);
-  if (receiver->is_smi() || receiver->is_large_integer()) return receiver;
-  if (receiver->is_double()) {
+  if (is_smi(receiver) || is_large_integer(receiver)) return receiver;
+  if (is_double(receiver)) {
     double value = Double::cast(receiver)->value();
     if (isnan(value)) INVALID_ARGUMENT;
     if (value < (double) INT64_MIN || value > (double) INT64_MAX) OUT_OF_RANGE;
@@ -1358,8 +1358,8 @@ PRIMITIVE(float_sqrt) {
 static bool is_validated_string(Program* program, Object* object) {
   // The only objects that are known to have valid UTF-8 sequences are
   // strings and string-slices.
-  if (object->is_string()) return true;
-  if (!object->is_heap_object()) return false;
+  if (is_string(object)) return true;
+  if (!is_heap_object(object)) return false;
   auto heap_object = HeapObject::cast(object);
   return heap_object->class_id() == program->string_slice_class_id();
 }
@@ -1554,11 +1554,11 @@ PRIMITIVE(array_new) {
 
 PRIMITIVE(list_add) {
   ARGS(Object, receiver, Object, value);
-  if (receiver->is_instance()) {
+  if (is_instance(receiver)) {
     Instance* list = Instance::cast(receiver);
     if (list->class_id() == process->program()->list_class_id()) {
       Object* array_object;
-      if ((array_object = list->at(0))->is_array()) {
+      if (is_array(array_object = list->at(0))) {
         // Small array backing case.
         Array* array = Array::cast(array_object);
         word size = Smi::cast(list->at(1))->value();
@@ -1570,7 +1570,7 @@ PRIMITIVE(list_add) {
       } else {
         // Large array backing case.
         Object* size_object = list->at(1);
-        if (size_object->is_smi()) {
+        if (is_smi(size_object)) {
           word size = Smi::cast(size_object)->value();
           if (Smi::is_valid(size + 1)) {
             if (Interpreter::fast_at(process, array_object, size_object, true, &value)) {
@@ -1674,7 +1674,7 @@ PRIMITIVE(byte_array_replace) {
 
 PRIMITIVE(smi_unary_minus) {
   ARGS(Object, receiver);
-  if (!receiver->is_smi()) WRONG_TYPE;
+  if (!is_smi(receiver)) WRONG_TYPE;
   // We can't assume that `-x` is still a smi, as -MIN_SMI_VALUE > MAX_SMI_VALUE.
   // However, it must fit a `word` as smis are smaller than words.
   word value = Smi::cast(receiver)->value();
@@ -1688,22 +1688,22 @@ PRIMITIVE(smi_not) {
 
 PRIMITIVE(smi_and) {
   ARGS(word, receiver, Object, arg);
-  if (arg->is_smi()) return Smi::from(receiver & Smi::cast(arg)->value());
-  if (!arg->is_large_integer()) WRONG_TYPE;
+  if (is_smi(arg)) return Smi::from(receiver & Smi::cast(arg)->value());
+  if (!is_large_integer(arg)) WRONG_TYPE;
   return Primitive::integer(((int64) receiver) & LargeInteger::cast(arg)->value() , process);
 }
 
 PRIMITIVE(smi_or) {
   ARGS(word, receiver, Object, arg);
-  if (arg->is_smi()) return Smi::from(receiver | Smi::cast(arg)->value());
-  if (!arg->is_large_integer()) WRONG_TYPE;
+  if (is_smi(arg)) return Smi::from(receiver | Smi::cast(arg)->value());
+  if (!is_large_integer(arg)) WRONG_TYPE;
   return Primitive::integer(((int64) receiver) | LargeInteger::cast(arg)->value() , process);
 }
 
 PRIMITIVE(smi_xor) {
   ARGS(word, receiver, Object, arg);
-  if (arg->is_smi()) return Smi::from(receiver ^ Smi::cast(arg)->value());
-  if (!arg->is_large_integer()) WRONG_TYPE;
+  if (is_smi(arg)) return Smi::from(receiver ^ Smi::cast(arg)->value());
+  if (!is_large_integer(arg)) WRONG_TYPE;
   return Primitive::integer(((int64) receiver) ^ LargeInteger::cast(arg)->value() , process);
 }
 
@@ -1716,7 +1716,7 @@ PRIMITIVE(smi_shift_right) {
 
 PRIMITIVE(smi_unsigned_shift_right) {
   ARGS(Object, receiver, int64, bits_to_shift);
-  if (!receiver->is_smi()) WRONG_TYPE;
+  if (!is_smi(receiver)) WRONG_TYPE;
   if (bits_to_shift < 0) NEGATIVE_ARGUMENT;
   if (bits_to_shift >= 64) return Smi::zero();
   uint64 value = static_cast<uint64>(Smi::cast(receiver)->value());
@@ -1726,7 +1726,7 @@ PRIMITIVE(smi_unsigned_shift_right) {
 
 PRIMITIVE(smi_shift_left) {
   ARGS(Object, receiver, int64, number_of_bits);
-  if (!receiver->is_smi()) WRONG_TYPE;
+  if (!is_smi(receiver)) WRONG_TYPE;
   if (number_of_bits < 0) NEGATIVE_ARGUMENT;
   if (number_of_bits >= 64) return Smi::zero();
   int64 value = Smi::cast(receiver)->value();
@@ -2001,7 +2001,7 @@ PRIMITIVE(rebuild_hash_index) {
   ARGS(Object, o, Object, n);
   // Sometimes the array is too big, and is a large array.  In this case, use
   // the Toit implementation.
-  if (!o->is_array() || !n->is_array()) OUT_OF_RANGE;
+  if (!is_array(o) || !is_array(n)) OUT_OF_RANGE;
   Array* old_array = Array::cast(o);
   Array* new_array = Array::cast(n);
   word index_mask = new_array->length() - 1;
@@ -2009,9 +2009,9 @@ PRIMITIVE(rebuild_hash_index) {
   for (word i = 0; i < length; i++) {
     Object* o = old_array->at(i);
     word hash_and_position;
-    if (o->is_smi()) {
+    if (is_smi(o)) {
       hash_and_position = Smi::cast(o)->value();
-    } else if (o->is_large_integer()) {
+    } else if (is_large_integer(o)) {
       hash_and_position = LargeInteger::cast(o)->value();
     } else {
       INVALID_ARGUMENT;
@@ -2288,7 +2288,7 @@ PRIMITIVE(get_env) {
 PRIMITIVE(literal_index) {
   ARGS(Object, o);
   auto null_object = process->program()->null_object();
-  if (!o->is_heap_object()) return null_object;
+  if (!is_heap_object(o)) return null_object;
   auto& literals = process->program()->literals;
   for (int i = 0; i < literals.length(); i++) {
     if (literals.at(i) == o) return Smi::from(i);

--- a/src/primitive_debug.cc
+++ b/src/primitive_debug.cc
@@ -50,14 +50,14 @@ PRIMITIVE(object_histogram) {
     if (object == capture.result) return;  // Don't count the resulting byte array.
     int class_index = Smi::cast(object->class_id())->value();
     int size = object->size(capture.program);
-    if (object->is_byte_array() && ByteArray::cast(object)->has_external_address()) {
+    if (is_byte_array(object) && ByteArray::cast(object)->has_external_address()) {
       ByteArray* byte_array = ByteArray::cast(object);
       word tag = byte_array->external_tag();
       if (tag == RawByteTag) {
         ByteArray::Bytes bytes(byte_array);
         size += bytes.length();
       }
-    } else if (object->is_string() && !String::cast(object)->content_on_heap()) {
+    } else if (is_string(object) && !String::cast(object)->content_on_heap()) {
       size += String::cast(object)->length() + 1;
     }
     capture.data[class_index * UINT32_PER_ENTRY + 0] += 1;

--- a/src/primitive_font.cc
+++ b/src/primitive_font.cc
@@ -491,7 +491,7 @@ PRIMITIVE(get_nonbuiltin) {
     Object* block_array = arrays->at(index);
     const uint8* bytes;
     int length;
-    if (!block_array->is_heap_object()) WRONG_TYPE;
+    if (!is_heap_object(block_array)) WRONG_TYPE;
     if (!block_array->byte_content(process->program(), &bytes, &length, STRINGS_OR_BYTE_ARRAYS)) WRONG_TYPE;
     // TODO: We should perhaps avoid redoing this verification if the data is
     // in flash and we already did it once.

--- a/src/program.h
+++ b/src/program.h
@@ -276,9 +276,9 @@ class Program : public FlashAllocation {
   //   not its bytecodes.
   inline Object* frame_marker() const {
     uword bytecodes_address = reinterpret_cast<uword>(bytecodes.data());
-    ASSERT(reinterpret_cast<Object*>(bytecodes_address)->is_smi());
+    ASSERT(is_smi(reinterpret_cast<Object*>(bytecodes_address)));
     auto result = reinterpret_cast<Object*>(bytecodes_address + Object::HEAP_TAG);
-    ASSERT(result->is_heap_object());
+    ASSERT(is_heap_object(result));
     return result;
   }
 

--- a/src/program_heap.cc
+++ b/src/program_heap.cc
@@ -266,7 +266,7 @@ HeapObject* ProgramHeap::Iterator::current() {
 void ProgramHeap::Iterator::advance() {
   ensure_started();
 
-  ASSERT(HeapObject::cast(_current)->header()->is_smi());  // Header is not a forwarding pointer.
+  ASSERT(is_smi(HeapObject::cast(_current)->header()));  // Header is not a forwarding pointer.
   _current = Utils::address_at(_current, HeapObject::cast(_current)->size(_program));
   if (_current >= _block->top() && _block != _list.last()) {
     _block = *++_iterator;

--- a/src/resources/pipe.cc
+++ b/src/resources/pipe.cc
@@ -291,9 +291,9 @@ class Freer {
 // o can be an IntResource, a Smi or null (which returns -1).
 // -2 is returned otherwise.
 static int get_fd(Object* obj) {
-  if (obj->is_smi()) {
+  if (is_smi(obj)) {
     return Smi::cast(obj)->value();
-  } else if (obj->is_byte_array()) {
+  } else if (is_byte_array(obj)) {
     ByteArray* ba = ByteArray::cast(obj);
     if (!ba->has_external_address()) return -2;
     if (ba->external_tag() != IntResource::tag) return -2;
@@ -352,7 +352,7 @@ PRIMITIVE(fork) {
   char** argv = reinterpret_cast<char**>(allocation.calloc(args->length() + 1, sizeof(char*)));
   if (argv == null) ALLOCATION_FAILED;
   for (word i = 0; i < args->length(); i++) {
-    if (!args->at(i)->is_string()) {
+    if (!is_string(args->at(i))) {
       WRONG_TYPE;
     }
     argv[i] = String::cast(args->at(i))->as_cstr();

--- a/src/resources/rmt_esp32.cc
+++ b/src/resources/rmt_esp32.cc
@@ -269,7 +269,7 @@ PRIMITIVE(transmit) {
   // As such, we need an external address.
   const uint8* address = items_bytes.address();
   Object* keep_alive = _raw_items_bytes;
-  if (_raw_items_bytes->is_byte_array() && ByteArray::cast(_raw_items_bytes)->has_external_address()) {
+  if (is_byte_array(_raw_items_bytes) && ByteArray::cast(_raw_items_bytes)->has_external_address()) {
     // Nothing to do. We already have an external address.
   } else {
     // Create an external byte array with the same size.

--- a/src/resources/tcp_esp32.cc
+++ b/src/resources/tcp_esp32.cc
@@ -619,7 +619,7 @@ PRIMITIVE(set_option) {
         break;
 
       case TCP_WINDOW_SIZE:
-        if (!capture.raw->is_smi()) return process->program()->wrong_object_type();
+        if (!is_smi(capture.raw)) return process->program()->wrong_object_type();
 
       default:
         return process->program()->unimplemented();

--- a/src/resources/tls.cc
+++ b/src/resources/tls.cc
@@ -307,7 +307,7 @@ PRIMITIVE(set_outgoing) {
   Object* null_object = process->program()->null_object();
   if (outgoing == null_object) {
     if (fullness != 0) INVALID_ARGUMENT;
-  } else if (outgoing->is_byte_array()) {
+  } else if (is_byte_array(outgoing)) {
     ByteArray::Bytes data_bytes(ByteArray::cast(outgoing));
     if (fullness < 0 || fullness >= data_bytes.length()) INVALID_ARGUMENT;
   } else {
@@ -497,7 +497,7 @@ PRIMITIVE(add_certificate) {
 
 static int toit_tls_send(void* ctx, const unsigned char* buf, size_t len) {
   auto socket = unvoid_cast<MbedTLSSocket*>(ctx);
-  if (!socket->outgoing_packet()->is_byte_array()) {
+  if (!is_byte_array(socket->outgoing_packet())) {
     return MBEDTLS_ERR_SSL_WANT_WRITE;
   }
   ByteArray::Bytes bytes(static_cast<ByteArray*>(socket->outgoing_packet()));

--- a/src/resources/udp_bsd.cc
+++ b/src/resources/udp_bsd.cc
@@ -180,7 +180,7 @@ PRIMITIVE(receive) {
 
   // TODO: Support IPv6.
   ByteArray* address = null;
-  if (output->is_array()) {
+  if (is_array(output)) {
     Error* error = null;
     address = process->allocate_byte_array(4, &error);
     if (address == null) return error;
@@ -212,7 +212,7 @@ PRIMITIVE(receive) {
   ASSERT(read == available);
   memcpy(ByteArray::Bytes(array).address(), buffer, read);
 
-  if (output->is_array()) {
+  if (is_array(output)) {
     Array* out = Array::cast(output);
     ASSERT(out->length() == 3);
     out->at_put(0, array);

--- a/src/resources/udp_esp32.cc
+++ b/src/resources/udp_esp32.cc
@@ -277,7 +277,7 @@ PRIMITIVE(receive)  {
     if (packet == null) return Smi::from(-1);
 
     ByteArray* address = null;
-    if (capture.output->is_array()) {
+    if (is_array(capture.output)) {
       // TODO: Support IPv6.
       Error* error = null;
       address = capture.process->allocate_byte_array(4, &error);
@@ -291,7 +291,7 @@ PRIMITIVE(receive)  {
 
     memcpy(ByteArray::Bytes(array).address(), p->payload, p->len);
 
-    if (capture.output->is_array()) {
+    if (is_array(capture.output)) {
       Array* out = Array::cast(capture.output);
       ASSERT(out->length() == 3);
       out->at_put(0, array);
@@ -346,7 +346,7 @@ PRIMITIVE(send) {
     p->payload = const_cast<uint8_t*>(content);
 
     err_t err;
-    if (capture.address->is_byte_array()) {
+    if (is_byte_array(capture.address)) {
       err = udp_sendto(capture.socket->upcb(), p, &capture.addr, capture.port);
     } else {
       err = udp_send(capture.socket->upcb(), p);

--- a/src/resources/udp_linux.cc
+++ b/src/resources/udp_linux.cc
@@ -167,7 +167,7 @@ PRIMITIVE(receive)  {
 
   // TODO: Support IPv6.
   ByteArray* address = null;
-  if (output->is_array()) {
+  if (is_array(output)) {
     Error* error = null;
     address = process->allocate_byte_array(4, &error);
     if (address == null) return error;
@@ -197,7 +197,7 @@ PRIMITIVE(receive)  {
   // Please note that the array might change length so no ByteArray::Bytes variables can pass this point.
   array->resize_external(process, read);
 
-  if (output->is_array()) {
+  if (is_array(output)) {
     Array* out = Array::cast(output);
     ASSERT(out->length() == 3);
     out->at_put(0, array);

--- a/src/resources/x509.cc
+++ b/src/resources/x509.cc
@@ -92,11 +92,11 @@ PRIMITIVE(parse) {
 
   const uint8_t* data = null;
   size_t length = 0;
-  if (input->is_byte_array()) {
+  if (is_byte_array(input)) {
     ByteArray::Bytes bytes(ByteArray::cast(input));
     data = bytes.address();
     length = bytes.length();
-  } else if (input->is_string()) {
+  } else if (is_string(input)) {
     // For PEM format, give a null terminated byte array (and the size of the
     // full array), otherwise parsing will fail.
     String* str = String::cast(input);

--- a/src/snapshot.cc
+++ b/src/snapshot.cc
@@ -1150,8 +1150,8 @@ void BaseSnapshotWriter::write_reference(int index) {
 }
 
 void BaseSnapshotWriter::write_object(Object* object) {
-  if (object->is_smi()) write_integer(Smi::cast(object)->value());
-  else if (object->is_large_integer()) write_integer(LargeInteger::cast(object)->value());
+  if (is_smi(object)) write_integer(Smi::cast(object)->value());
+  else if (is_large_integer(object)) write_integer(LargeInteger::cast(object)->value());
   else write_heap_object(HeapObject::cast(object));
 }
 
@@ -1213,7 +1213,7 @@ void BaseSnapshotWriter::write_heap_object(HeapObject* object) {
                       length);
   write_byte(tag);
   _allocator.allocate_object(tag, length);
-  ASSERT(object->header()->is_smi());
+  ASSERT(is_smi(object->header()));
   write_object(object->header());
   switch (object->class_tag()) {
     case TypeTag::ARRAY_TAG:
@@ -1276,7 +1276,7 @@ class RelocationBits : public PointerCallback {
  public:
   void object_address(Object** p) {
     // Only make heap objects relocatable.
-    if ((*p)->is_heap_object()) set_bit_for(reinterpret_cast<word*>(p));
+    if (is_heap_object(*p)) set_bit_for(reinterpret_cast<word*>(p));
   }
 
   void c_address(void** p, bool is_sentinel) {

--- a/src/third_party/dartino/object_memory.cc
+++ b/src/third_party/dartino/object_memory.cc
@@ -164,7 +164,7 @@ class InSpaceVisitor : public RootCallback {
   void do_roots(Object** p, int length) {
     for (int i = 0; i < length; i++) {
       Object* object = p[i];
-      if (object->is_smi()) continue;
+      if (is_smi(object)) continue;
       if (space->includes(reinterpret_cast<uword>(object))) {
         in_space = true;
         break;

--- a/src/third_party/dartino/two_space_heap.h
+++ b/src/third_party/dartino/two_space_heap.h
@@ -144,7 +144,7 @@ class ScavengeVisitor : public RootCallback {
   virtual void do_root(Object** p) { do_roots(p, 1); }
 
   inline bool in_from_space(Object* object) {
-    if (object->is_smi()) return false;
+    if (is_smi(object)) return false;
     return reinterpret_cast<uword>(object) - from_start_ < from_size_;
   }
 

--- a/src/visitor.cc
+++ b/src/visitor.cc
@@ -21,7 +21,7 @@
 namespace toit {
 
 void Visitor::accept(Object* object) {
-  if (object->is_smi()) {
+  if (is_smi(object)) {
     visit_smi(Smi::cast(object));
     return;
   }


### PR DESCRIPTION
The type tests must not be instance methods, as the compiler is allowed
to assume that instance calls were never done on null-pointers.

If we have a Smi object of value 0, then `o->is_X` lets the compiler
assume that `o` is not equal to `null` (or 0). If we then want to use
`o` as a 0-smi (for example by doing a value check:
`if (Smi::cast(o)->value() == 0)` then the compiler optimizes the check
away as it "knows" that `o` can't be null.