### PR TITLE
Remove support for deprecated A.member.

### DIFF
--- a/tests/health/gold/sdk/tests__lsp__bad_definition_test.toit.gold
+++ b/tests/health/gold/sdk/tests__lsp__bad_definition_test.toit.gold
@@ -22,21 +22,15 @@ tests/lsp/bad_definition_test.toit:73:5: error: Argument mismatch for 'bar'
 Too few arguments provided
   A.bar
     ^~~
-tests/lsp/bad_definition_test.toit:78:4: warning: Deprecated use of static method syntax to call an unnamed constructor. Use (<Class>).<member> instead.
+tests/lsp/bad_definition_test.toit:78:4: error: Class 'A' does not have any static member or constructor with name 'fo'
   A.fo
    ^
-tests/lsp/bad_definition_test.toit:83:4: warning: Deprecated use of static method syntax to call an unnamed constructor. Use (<Class>).<member> instead.
+tests/lsp/bad_definition_test.toit:83:4: error: Class 'A' does not have any static member or constructor with name 'name'
   A.name
    ^
-tests/lsp/bad_definition_test.toit:109:4: warning: Deprecated use of static method syntax to call an unnamed constructor. Use (<Class>).<member> instead.
+tests/lsp/bad_definition_test.toit:109:4: error: Class 'C' does not have any static member or constructor with name 'foo'
   C.foo
    ^
-tests/lsp/bad_definition_test.toit:78:5: error: Class 'A' does not have any method 'fo'
-  A.fo
-    ^~
-tests/lsp/bad_definition_test.toit:83:5: error: Class 'A' does not have any method 'name'
-  A.name
-    ^~~~
 tests/lsp/bad_definition_test.toit:88:7: error: Class 'A' does not have any method 'fo'
   (A).fo
       ^~
@@ -51,7 +45,3 @@ tests/lsp/bad_definition_test.toit:104:7: error: Argument mismatch for 'C.foo'
 Too few arguments provided
   (C).foo
       ^~~
-tests/lsp/bad_definition_test.toit:109:5: error: Argument mismatch for 'C.foo'
-Too few arguments provided
-  C.foo
-    ^~~

--- a/tests/negative/constructor_receiver2_test.toit
+++ b/tests/negative/constructor_receiver2_test.toit
@@ -1,0 +1,32 @@
+// Copyright (C) 2022 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import .constructor_receiver2_test as prefix
+
+class A:
+  static FOO ::= 499
+
+  constructor x:
+
+class B:
+  static FOO ::= 42
+
+class C:
+  foo: 42
+
+class D:
+  constructor.named:
+
+  static FOO ::= 42
+
+main:
+  print A.FOOO
+  print B.FOOO
+  print C.foo
+  print D.FOOO
+
+  print prefix.A.FOOO
+  print prefix.B.FOOO
+  print prefix.C.foo
+  print prefix.D.FOOO

--- a/tests/negative/gold/constructor_receiver2_test.gold
+++ b/tests/negative/gold/constructor_receiver2_test.gold
@@ -1,0 +1,25 @@
+tests/negative/constructor_receiver2_test.toit:24:10: error: Class 'A' does not have any static member or constructor with name 'FOOO'
+  print A.FOOO
+         ^
+tests/negative/constructor_receiver2_test.toit:25:10: error: Class 'B' does not have any static member or constructor with name 'FOOO'
+  print B.FOOO
+         ^
+tests/negative/constructor_receiver2_test.toit:26:10: error: Class 'C' does not have any static member or constructor with name 'foo'
+  print C.foo
+         ^
+tests/negative/constructor_receiver2_test.toit:27:10: error: Class 'D' does not have any static member or constructor with name 'FOOO'
+  print D.FOOO
+         ^
+tests/negative/constructor_receiver2_test.toit:29:17: error: Class 'A' does not have any static member or constructor with name 'FOOO'
+  print prefix.A.FOOO
+                ^
+tests/negative/constructor_receiver2_test.toit:30:17: error: Class 'B' does not have any static member or constructor with name 'FOOO'
+  print prefix.B.FOOO
+                ^
+tests/negative/constructor_receiver2_test.toit:31:17: error: Class 'C' does not have any static member or constructor with name 'foo'
+  print prefix.C.foo
+                ^
+tests/negative/constructor_receiver2_test.toit:32:17: error: Class 'D' does not have any static member or constructor with name 'FOOO'
+  print prefix.D.FOOO
+                ^
+Compilation failed.

--- a/tests/negative/gold/constructor_receiver_test.gold
+++ b/tests/negative/gold/constructor_receiver_test.gold
@@ -1,13 +1,13 @@
-tests/negative/constructor_receiver_test.toit:21:4: warning: Deprecated use of static method syntax to call an unnamed constructor. Use (<Class>).<member> instead.
+tests/negative/constructor_receiver_test.toit:21:4: error: Class 'A' does not have any static member or constructor with name 'member'
   A.member
    ^
-tests/negative/constructor_receiver_test.toit:22:4: warning: Deprecated use of static method syntax to call an unnamed constructor. Use (<Class>).<member> instead.
+tests/negative/constructor_receiver_test.toit:22:4: error: Class 'B' does not have any static member or constructor with name 'member'
   B.member
    ^
-tests/negative/constructor_receiver_test.toit:24:8: warning: Deprecated use of static method syntax to call an unnamed constructor. Use (<Class>).<member> instead.
+tests/negative/constructor_receiver_test.toit:24:8: error: Class 'A' does not have any static member or constructor with name 'member'
   pre.A.member
        ^
-tests/negative/constructor_receiver_test.toit:25:8: warning: Deprecated use of static method syntax to call an unnamed constructor. Use (<Class>).<member> instead.
+tests/negative/constructor_receiver_test.toit:25:8: error: Class 'B' does not have any static member or constructor with name 'member'
   pre.B.member
        ^
 tests/negative/constructor_receiver_test.toit:33:3: error: Unresolved identifier: 'unresolved'


### PR DESCRIPTION
We now required the constructor to be in parenthesis: `(A).member`.
By removing the deprecated support we can provide better error messages
when the left-hand side points to a constructor.

In the following example we used to give bad messages:
```
class A:
  static FOO ::= 499
  constructor x:
main:
  print A.FOOO
```

```
bad.toit:6:9: error: Argument mismatch for 'A'
Too few arguments provided
  print A.FOOO
        ^
```