### PR TITLE
Add virtual spi bus

### DIFF
--- a/examples/spi.toit
+++ b/examples/spi.toit
@@ -1,37 +1,49 @@
 import gpio
 import spi
 
-
 main:
-    bus/spi.Bus := platform == PLATFORM_FREERTOS?
-        spi.Bus
-            --miso=gpio.Pin 12
-            --mosi=gpio.Pin 13
-            --clock=gpio.Pin 14 
-        :
-        spi.VirtualBus 
+
+    dc /gpio.Pin? := ?
+    cs /gpio.Pin? := ?
+    bus/spi.Bus   := ?
+
+    if platform == PLATFORM_FREERTOS:
+        bus = spi.Bus
+                --miso=gpio.Pin 12
+                --mosi=gpio.Pin 13
+                --clock=gpio.Pin 14 
+        
+        cs = gpio.Pin 15
+        dc = gpio.Pin 16
+
+    else:
+        bus = spi.VirtualBus 
+        
+        cs = gpio.VirtualPin :: | value | print "Cs set to: $value"
+        dc = gpio.VirtualPin :: | value | print "Dc set to: $value"
 
     device := bus.device
-        --cs=gpio.VirtualPin :: | value | print "Cs set to: $value"
-        --dc=gpio.VirtualPin :: | value | print "Dc set to: $value"
+        --cs=cs
+        --dc=dc
         --address_bits=7
         --command_bits=7
         --frequency=2_000_000
         --mode=0
     
-
-    result := device.transfer 
-        #[0x00, 0x01, 0x02, 0x03]
+    to_transmit := #[0x00, 0x01, 0x02, 0x03]
+    device.transfer 
+        to_transmit
         --address=0xFF
         --command=0xFF
         --dc=0
         --read
     
-    print "Result of transfer: $result"
+    print "Result of transfer: $to_transmit"
 
     catch:
-        result = device.transfer 
-            #[0x04, 0x05, 0x06, 0x07]
+        to_transmit = #[0x04, 0x05, 0x06, 0x07]
+        device.transfer 
+            to_transmit
             --address=0xFF
             --command=0xFF
             --dc=1
@@ -43,20 +55,24 @@ main:
         
     catch --trace:
         device.with_reserved_bus:
-            result = device.transfer 
-                #[0x04, 0x05, 0x06, 0x07]
+            to_transmit = #[0x04, 0x05, 0x06, 0x07]
+            device.transfer 
+                to_transmit
                 --address=0x01
                 --command=0xAA
                 --dc=1
                 --read
                 --keep_cs_active
 
-            print "Result of transfer: $result"
+            print "Result of transfer: $to_transmit"
 
-            result = device.transfer
-                #[0x08, 0x09, 0x0A, 0x0B]
+            to_transmit = #[0x08, 0x09, 0x0A, 0x0B]
+            device.transfer
+                to_transmit
                 --address=0x01
                 --command=0x55
                 --dc=0
 
-            print "Result of transfer: $result"
+            print "Result of transfer: $to_transmit"
+
+    

--- a/examples/spi.toit
+++ b/examples/spi.toit
@@ -1,11 +1,16 @@
-
 import gpio
 import spi
 
 
 main:
-    bus/spi.Bus := spi.VirtualBus
-    
+    bus/spi.Bus := platform == PLATFORM_FREERTOS?
+        spi.Bus
+            --miso=gpio.Pin 12
+            --mosi=gpio.Pin 13
+            --clock=gpio.Pin 14 
+        :
+        spi.VirtualBus 
+
     device := bus.device
         --cs=gpio.VirtualPin :: | value | print "Cs set to: $value"
         --dc=gpio.VirtualPin :: | value | print "Dc set to: $value"

--- a/examples/spi.toit
+++ b/examples/spi.toit
@@ -1,0 +1,57 @@
+
+import gpio
+import spi
+
+
+main:
+    bus/spi.Bus := spi.VirtualBus
+    
+    device := bus.device
+        --cs=gpio.VirtualPin :: | value | print "Cs set to: $value"
+        --dc=gpio.VirtualPin :: | value | print "Dc set to: $value"
+        --address_bits=7
+        --command_bits=7
+        --frequency=2_000_000
+        --mode=0
+    
+
+    result := device.transfer 
+        #[0x00, 0x01, 0x02, 0x03]
+        --address=0xFF
+        --command=0xFF
+        --dc=0
+        --read
+    
+    print "Result of transfer: $result"
+
+    catch:
+        result = device.transfer 
+            #[0x04, 0x05, 0x06, 0x07]
+            --address=0xFF
+            --command=0xFF
+            --dc=1
+            --read
+            --keep_cs_active
+        
+        //Should not get here
+        print "Implementation error as this was not called with \$spi.Device.with_reserved_bus"
+        
+    catch --trace:
+        device.with_reserved_bus:
+            result = device.transfer 
+                #[0x04, 0x05, 0x06, 0x07]
+                --address=0x01
+                --command=0xAA
+                --dc=1
+                --read
+                --keep_cs_active
+
+            print "Result of transfer: $result"
+
+            result = device.transfer
+                #[0x08, 0x09, 0x0A, 0x0B]
+                --address=0x01
+                --command=0x55
+                --dc=0
+
+            print "Result of transfer: $result"

--- a/examples/spi.toit
+++ b/examples/spi.toit
@@ -17,8 +17,9 @@ main:
         dc = gpio.Pin 16
 
     else:
+        //Default spi.VirtualBus transfer method
         bus = spi.VirtualBus 
-        
+
         cs = gpio.VirtualPin :: | value | print "Cs set to: $value"
         dc = gpio.VirtualPin :: | value | print "Dc set to: $value"
 


### PR DESCRIPTION
Add a virtual spi bus that emulates the spi_transfer_ primitive. 
The virtual spi bus can be used to stub spi device calls in tests to ensure that the expected calls are made.
This can now run on non-esp32 and embedded Linux platforms.

The addition of the spi.VirtualBus class will also allow other platforms to have the same calling convention as the esp32 library by supplying their own "transfer primitive" to the VirtualBus class.

Also added an example of how to use the spi.Bus and spi.Device.
In the example, it is also shown how to use the new spi.VirtualBus.