### PR TITLE
Improve stacktrace.toit.

### DIFF
--- a/tools/package.lock
+++ b/tools/package.lock
@@ -8,5 +8,5 @@ packages:
     hash: 175bcdfd59b2597c0825ef8765a20498a7e6a2db
   pkg-host:
     url: github.com/toitlang/pkg-host
-    version: 1.4.1
-    hash: 444a69af53c5c2010074bceaef1afef615f14047
+    version: 1.5.0
+    hash: be4560e469b98d8f52b16a34a3ffaa7e84c3a82c

--- a/tools/package.yaml
+++ b/tools/package.yaml
@@ -4,4 +4,4 @@ dependencies:
     version: ^1.0.0
   host:
     url: github.com/toitlang/pkg-host
-    version: ^1.4.1
+    version: ^1.5.0


### PR DESCRIPTION
This tool (for native stacktraces) now uses host.arguments
to parse command line args.

Also improves it so it can use any elf-compatible objdump if
the Xtensa objdump is not installed.  Demangling may or may
not work in this case.

Faster for the the non-disassembly case where there is no
need to parse millions of lines of disassembly.

By using the new version of pkg-host we detect if objdump
exits with an error without producing meaningful output.