### PR TITLE
Add warning when instance variable resembles constant.

### DIFF
--- a/lib/tls/socket.toit
+++ b/lib/tls/socket.toit
@@ -13,7 +13,7 @@ import .certificate
 TLS Socket implementation that can upgrade a TCP socket to a secure TLS socket.
 */
 class Socket implements tcp.Socket:
-  TLS_HEADER_SIZE_ ::= 29
+  static TLS_HEADER_SIZE_ ::= 29
 
   socket_/tcp.Socket
   session_/Session

--- a/tests/negative/constant_name_test.toit
+++ b/tests/negative/constant_name_test.toit
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+CONST ::= 499
+A_B ::= 43
+
+class A:
+  CONST ::= 499
+  _ ::= 42
+  A_B ::= 43
+  __ ::= 42
+
+  NON_CONST := 1
+  NON_CONST2 := ?
+
+  constructor:
+    NON_CONST2 = 2
+
+main:
+  a := A

--- a/tests/negative/gold/constant_name_test.gold
+++ b/tests/negative/gold/constant_name_test.gold
@@ -1,0 +1,10 @@
+tests/negative/constant_name_test.toit:10:3: error: Can't use '_' as name for a field
+  _ ::= 42
+  ^
+tests/negative/constant_name_test.toit:9:3: warning: Final field with constant-like name: 'CONST'. Missing 'static'?
+  CONST ::= 499
+  ^~~~~
+tests/negative/constant_name_test.toit:11:3: warning: Final field with constant-like name: 'A_B'. Missing 'static'?
+  A_B ::= 43
+  ^~~
+Compilation failed.

--- a/tools/mirror.toit
+++ b/tools/mirror.toit
@@ -401,10 +401,10 @@ class HeapPage extends Mirror:
   //   W 7 - LwIP
   //   H 8 - Malloc heap overhead
 
-  GRANULARITY_ ::= 8
-  HEADER_ ::= 8
-  PAGE_HEADER_ ::= 24
-  PAGE_ ::= 4096
+  static GRANULARITY_ ::= 8
+  static HEADER_ ::= 8
+  static PAGE_HEADER_ ::= 24
+  static PAGE_ ::= 4096
 
   constructor json program [on_error]:
     address = json[1]
@@ -522,8 +522,8 @@ class ColorBlockOutputter_ extends UnicodeBlockOutputter_:
   foreground := -1
 
   // Escape sequences for 256 color terminals.
-  BG ::= "\u001b[48;5;"
-  FG ::= "\u001b[38;5;"
+  static BG ::= "\u001b[48;5;"
+  static FG ::= "\u001b[38;5;"
 
   // See 256-color scheme at http://www.lihaoyi.com/post/BuildyourownCommandLinewithANSIescapecodes.html#256-colors
   colors ::= {


### PR DESCRIPTION
Warn the user when it's likely they forgot a `static`.