### PR TITLE
Attempt to work around spurious out-of-memory on M1 Mac.

### DIFF
--- a/src/os.cc
+++ b/src/os.cc
@@ -203,7 +203,7 @@ OS::HeapMemoryRange OS::get_heap_memory_range() {
     // anything in that range.
     const uword FOUR_GB = 4LL * GB;
     if (addr < FOUR_GB && addr + MAX_HEAP > FOUR_GB) {
-      _single_range.address = FOUR_GB;
+      _single_range.address = reinterpret_cast<void*>(FOUR_GB);
     } else {
 #else
     {

--- a/src/os.cc
+++ b/src/os.cc
@@ -197,12 +197,14 @@ OS::HeapMemoryRange OS::get_heap_memory_range() {
     // be the last MAX_HEAP of the address space.
     _single_range.address = reinterpret_cast<void*>(-static_cast<word>(MAX_HEAP + TOIT_PAGE_SIZE));
   } else {
+    uword from = addr - MAX_HEAP / 2;
+    uword to = addr + MAX_HEAP / 2;
 #if defined(TOIT_DARWIN) && defined(BUILD_64)
     // MacOS never returns addresses in the first 4Gbytes, in order to flush
     // out 32 bit uncleanness, so let's try to avoid having the range cover
     // anything in that range.
     const uword FOUR_GB = 4LL * GB;
-    if (addr < FOUR_GB && addr + MAX_HEAP > FOUR_GB) {
+    if (from < FOUR_GB && to > FOUR_GB) {
       _single_range.address = reinterpret_cast<void*>(FOUR_GB);
     } else {
 #else
@@ -210,7 +212,7 @@ OS::HeapMemoryRange OS::get_heap_memory_range() {
 #endif
       // We will be allocating within a symmetric range either side of this
       // single allocation.
-      _single_range.address = reinterpret_cast<void*>(addr - HALF_MAX);
+      _single_range.address = reinterpret_cast<void*>(from);
     }
   }
   _single_range.size = MAX_HEAP;

--- a/src/os.cc
+++ b/src/os.cc
@@ -198,8 +198,8 @@ OS::HeapMemoryRange OS::get_heap_memory_range() {
     _single_range.address = reinterpret_cast<void*>(-static_cast<word>(MAX_HEAP + TOIT_PAGE_SIZE));
   } else {
     uword from = addr - MAX_HEAP / 2;
-    uword to = addr + MAX_HEAP / 2;
 #if defined(TOIT_DARWIN) && defined(BUILD_64)
+    uword to = addr + MAX_HEAP / 2;
     // MacOS never returns addresses in the first 4Gbytes, in order to flush
     // out 32 bit uncleanness, so let's try to avoid having the range cover
     // anything in that range.

--- a/src/os.cc
+++ b/src/os.cc
@@ -197,7 +197,7 @@ OS::HeapMemoryRange OS::get_heap_memory_range() {
     // be the last MAX_HEAP of the address space.
     _single_range.address = reinterpret_cast<void*>(-static_cast<word>(MAX_HEAP + TOIT_PAGE_SIZE));
   } else {
-#ifdef TOIT_DARWIN
+#if defined(TOIT_DARWIN) && defined(BUILD_64)
     // MacOS never returns addresses in the first 4Gbytes, in order to flush
     // out 32 bit uncleanness, so let's try to avoid having the range cover
     // anything in that range.

--- a/src/os.cc
+++ b/src/os.cc
@@ -199,10 +199,10 @@ OS::HeapMemoryRange OS::get_heap_memory_range() {
   } else {
     uword from = addr - MAX_HEAP / 2;
 #if defined(TOIT_DARWIN) && defined(BUILD_64)
-    uword to = addr + MAX_HEAP / 2;
-    // MacOS never returns addresses in the first 4Gbytes, in order to flush
+    uword to = from + MAX_HEAP;
+    // On macOS, we never get addresses in the first 4Gbytes, in order to flush
     // out 32 bit uncleanness, so let's try to avoid having the range cover
-    // anything in that range.
+    // both sides of the 4Gbytes boundary.
     const uword FOUR_GB = 4LL * GB;
     if (from < FOUR_GB && to > FOUR_GB) {
       _single_range.address = reinterpret_cast<void*>(FOUR_GB);

--- a/src/top.h
+++ b/src/top.h
@@ -163,9 +163,13 @@ static const int BYTE_BIT_SIZE = 8;  // Number of bits in a byte.
 // heap for now.  Can be fixed if we can resize the metadata on demand.
 // This constant is not used on embedded platforms.
 #ifdef BUILD_64
-static const uword MAX_HEAP = 1ull * GB;  // Metadata ca. 8.5Mbytes.
+#ifdef TOIT_DARWIN
+static const uword MAX_HEAP = 2ULL * GB;  // Metadata ca. 17Mbytes.
 #else
-static const uword MAX_HEAP = 512ull * MB;  // Metadata ca. 8.2Mbytes.
+static const uword MAX_HEAP = 1ULL * GB;  // Metadata ca. 8.5Mbytes.
+#endif
+#else
+static const uword MAX_HEAP = 512ULL * MB;  // Metadata ca. 8.2Mbytes.
 #endif
 
 // Perhaps some ARM CPUs and platforms allow unaligned operations, but to be

--- a/src/top.h
+++ b/src/top.h
@@ -163,13 +163,9 @@ static const int BYTE_BIT_SIZE = 8;  // Number of bits in a byte.
 // heap for now.  Can be fixed if we can resize the metadata on demand.
 // This constant is not used on embedded platforms.
 #ifdef BUILD_64
-#ifdef TOIT_DARWIN
-static const uword MAX_HEAP = 2ULL * GB;  // Metadata ca. 17Mbytes.
+static const uword MAX_HEAP = 1ull * GB;  // Metadata ca. 8.5Mbytes.
 #else
-static const uword MAX_HEAP = 1ULL * GB;  // Metadata ca. 8.5Mbytes.
-#endif
-#else
-static const uword MAX_HEAP = 512ULL * MB;  // Metadata ca. 8.2Mbytes.
+static const uword MAX_HEAP = 512ull * MB;  // Metadata ca. 8.2Mbytes.
 #endif
 
 // Perhaps some ARM CPUs and platforms allow unaligned operations, but to be


### PR DESCRIPTION
If this doesn't work we may need to reserve the memory
at the start instead of trying to guess where it will
be allocated.