### PR TITLE
Devices with limited memory: reduce heap metadata.

### DIFF
--- a/src/third_party/dartino/gc_metadata.cc
+++ b/src/third_party/dartino/gc_metadata.cc
@@ -32,8 +32,11 @@ void GcMetadata::set_up_singleton() {
   // If we have very limited memory then we restrict the Toit heap
   // to the high half, which reduces the metadata allocation from
   // 24k to 12k.
-  if (false && !OS::use_spiram_for_metadata() && !OS::use_spiram_for_heap() && 148 * KB < size && size < 300 * KB) {
-    uword adjust = size - 148 * KB;
+  const uword TWELVE_K_METADATA_LIMIT = 148 * KB;
+  const uword PLENTY_OF_MEMORY = 308 * KB;
+  if (!OS::use_spiram_for_metadata() && !OS::use_spiram_for_heap() &&
+      TWELVE_K_METADATA_LIMIT < size && size < PLENTY_OF_MEMORY) {
+    uword adjust = size - TWELVE_K_METADATA_LIMIT;
     lowest_address_ += adjust;
     size -= adjust;
   }

--- a/src/third_party/dartino/gc_metadata.h
+++ b/src/third_party/dartino/gc_metadata.h
@@ -383,9 +383,11 @@ class GcMetadata {
 
   static uword heap_extent() { return singleton_.heap_extent_; }
 
-  static bool in_metadata_range(uword address) {
+  template<typename T>
+  static bool in_metadata_range(T address_argument) {
+    uword address = reinterpret_cast<uword>(address_argument);
     uword lowest = singleton_.lowest_address_;
-    return address >= lowest && address - lowest <= singleton_.heap_extent_;
+    return lowest <= address && address < lowest + singleton_.heap_extent_;
   }
 
   static uword remembered_set_bias() { return singleton_.remembered_set_bias_; }

--- a/src/third_party/dartino/object_memory.cc
+++ b/src/third_party/dartino/object_memory.cc
@@ -214,27 +214,25 @@ void Chunk::find(uword word, const char* name) {
 Chunk* ObjectMemory::allocate_chunk(Space* owner, uword size) {
   static const int UNUSABLE_SIZE = 50;
   void* unusable_pages[UNUSABLE_SIZE];
-  int unusable_pages_count = 0;
   size = Utils::round_up(size, TOIT_PAGE_SIZE);
-  void* memory = OS::allocate_pages(size);
   uword lowest = GcMetadata::lowest_old_space_address();
-  USE(lowest);
-  while (memory != null &&
-         (reinterpret_cast<uword>(memory) < lowest ||
-          reinterpret_cast<uword>(memory) - lowest + size > GcMetadata::heap_extent())) {
-    if (unusable_pages_count == UNUSABLE_SIZE) {
-      printf("New allocation %p-%p\n", memory, unvoid_cast<char*>(memory) + size);
-      printf("Metadata range %p-%p\n", reinterpret_cast<void*>(lowest), reinterpret_cast<uint8*>(lowest) + GcMetadata::heap_extent());
-      FATAL("Toit heap outside expected range");
+  for (int i = 0; i < UNUSABLE_SIZE; i++) {
+    void* memory = OS::allocate_pages(size);
+    if (memory == null ||
+        (GcMetadata::in_metadata_range(memory) &&
+         GcMetadata::in_metadata_range(reinterpret_cast<uword>(memory) + size - 1))) {
+      for (int j = 0; j < i; j++) OS::free_pages(unusable_pages[j], size);
+      return allocate_chunk_helper(owner, size, memory);
     }
-    unusable_pages[unusable_pages_count++] = memory;
-    memory = OS::allocate_pages(size);
+    unusable_pages[i] = memory;
   }
+  printf("New allocation %p-%p\n", unusable_pages[0], unvoid_cast<char*>(unusable_pages[0]) + size);
+  printf("Metadata range %p-%p\n", reinterpret_cast<void*>(lowest), reinterpret_cast<uint8*>(lowest) + GcMetadata::heap_extent());
+  FATAL("Toit heap outside expected range");
+}
 
-  for (int i = 0; i < unusable_pages_count; i++) {
-    OS::free_pages(unusable_pages[i], size);
-  }
 
+Chunk* ObjectMemory::allocate_chunk_helper(Space* owner, uword size, void* memory) {
   if (memory == null) return null;
 
   uword base = reinterpret_cast<uword>(memory);

--- a/src/third_party/dartino/object_memory.h
+++ b/src/third_party/dartino/object_memory.h
@@ -525,6 +525,8 @@ class ObjectMemory {
   static inline void set_spare_chunk(Locker& locker, Chunk* spare_chunk) { spare_chunk_ = spare_chunk; }
 
  private:
+  static Chunk* allocate_chunk_helper(Space* space, uword size, void* memory);
+
   static std::atomic<uword> allocated_;
 
   static Chunk* spare_chunk_;


### PR DESCRIPTION
Restricts the Toit heap to the top half of memory, so that the metadata area can be reduced from 24k to 12k.