### PR TITLE
Fixes bad resolution of index-calls with parameters

### DIFF
--- a/src/compiler/resolver_method.cc
+++ b/src/compiler/resolver_method.cc
@@ -2717,16 +2717,16 @@ void MethodResolver::_visit_potential_call_dot(ast::Dot* ast_dot,
   }
 }
 
-void MethodResolver::_visit_potential_call_index(ast::Index* ast_index,
+void MethodResolver::_visit_potential_call_index(ast::Node* ast_target,
                                                  CallBuilder& call_builder) {
-  auto receiver = resolve_expression(ast_index->receiver(),
+  auto receiver = resolve_expression(ast_target,
                                      "Can't use the index operator on a block");
   push(call_builder.call_instance(_new ir::Dot(receiver, Symbols::index)));
 }
 
-void MethodResolver::_visit_potential_call_index_slice(ast::IndexSlice* ast_index_slice,
+void MethodResolver::_visit_potential_call_index_slice(ast::Node* ast_target,
                                                        CallBuilder& call_builder) {
-  auto receiver = resolve_expression(ast_index_slice->receiver(),
+  auto receiver = resolve_expression(ast_target,
                                      "Can't use the slice operator on a block");
   push(call_builder.call_instance(_new ir::Dot(receiver, Symbols::index_slice)));
 }
@@ -2851,9 +2851,10 @@ void MethodResolver::_visit_potential_call_super(ast::Node* ast_target,
   }
 }
 
-void MethodResolver::_visit_potential_call(ast::Node* ast_target,
+void MethodResolver::_visit_potential_call(ast::Expression* potential_call,
+                                           ast::Node* ast_target,
                                            List<ast::Expression*> ast_arguments) {
-  auto range = ast_target->range();
+  auto range = potential_call->range();
 
   bool is_constructor_super_call = false;
 
@@ -2968,31 +2969,39 @@ void MethodResolver::_visit_potential_call(ast::Node* ast_target,
     }
   }
 
-  if ((ast_target->is_Identifier() && !is_literal_super(ast_target)) ||
-      _scope->is_prefixed_identifier(ast_target) ||
-      _scope->is_static_identifier(ast_target)) {
-    _visit_potential_call_identifier(ast_target,
-                                     call_builder,
-                                     named_lsp_selection,
-                                     target_name_node,
-                                     target_name);
-  } else if (ast_target->is_Dot() && !is_constructor_super_call) {
-    _visit_potential_call_dot(ast_target->as_Dot(),
-                              call_builder,
-                              named_lsp_selection);
-  } else if (ast_target->is_Index()) {
-    _visit_potential_call_index(ast_target->as_Index(), call_builder);
-  } else if (ast_target->is_IndexSlice()) {
-    _visit_potential_call_index_slice(ast_target->as_IndexSlice(), call_builder);
-  } else if (is_literal_super(ast_target) ||
-             (ast_target->is_Dot() && is_constructor_super_call)) {
-    _visit_potential_call_super(ast_target, call_builder, is_constructor_super_call);
+  if (potential_call->is_Index()) {
+    // The target is the receiver, and the arguments are the parameters that were
+    // inside the brackets.
+    _visit_potential_call_index(ast_target, call_builder);
+  } else if (potential_call->is_IndexSlice()) {
+    // The target is the receiver, and the arguments are the parameters that were
+    // inside the brackets.
+    _visit_potential_call_index_slice(ast_target, call_builder);
   } else {
-    report_error(ast_target, "Can't call result of evaluating expression");
-    ListBuilder<ir::Expression*> all_ir_nodes;
-    all_ir_nodes.add(resolve_error(ast_target));
-    all_ir_nodes.add(call_builder.arguments());
-    push(_new ir::Error(ast_target->range(), all_ir_nodes.build()));
+    ASSERT(potential_call->is_Call() || potential_call->is_Dot() || potential_call->is_Identifier());
+
+    if ((ast_target->is_Identifier() && !is_literal_super(ast_target)) ||
+        _scope->is_prefixed_identifier(ast_target) ||
+        _scope->is_static_identifier(ast_target)) {
+      _visit_potential_call_identifier(ast_target,
+                                      call_builder,
+                                      named_lsp_selection,
+                                      target_name_node,
+                                      target_name);
+    } else if (ast_target->is_Dot() && !is_constructor_super_call) {
+      _visit_potential_call_dot(ast_target->as_Dot(),
+                                call_builder,
+                                named_lsp_selection);
+    } else if (is_literal_super(ast_target) ||
+              (ast_target->is_Dot() && is_constructor_super_call)) {
+      _visit_potential_call_super(ast_target, call_builder, is_constructor_super_call);
+    } else {
+      report_error(ast_target, "Can't call result of evaluating expression");
+      ListBuilder<ir::Expression*> all_ir_nodes;
+      all_ir_nodes.add(resolve_error(ast_target));
+      all_ir_nodes.add(call_builder.arguments());
+      push(_new ir::Error(ast_target->range(), all_ir_nodes.build()));
+    }
   }
 }
 
@@ -3004,16 +3013,16 @@ void MethodResolver::visit_Call(ast::Call* node) {
   if (node->is_call_primitive()) {
     visit_call_primitive(node);
   } else {
-    _visit_potential_call(node->target(), node->arguments());
+    _visit_potential_call(node, node->target(), node->arguments());
   }
 }
 
 void MethodResolver::visit_Dot(ast::Dot* node) {
-  _visit_potential_call(node);
+  _visit_potential_call(node, node);
 }
 
 void MethodResolver::visit_Index(ast::Index* node) {
-  _visit_potential_call(node, node->arguments());
+  _visit_potential_call(node, node->receiver(), node->arguments());
 }
 
 void MethodResolver::visit_IndexSlice(ast::IndexSlice* node) {
@@ -3036,7 +3045,7 @@ void MethodResolver::visit_IndexSlice(ast::IndexSlice* node) {
     // Change it to a named argument.
     arguments.add(create_named_argument(Symbols::to, node->to()));
   }
-  _visit_potential_call(node, arguments.build());
+  _visit_potential_call(node, node->receiver(), arguments.build());
 }
 
 void MethodResolver::visit_labeled_break_continue(ast::BreakContinue* node) {
@@ -3134,7 +3143,7 @@ void MethodResolver::visit_Identifier(ast::Identifier* node) {
   if (is_literal_this(node)) {
     visit_literal_this(node);
   } else {
-    _visit_potential_call(node);
+    _visit_potential_call(node, node);
   }
 }
 

--- a/src/compiler/resolver_method.h
+++ b/src/compiler/resolver_method.h
@@ -219,14 +219,15 @@ class MethodResolver : public ast::Visitor {
   void _visit_potential_call_dot(ast::Dot* ast_dot,
                                  CallBuilder& call_builder,
                                  ast::LspSelection* named_lsp_selection);
-  void _visit_potential_call_index(ast::Index* ast_index,
+  void _visit_potential_call_index(ast::Node* ast_target,
                                    CallBuilder& call_builder);
-  void _visit_potential_call_index_slice(ast::IndexSlice* ast_index_slice,
+  void _visit_potential_call_index_slice(ast::Node* ast_target,
                                          CallBuilder& call_builder);
   void _visit_potential_call_super(ast::Node* ast_target,
                                    CallBuilder& call_builder,
                                    bool is_constructor_super_call);
-  void _visit_potential_call(ast::Node* ast_target,
+  void _visit_potential_call(ast::Expression* potential_call,
+                             ast::Node* ast_target,
                              List<ast::Expression*> ast_arguments = List<ast::Expression*>());
 
   ir::Expression* _instantiate_runtime(Symbol id,

--- a/tests/negative/gold/block_call2_test.gold
+++ b/tests/negative/gold/block_call2_test.gold
@@ -3,4 +3,4 @@ Got: 1 Expected: 2.
 Target:
      main.<block>              tests/negative/block_call2_test.toit:6:12
 
-  0: main                      tests/negative/block_call2_test.toit:7:8
+  0: main                      tests/negative/block_call2_test.toit:7:3

--- a/tests/negative/gold/index_call_test.gold
+++ b/tests/negative/gold/index_call_test.gold
@@ -1,0 +1,7 @@
+tests/negative/index_call_test.toit:7:7: error: Can't call result of evaluating expression
+  data[pos++] 499
+      ^
+tests/negative/index_call_test.toit:7:8: error: Can't assign to unknown 'pos'
+  data[pos++] 499
+       ^~~
+Compilation failed.

--- a/tests/negative/gold/type9_test.gold
+++ b/tests/negative/gold/type9_test.gold
@@ -1,4 +1,4 @@
 As check failed: a string ("str") is not a int.
   0: main.<block>              tests/negative/type9_test.toit:8:15
-  1: run                       tests/negative/type9_test.toit:5:21
+  1: run                       tests/negative/type9_test.toit:5:16
   2: main                      tests/negative/type9_test.toit:8:3

--- a/tests/negative/gold/typeB_test.gold
+++ b/tests/negative/gold/typeB_test.gold
@@ -1,4 +1,4 @@
 As check failed: an int (499) is not a string.
   0: main.<block>              tests/negative/typeB_test.toit:10:13
-  1: run                       tests/negative/typeB_test.toit:5:21
+  1: run                       tests/negative/typeB_test.toit:5:16
   2: main                      tests/negative/typeB_test.toit:10:3

--- a/tests/negative/index_call_test.toit
+++ b/tests/negative/index_call_test.toit
@@ -1,0 +1,7 @@
+// Copyright (C) 2022 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+main:
+  data := [1, 2, 3]
+  data[pos++] 499


### PR DESCRIPTION
Fixes a confusion in the resolver.
Take the call `o[3] 4`

The parser would correctly parse this as a call of `o[3]` with argument
`4`.

However, the resolver tried to reuse functionality and gave a
call-resolving function just a "target" and "arguments".

For a normal call the "target" was the target of the call (for `foo 1
2`, the `foo` identifier).
For an index call, the "target" was the node itself: `o[3]`.

Once the target and arguments were resolved, the resolver would then
again check whether it was trying to solve a normal call or an index
call. It did this, by looking at the target-node. If it was and
index-node, it assumed that it was resolving and index-call. Otherwise,
it assumed it was for a call-node.

However, this led to the following bug, where a normal node had an
index-call as target. For our example `o[3] 4`, the resolver now got
confused and thought that it was doing work for an index node (since
the target of the call was `o[3]`, and index node). It assumed that
the argument `4` was the argument to the index (as if the user had
written `o[4]`). The actual arguments to the index-node were completely
dropped.