### PR TITLE
Qualify all config key strings so they don't clash

### DIFF
--- a/lib/net/cellular.toit
+++ b/lib/net/cellular.toit
@@ -7,20 +7,20 @@ import system.api.cellular show CellularServiceClient
 
 import .impl
 
-CONFIG_LOG_LEVEL / string ::= "log.level"
+CONFIG_LOG_LEVEL / string ::= "cellular.log.level"
 
-CONFIG_APN   /string ::= "apn"
-CONFIG_BANDS /string ::= "bands"
-CONFIG_RATS  /string ::= "rats"
+CONFIG_APN   /string ::= "cellular.apn"
+CONFIG_BANDS /string ::= "cellular.bands"
+CONFIG_RATS  /string ::= "cellular.rats"
 
-CONFIG_UART_BAUD_RATE /string ::= "uart.baud"
-CONFIG_UART_RX        /string ::= "uart.rx"
-CONFIG_UART_TX        /string ::= "uart.tx"
-CONFIG_UART_CTS       /string ::= "uart.cts"
-CONFIG_UART_RTS       /string ::= "uart.rts"
+CONFIG_UART_BAUD_RATE /string ::= "cellular.uart.baud"
+CONFIG_UART_RX        /string ::= "cellular.uart.rx"
+CONFIG_UART_TX        /string ::= "cellular.uart.tx"
+CONFIG_UART_CTS       /string ::= "cellular.uart.cts"
+CONFIG_UART_RTS       /string ::= "cellular.uart.rts"
 
-CONFIG_POWER /string ::= "power"
-CONFIG_RESET /string ::= "reset"
+CONFIG_POWER /string ::= "cellular.power"
+CONFIG_RESET /string ::= "cellular.reset"
 
 CONFIG_ACTIVE_LOW  /int ::= 0
 CONFIG_ACTIVE_HIGH /int ::= 1

--- a/lib/net/wifi.toit
+++ b/lib/net/wifi.toit
@@ -7,11 +7,11 @@ import system.api.wifi show WifiServiceClient
 
 import .impl
 
-CONFIG_SSID      /string ::= "ssid"
-CONFIG_PASSWORD  /string ::= "password"
+CONFIG_SSID      /string ::= "wifi.ssid"
+CONFIG_PASSWORD  /string ::= "wifi.password"
 
-CONFIG_BROADCAST /string ::= "broadcast"
-CONFIG_CHANNEL   /string ::= "channel"
+CONFIG_BROADCAST /string ::= "wifi.broadcast"
+CONFIG_CHANNEL   /string ::= "wifi.channel"
 
 service_/WifiServiceClient? ::= (WifiServiceClient --no-open).open
 


### PR DESCRIPTION
This makes it easier to accept these configurations as `jag -D` options.