### PR TITLE
Fix error message for methods in super classes

### DIFF
--- a/tests/negative/bad_arguments_super_test.toit
+++ b/tests/negative/bad_arguments_super_test.toit
@@ -1,0 +1,13 @@
+// Copyright (C) 2020 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+class A:
+  foo x y:
+
+class B extends A:
+
+main:
+  b := B
+  b.foo
+  unresolved

--- a/tests/negative/gold/bad_arguments_super_test.gold
+++ b/tests/negative/gold/bad_arguments_super_test.gold
@@ -1,0 +1,8 @@
+tests/negative/bad_arguments_super_test.toit:13:3: error: Unresolved identifier: 'unresolved'
+  unresolved
+  ^~~~~~~~~~
+tests/negative/bad_arguments_super_test.toit:12:5: error: Argument mismatch for 'B.foo'
+Too few arguments provided
+  b.foo
+    ^~~
+Compilation failed.


### PR DESCRIPTION
When providing helpful error messages of why a method call didn't work,
     we didn't take super classes into account.