### PR TITLE
Run tests on windows with bash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,7 @@ jobs:
 
       # Test.
       - name: Test
+        shell: bash  # This is crucial, as the powershell doesn't abort when there is an error.
         run: |
           make test
           make test-health

--- a/tests/fail.cmake
+++ b/tests/fail.cmake
@@ -27,15 +27,18 @@ list(APPEND TOIT_SKIP_TESTS
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" OR "${CMAKE_SYSTEM_NAME}" STREQUAL "MSYS")
   list(APPEND TOIT_FAILING_TESTS
     tests/close_test.toit
+    tests/containers_test.toit
     tests/dns_test.toit
     tests/interface_address_test.toit
     tests/keepalive_test.toit
     tests/regress/issue3_test.toit
+    tests/services_network_test.toit
     tests/socket_close_test.toit
     tests/socket_option_test.toit
     tests/socket_task_test.toit
     tests/socket_test.toit
     tests/socket_timeout_test.toit
+    tests/tcp_close_test.toit
     tests/time_test.toit
     tests/tls2_test.toit
     tests/udp_test.toit

--- a/tests/image/fail.cmake
+++ b/tests/image/fail.cmake
@@ -18,8 +18,6 @@ set(TOIT_FAILING_TESTS
 
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" OR "${CMAKE_SYSTEM_NAME}" STREQUAL "MSYS")
   list(APPEND TOIT_FAILING_TESTS
-    tests/image/basic_input.toit
     tests/image/full_page_test.toit
-    tests/image/large_string_input.toit
   )
 endif()


### PR DESCRIPTION
Powershell doesn't abort execution when a command fails, so we were not
correctly testing on Windows.