### PR TITLE
Add error when a global is initialized using itself

### DIFF
--- a/src/compiler/resolver_method.cc
+++ b/src/compiler/resolver_method.cc
@@ -2579,6 +2579,13 @@ void MethodResolver::_visit_potential_call_identifier(ast::Node* ast_target,
     push(ir_target);
   } else if (ir_target->is_ReferenceLocal() || ir_target->is_ReferenceGlobal()) {
     if (shape_without_implicit_this == CallShape(0)) {
+      if (ir_target->is_ReferenceGlobal() &&
+          ir_target->as_ReferenceGlobal()->target() == _method &&
+          _current_lambda == null) {
+        report_error(ast_target,
+                     "Can't access global '%s' while initializing it",
+                     _method->name().c_str());
+      }
       push(ir_target);  // Not a call.
     } else {
       const char* kind = null;

--- a/tests/negative/global_self_ref_test.toit
+++ b/tests/negative/global_self_ref_test.toit
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+some_global := some_global + 1
+some_global2 := store_lambda:: some_global2  // A lambda is allowed.
+some_global3 := just_block: some_global3
+
+store_lambda fun/Lambda: return 499
+just_block [block]: return 42
+
+main:
+  some_global
+  some_global2
+  some_global3

--- a/tests/negative/gold/global_self_ref_test.gold
+++ b/tests/negative/gold/global_self_ref_test.gold
@@ -1,0 +1,7 @@
+tests/negative/global_self_ref_test.toit:5:16: error: Can't access global 'some_global' while initializing it
+some_global := some_global + 1
+               ^~~~~~~~~~~
+tests/negative/global_self_ref_test.toit:7:29: error: Can't access global 'some_global3' while initializing it
+some_global3 := just_block: some_global3
+                            ^~~~~~~~~~~~
+Compilation failed.


### PR DESCRIPTION
Fixes #490.