### PR TITLE
Change ARRAY_CANNOT_CHANGE_SIZE to COLLECTION_CANNOT...

### DIFF
--- a/lib/core/collections.toit
+++ b/lib/core/collections.toit
@@ -862,7 +862,7 @@ abstract class Array_ extends List:
 
   /** See $super. */
   resize new_size:
-    throw "ARRAY_CANNOT_CHANGE_SIZE"
+    throw "COLLECTION_CANNOT_CHANGE_SIZE"
 
   /** See $super. */
   operator + collection -> Array_:

--- a/tests/rpc_test.toit
+++ b/tests/rpc_test.toit
@@ -301,7 +301,7 @@ test_map myself/int -> none:
   // Can't add to the map after going through RPC.  We could fix this in the
   // map class, but it's harder to fix the same issue for growable lists that
   // turn into ungrowable arrays after RPC.
-  expect.expect_throw "ARRAY_CANNOT_CHANGE_SIZE": roundtripped["kat"] = "cat"
+  expect.expect_throw "COLLECTION_CANNOT_CHANGE_SIZE": roundtripped["kat"] = "cat"
 
   // Empty map in list in list.
   l := [[{:}]]


### PR DESCRIPTION
We also throw this exception when someone attempts to
change the size of a map that has been through RPC, so
it makes sense for the exception to be more generic.