### PR TITLE
Make fail-case of external tests more robust.

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -204,10 +204,9 @@ function(add_repo_tests REPO)
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
       CONFIGURATIONS external
     )
-  endforeach()
-
-  foreach(test ${FAILING_TESTS})
-    set_tests_properties(${test} PROPERTIES WILL_FAIL TRUE)
+    if("${FILE}" IN_LIST FAILING_TESTS)
+      set_tests_properties(${FILE} PROPERTIES WILL_FAIL TRUE)
+    endif()
   endforeach()
 endfunction()
 


### PR DESCRIPTION
CMake would complain if it can't find the test we try to mark as
failing. With the new setup it only looks if it a new test is in the
failing-test list.