### PR TITLE
Add TPKG_SDK_VERSION for pkg downloads

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -170,6 +170,8 @@ function(find_toit_projects REPO)
       if (NOT "${LOCATION}" STREQUAL "")
         set(PROJECT_NAME "${PROJECT_NAME}-${LOCATION}")
       endif()
+      # Override the SDK version, so that package downloads find the newest packages.
+      set(TPKG_SDK_VERSION "v2.0.0-alpha.21")
       # Mark it as a toit-project so we download its dependencies.
       toit_project("${PROJECT_NAME}" "${LOCATION_PATH}")
     endif()

--- a/tools/toit.cmake
+++ b/tools/toit.cmake
@@ -28,8 +28,11 @@ if (DEFINED EXECUTING_SCRIPT)
     endif()
 
     if (EXISTS "${TOIT_PROJECT}/package.yaml" OR EXISTS "${TOIT_PROJECT}/package.lock")
+      if (NOT "${TPKG_SDK_VERSION}" STREQUAL "")
+        set(TPKG_SDK_VERSION_ARG "--sdk-version=${TPKG_SDK_VERSION}")
+      endif()
       execute_process(
-        COMMAND "${TOITPKG}" install --auto-sync=false "--project-root=${TOIT_PROJECT}"
+        COMMAND "${TOITPKG}" install --auto-sync=false ${TPKG_SDK_VERSION_ARG} "--project-root=${TOIT_PROJECT}"
         COMMAND_ERROR_IS_FATAL ANY
       )
     endif()
@@ -112,6 +115,7 @@ macro(toit_project NAME PATH)
         -DSCRIPT_COMMAND=install_packages
         "-DTOIT_PROJECT=${PATH}"
         "-DTOITPKG=${TOITPKG}"
+        "-DTPKG_SDK_VERSION=${TPKG_SDK_VERSION}"
         -P "${TOIT_DOWNLOAD_PACKAGE_SCRIPT}"
     DEPENDS "${TOITPKG}"
   )


### PR DESCRIPTION
Hardcode an SDK version number for external package downloads.
The inferred SDK number is lower than the one we need to download all
dependencies in the external packages. As a work-around we hard-code a
version number that works.