### PR TITLE
Use dkhostmaster.dk instead of oracle.com for TLS test

### DIFF
--- a/tests/tls_test_slow.toit
+++ b/tests/tls_test_slow.toit
@@ -44,7 +44,7 @@ run_tests:
     "ebay.de",
     //"$(dns_lookup "amazon.com")/amazon.com",  // Connect to the IP address at the TCP level, but
 
-    "github.com",
+    "dkhostmaster.dk",
 
     "sha256.badssl.com",
     //"sha384.badssl.com",

--- a/tests/tls_test_slow.toit
+++ b/tests/tls_test_slow.toit
@@ -44,7 +44,7 @@ run_tests:
     "ebay.de",
     //"$(dns_lookup "amazon.com")/amazon.com",  // Connect to the IP address at the TCP level, but
 
-    "oracle.com",
+    "github.com",
 
     "sha256.badssl.com",
     //"sha384.badssl.com",


### PR DESCRIPTION
For make glorious stability of test!