### PR TITLE
Revive the dump_heap primitive, more detailed malloc report.

### DIFF
--- a/lib/esp32.toit
+++ b/lib/esp32.toit
@@ -137,7 +137,7 @@ rtc_user_bytes -> ByteArray:
   #primitive.esp32.rtc_user_bytes
 
 /**
-Produces (as a system message) a report over the usage of memory at the OS level.
+Sends (as a system message) a report over the usage of memory at the OS level.
 */
 memory_page_report -> none:
   report := memory_page_report_
@@ -145,3 +145,13 @@ memory_page_report -> none:
 
 memory_page_report_ -> ByteArray:
   #primitive.esp32.memory_page_report
+
+/**
+Sends (as a system message) a detailed report over the usage of memory at the OS level.
+*/
+dump_heap -> none:
+  report := dump_heap_ 300
+  send_trace_message report
+
+dump_heap_ slack/int -> ByteArray:
+  #primitive.core.dump_heap

--- a/src/heap_report.cc
+++ b/src/heap_report.cc
@@ -227,12 +227,12 @@ class SerialFragmentationDumper : public HeapFragmentationDumper {
 };
 
 void dump_heap_fragmentation(output_char_t* output_char_fn) {
-  const char* p = "toit serial decode ";
+  const char* p = "jag decode ";
   while (*p) output_char_fn(*p++);
 
   SerialFragmentationDumper dumper(output_char_fn);
 
-  int flags = MALLOC_ITERATE_ALL_ALLOCATIONS | MALLOC_ITERATE_UNALLOCATED | MALLOC_ITERATE_UNLOCKED;
+  int flags = MALLOC_ITERATE_ALL_ALLOCATIONS | MALLOC_ITERATE_UNALLOCATED;
   int caps = OS::toit_heap_caps_flags_for_heap();
   heap_caps_iterate_tagged_memory_areas(&dumper, null, HeapFragmentationDumper::log_allocation, flags, caps);
   if (!dumper.has_overflow()) {

--- a/system/containers.toit
+++ b/system/containers.toit
@@ -350,8 +350,8 @@ trace_using_print message/ByteArray --from=0 --to=message.size:
     end := i >= to - BLOCK_SIZE
     prefix := i == from ? "jag decode " : ""
     base64_text := base64.encode message[i..(end ? to : i + BLOCK_SIZE)]
-    postfix := end ? "" : "\\"
-    print_ "$prefix$base64_text$postfix"
+    postfix := end ? "\n" : ""
+    write_on_stderr_ "$prefix$base64_text$postfix" false
 
 trace_find_origin_id trace/ByteArray -> uuid.Uuid?:
   // Short strings are encoded with a single unsigned byte length ('U').

--- a/system/containers.toit
+++ b/system/containers.toit
@@ -354,7 +354,7 @@ trace_using_print message/ByteArray --from=0 --to=message.size:
     prefix := i == from ? "jag decode " : ""
     base64_text := base64.encode message[i..(end ? to : i + BLOCK_SIZE)]
     postfix := end ? "\n" : ""
-    write_on_stderr_ "$prefix$base64_text$postfix" false
+    write_on_stdout_ "$prefix$base64_text$postfix" false
 
 trace_find_origin_id trace/ByteArray -> uuid.Uuid?:
   // Short strings are encoded with a single unsigned byte length ('U').


### PR DESCRIPTION
This report needs a bit more memory, but shows the fragmentation for each 8-byte memory cell.  For it to work we need to output the base64 data in a single line (recognized by Jaguar).