### PR TITLE
Allow numbers in constant variable names.

### DIFF
--- a/src/compiler/resolver_method.cc
+++ b/src/compiler/resolver_method.cc
@@ -1031,6 +1031,7 @@ static bool has_constant_name(Symbol name) {
       seen_capital = true;
       continue;
     }
+    if ('0' <= c && c <= '9') continue;
     if (c == '_') continue;
     return false;
   }

--- a/tests/negative/constant_name_test.toit
+++ b/tests/negative/constant_name_test.toit
@@ -9,6 +9,7 @@ class A:
   CONST ::= 499
   _ ::= 42
   A_B ::= 43
+  A_B499 ::= 43
   __ ::= 42
 
   NON_CONST := 1

--- a/tests/negative/gold/constant_name_test.gold
+++ b/tests/negative/gold/constant_name_test.gold
@@ -7,4 +7,7 @@ tests/negative/constant_name_test.toit:9:3: warning: Final field with constant-l
 tests/negative/constant_name_test.toit:11:3: warning: Final field with constant-like name: 'A_B'. Missing 'static'?
   A_B ::= 43
   ^~~
+tests/negative/constant_name_test.toit:12:3: warning: Final field with constant-like name: 'A_B499'. Missing 'static'?
+  A_B499 ::= 43
+  ^~~~~~
 Compilation failed.


### PR DESCRIPTION
Otherwise we don't give warnings for `FOO499 ::= 33`.