### PR TITLE
Print the failing primitive on OOM.

### DIFF
--- a/src/interpreter_run.cc
+++ b/src/interpreter_run.cc
@@ -980,6 +980,9 @@ Interpreter::Result Interpreter::run() {
         }
 
         if (attempts > 3) {
+          if (VM::current()->scheduler()->is_boot_process(_process)) {
+            printf("Allocation failure in primitive %d:%d.\n", primitive_module, primitive_index);
+          }
           sp = push_error(sp, result, "");
           goto THROW_IMPLEMENTATION;
         }


### PR DESCRIPTION
If the system process fails on OOM it may be just an unrealistically large allocation, so it could be
helpful to print the primitive number.