### PR TITLE
Provide the correct address of the programs table

### DIFF
--- a/src/flash_registry_shared.cc
+++ b/src/flash_registry_shared.cc
@@ -17,10 +17,6 @@
 #include "os.h"
 #include "flash_registry.h"
 
-#ifdef TOIT_FREERTOS
-extern "C" uword _thread_local_end;
-#endif
-
 namespace toit {
 
 int FlashRegistry::find_next(int offset, ReservationList::Iterator* it) {
@@ -77,7 +73,7 @@ void* FlashRegistry::memory(int offset, int size) {
   }
 
 #ifdef TOIT_FREERTOS
-  const uword* table = &_thread_local_end;
+  const uword* table = OS::image_bundled_programs_table();
   uword diff = static_cast<uword>(offset - 1);
   return reinterpret_cast<void*>(reinterpret_cast<uword>(table) + diff);
 #else

--- a/src/os.h
+++ b/src/os.h
@@ -245,6 +245,9 @@ class OS {
   // Unique 16-bytes uuid of the running image.
   static const uint8* image_uuid();
 
+  // Bundled programs table.
+  static const uword* image_bundled_programs_table();
+
   // ubjson-encoded configuration of the running image. Return NULL if not found.
   static uint8* image_config(size_t *length);
 

--- a/src/os_esp32.cc
+++ b/src/os_esp32.cc
@@ -741,19 +741,20 @@ void OS::heap_summary_report(int max_pages, const char* marker) { }
 #endif // def TOIT_CMPCTMALLOC
 
 static const int TOIT_IMAGE_DATA_SIZE = 1024;
-static const int TOIT_CONFIG_IMAGE_SIZE = TOIT_IMAGE_DATA_SIZE - UUID_SIZE;
+static const int TOIT_CONFIG_IMAGE_SIZE = TOIT_IMAGE_DATA_SIZE - UUID_SIZE - sizeof(uint32);
 
 class ImageData {
  public:
-  uint32_t image_pad = 0;
-  uint32_t image_magic1 = 0x7017da7a;  // "Toitdata"
+  uint32 image_pad = 0;
+  uint32 image_magic1 = 0x7017da7a;  // "Toitdata"
   // The data between image_magic1 and image_magic2 must be a multiple of 512
   // bytes, otherwise the patching utility will not detect it. Search for
   // 0x7017da7a. Note when updating this restriction is baked into the SDK that
   // you are updating *from* so it can't be fixed without multiple SDK updates.
-  uint8_t image_config[TOIT_CONFIG_IMAGE_SIZE] = {0};
-  uint8_t image_uuid[UUID_SIZE] = {0};
-  uint32_t image_magic2 = 0xc09f19;    // "config"
+  uint8 image_config[TOIT_CONFIG_IMAGE_SIZE] = {0};
+  uint8 image_uuid[UUID_SIZE] = {0};
+  uint32 image_bundled_programs_table = 0;
+  uint32 image_magic2 = 0xc09f19;    // "config"
 } __attribute__((packed));
 
 // Note, you can't declare this const because then the compiler thinks it can
@@ -763,6 +764,10 @@ __attribute__((section(".rodata_custom_desc"))) ImageData toit_image_data;
 
 const uint8* OS::image_uuid() {
   return toit_image_data.image_uuid;
+}
+
+const uword* OS::image_bundled_programs_table() {
+  return reinterpret_cast<const uword*>(toit_image_data.image_bundled_programs_table);
 }
 
 uint8* OS::image_config(size_t *length) {

--- a/src/os_posix.cc
+++ b/src/os_posix.cc
@@ -291,6 +291,11 @@ const uint8* OS::image_uuid() {
   return uuid;
 }
 
+const uword* OS::image_bundled_programs_table() {
+  FATAL("should not be used on posix")
+  return null;
+}
+
 uint8* OS::image_config(size_t *length) {
   FATAL("should not be used on posix")
   return null;

--- a/src/os_win.cc
+++ b/src/os_win.cc
@@ -261,7 +261,7 @@ const uint8* OS::image_uuid() {
   return uuid;
 }
 
-const uword* OS::image_builtin_programs_table() {
+const uword* OS::image_bundled_programs_table() {
   FATAL("should not be used on windows")
   return null;
 }

--- a/src/os_win.cc
+++ b/src/os_win.cc
@@ -261,6 +261,11 @@ const uint8* OS::image_uuid() {
   return uuid;
 }
 
+const uword* OS::image_builtin_programs_table() {
+  FATAL("should not be used on windows")
+  return null;
+}
+
 uint8* OS::image_config(size_t *length) {
   FATAL("should not be used on windows")
   return null;

--- a/src/primitive_programs_registry.cc
+++ b/src/primitive_programs_registry.cc
@@ -21,10 +21,6 @@
 #include "scheduler.h"
 #include "vm.h"
 
-#ifdef TOIT_FREERTOS
-extern "C" uword _thread_local_end;
-#endif
-
 namespace toit {
 
 MODULE_IMPLEMENTATION(programs_registry, MODULE_PROGRAMS_REGISTRY)
@@ -96,7 +92,7 @@ PRIMITIVE(kill) {
 
 PRIMITIVE(bundled_images) {
 #ifdef TOIT_FREERTOS
-  const uword* table = &_thread_local_end;
+  const uword* table = OS::image_bundled_programs_table();
   int length = table[0];
 
   Array* result = process->object_heap()->allocate_array(length * 2, Smi::from(0));

--- a/src/resources/image.cc
+++ b/src/resources/image.cc
@@ -99,11 +99,11 @@ PRIMITIVE(writer_commit) {
   // If there are extra bytes after the program, they represent assets associated
   // with the program image. Check that the size of the encoded assets is within
   // bounds and mark the metadata to indicate the presence of the assets.
-  int program_size = output->program_size();
-  int assets_extra = image.byte_size() - program_size;
+  uword program_size = output->program_size();
+  uword assets_extra = image.byte_size() - program_size;
   if (assets_extra > 0) {
     uword assets_address = reinterpret_cast<uword>(image.begin()) + program_size;
-    int assets_length = *reinterpret_cast<uint32*>(assets_address);
+    uword assets_length = *reinterpret_cast<uint32*>(assets_address);
     if (assets_length + sizeof(uint32) > assets_extra) OUT_OF_BOUNDS;
     // TODO(kasper): Can we get the metadata to already contain the right bits
     // from the get go? Right now, we ignore the bits put in there when

--- a/tools/firmware.toit
+++ b/tools/firmware.toit
@@ -741,8 +741,8 @@ inject_config config/Map unique_id/uuid.Uuid bits/ByteArray -> ByteArray:
 
   bits.replace image_data_offset (ByteArray image_data_size)  // Zero out area.
   bits.replace image_data_offset config_data
-  bits.replace image_data_offset + image_config_size unique_id.to_byte_array
-  bits.replace image_data_offset + image_data_size - 4 bundled_programs_table_address
+  bits.replace (image_data_offset + image_config_size) unique_id.to_byte_array
+  bits.replace (image_data_offset + image_data_size - 4) bundled_programs_table_address
   return bits
 
 // Searches for two magic numbers that surround the image data area.


### PR DESCRIPTION
Now communicated through the image info blob, instead of relying on weird link table entries.