### PR TITLE
Some small fixes to tracegc and heap accounting

### DIFF
--- a/src/os_esp32.cc
+++ b/src/os_esp32.cc
@@ -668,11 +668,8 @@ class HeapSummaryCollector {
     int type = current_page_
         ? current_page_->register_user(tag, size)
         : HeapSummaryPage::compute_type(tag);
-    // Disregard IRAM allocations.
-    if (reinterpret_cast<uword>(address) < 0x40000000) {
-      sizes_[type] += size;
-      counts_[type]++;
-    }
+    sizes_[type] += size;
+    counts_[type]++;
   }
 
   void print(const char* marker) {
@@ -706,8 +703,10 @@ class HeapSummaryCollector {
     int capacity_bytes = info.total_allocated_bytes + info.total_free_bytes;
     int used_bytes = size * 100 / capacity_bytes;
     printf("  └───────────┴─────────┴───────────────────────┘\n");
-    printf("  Total: %d bytes in %d allocations (%d%%)\n",
-        size, count, used_bytes);
+    printf("  Total: %d bytes in %d allocations (%d%%), largest free %dk, total free %dk\n",
+        size, count, used_bytes,
+        static_cast<int>(info.largest_free_block >> 10),
+        static_cast<int>(info.total_free_bytes >> 10));
 
     int page_count = 0;
     for (int i = 0; i < max_pages_; i++) {

--- a/src/third_party/dartino/gc_metadata.cc
+++ b/src/third_party/dartino/gc_metadata.cc
@@ -6,8 +6,9 @@
 
 #include <stdio.h>
 
-#include "../../utils.h"
+#include "../../heap_report.h"
 #include "../../objects.h"
+#include "../../utils.h"
 
 #include "gc_metadata.h"
 
@@ -61,7 +62,10 @@ void GcMetadata::set_up_singleton() {
   // We create all the metadata with just one allocation.  Otherwise we will
   // lose memory when the malloc rounds a series of big allocations up to 4k
   // page boundaries.
-  metadata_ = reinterpret_cast<uint8*>(OS::grab_virtual_memory(null, metadata_size_));
+  {
+    HeapTagScope scope(ITERATE_CUSTOM_TAGS + TOIT_HEAP_MALLOC_TAG);
+    metadata_ = reinterpret_cast<uint8*>(OS::grab_virtual_memory(null, metadata_size_));
+  }
 
   if (metadata_ == null) {
     printf("[toit] ERROR: failed to allocate GC metadata\n");

--- a/src/third_party/dartino/object_memory.h
+++ b/src/third_party/dartino/object_memory.h
@@ -44,7 +44,7 @@ static inline bool has_sentinel_at(uword address) {
 }
 
 enum PageType {
-  UNKNOWN_SPACE_PAGE,  // Probably a program space page.
+  UNKNOWN_SPACE_PAGE,  // Probably a metadata page.
   OLD_SPACE_PAGE,
   NEW_SPACE_PAGE
 };

--- a/src/third_party/dartino/two_space_heap.cc
+++ b/src/third_party/dartino/two_space_heap.cc
@@ -136,7 +136,7 @@ GcType TwoSpaceHeap::collect_new_space(bool try_hard) {
 
   if (has_empty_new_space()) {
     if (Flags::tracegc) {
-      printf("Old-space-only GC:\n");
+      printf("Old-space-only GC (try_hard = %s)\n", try_hard ? "true" : "false");
     }
     return collect_old_space_if_needed(try_hard, try_hard);
   }


### PR DESCRIPTION
The heap iteration can now filter out IRAM so we don't have to filter it out with a hack.
