### PR TITLE
Reserve 'catch', 'throw', 'rethrow' and 'switch'.

### DIFF
--- a/src/compiler/ir.h
+++ b/src/compiler/ir.h
@@ -519,6 +519,7 @@ class Method : public Node {
       , _plain_shape(shape)
       , _is_abstract(is_abstract)
       , _does_not_return(false)
+      , _is_runtime_method(false)
       , _kind(kind)
       , _range(range)
       , _body(null)
@@ -586,6 +587,9 @@ class Method : public Node {
   bool does_not_return() const { return _does_not_return; }
   void mark_does_not_return() { _does_not_return = true; }
 
+  bool is_runtime_method() const { return _is_runtime_method; }
+  void mark_runtime_method() { _is_runtime_method = true; }
+
   Type return_type() const { return _return_type; }
   void set_return_type(Type type) {
     ASSERT(!_return_type.is_valid());
@@ -636,6 +640,7 @@ class Method : public Node {
 
   const bool _is_abstract;
   bool _does_not_return;
+  bool _is_runtime_method;
   const MethodKind _kind;
   const Source::Range _range;
 

--- a/src/compiler/ir.h
+++ b/src/compiler/ir.h
@@ -500,6 +500,7 @@ class Method : public Node {
       , _plain_shape(PlainShape::invalid())
       , _is_abstract(is_abstract)
       , _does_not_return(false)
+      , _is_runtime_method(false)
       , _kind(kind)
       , _range(range)
       , _body(null)

--- a/src/compiler/resolver.cc
+++ b/src/compiler/resolver.cc
@@ -97,7 +97,6 @@ ir::Program* Resolver::resolve(const std::vector<ast::Unit*>& units,
   mark_runtime(modules[core_index]);
   mark_non_returning(modules[core_index]);
 
-
   setup_inheritance(modules, core_index);
 
   fill_classes_with_skeletons(modules);

--- a/src/compiler/resolver.cc
+++ b/src/compiler/resolver.cc
@@ -94,14 +94,17 @@ ir::Program* Resolver::resolve(const std::vector<ast::Unit*>& units,
   auto modules = build_modules(units, entry_index, core_index);
   build_module_scopes(modules);
 
-  mark_runtime_classes(modules[core_index]);
+  mark_runtime(modules[core_index]);
   mark_non_returning(modules[core_index]);
+
 
   setup_inheritance(modules, core_index);
 
   fill_classes_with_skeletons(modules);
 
   check_clashing_or_conflicting(modules);
+
+  check_future_reserved_globals(modules);
 
   report_abstract_classes(modules);
   check_interface_implementations_and_flatten(modules);
@@ -201,7 +204,12 @@ std::vector<Module*> Resolver::build_modules(const std::vector<ast::Unit*>& unit
       if (auto method = declaration->as_Method()) {
         Symbol name = Symbol::invalid();
         ir::Method::MethodKind kind;
-        check_method(method, null, &name, &kind);
+        // For top-level methods we don't weed out future-reserved identifiers
+        // at this stage. We are not allowed to give warnings for identifiers that
+        // come from the core libraries, and we don't (easily) know yet whether the
+        // current method is part of the core libraries.
+        bool allow_future_reserved = true;
+        check_method(method, null, &name, &kind, allow_future_reserved);
         ASSERT(kind == ir::Method::GLOBAL_FUN);
         auto shape = ResolutionShape::for_static_method(method);
         ir::Method* ir = _new ir::MethodStatic(name,
@@ -577,6 +585,24 @@ void Resolver::check_clashing_or_conflicting(std::vector<Module*> modules) {
         auto& vector = member_declarations[name];
         auto list = ListBuilder<ir::Node*>::build_from_vector(vector);
         check_clashing_or_conflicting(name, list);
+      }
+    }
+  }
+}
+
+void Resolver::check_future_reserved_globals(std::vector<Module*> modules) {
+  // We have checked already all identifiers except for globals. This is,
+  // because we didn't know yet which methods were from the core libraries.
+  // This information is present now.
+  for (auto module : modules) {
+    for (auto method : module->methods()) {
+      if (method->is_runtime_method()) continue;
+      auto name = method->name();
+      if (Symbols::is_future_reserved(name)) {
+        auto ast_name = _ir_to_ast_map.at(method)->as_Method()->name_or_dot();
+        report_warning(ast_name,
+                       "Name '%s' will be reserved in future releases",
+                       name.c_str());
       }
     }
   }
@@ -1018,16 +1044,19 @@ void Resolver::build_module_scopes(std::vector<Module*>& modules) {
   resolve_shows_and_exports(modules);
 }
 
-void Resolver::mark_runtime_classes(Module* core_module) {
+void Resolver::mark_runtime(Module* core_module) {
   UnorderedSet<Module*> finished_modules;
 
   std::function<void (Module*)> mark;
   mark = [&](Module* module) {
     if (finished_modules.contains(module)) return;
     finished_modules.insert(module);
+
     for (auto klass : module->classes()) {
-      if (klass->is_runtime_class()) return;
       klass->mark_runtime_class();
+    }
+    for (auto method : module->methods()) {
+      method->mark_runtime_method();
     }
 
     for (auto imported : module->imported_modules()) {
@@ -1387,7 +1416,8 @@ class HasExplicitReturnVisitor : public ast::TraversingVisitor {
 };
 
 void Resolver::check_method(ast::Method* method, ir::Class* holder,
-                            Symbol* name, ir::Method::MethodKind* kind) {
+                            Symbol* name, ir::Method::MethodKind* kind,
+                            bool allow_future_reserved) {
   bool is_toplevel = holder == null;
   bool class_is_interface = is_toplevel ? false : holder->is_interface();
   auto class_name = is_toplevel ? Symbol::invalid() : holder->name();
@@ -1416,6 +1446,14 @@ void Resolver::check_method(ast::Method* method, ir::Class* holder,
                  "Can't use '%s' as name for a %s",
                  name->c_str(),
                  is_named_constructor_or_factory ? "constructor" : "method");
+  }
+  if (Symbols::is_future_reserved(*name)) {
+    // Some core methods are allowed to have the reserved identifier for now.
+    if (!is_toplevel || !allow_future_reserved) {
+      diagnostics()->report_warning(ast_name_node,
+                                    "Name '%s' will be reserved in future releases",
+                                    name->c_str());
+    }
   }
   auto method_is_abstract = method->is_abstract();
   auto is_static = method->is_static();
@@ -1532,6 +1570,11 @@ void Resolver::check_field(ast::Field* field, ir::Class* holder) {
   if (Symbols::is_reserved(name)) {
     report_error(field->name(), "Can't use '%s' as name for a field", name.c_str());
   }
+  if (Symbols::is_future_reserved(name)) {
+    diagnostics()->report_warning(field->name(),
+                                  "Name '%s' will be reserved in future releases",
+                                  name.c_str());
+  }
   if (field->is_abstract()) {
     report_error(field, "Fields can't be abstract");
   }
@@ -1549,6 +1592,11 @@ void Resolver::check_class(ast::Class* klass) {
     report_error(klass->name(), "Can't use '%s' as name for a %s",
                  name.c_str(),
                  klass->is_interface() ? "interface" : "class");
+  }
+  if (Symbols::is_future_reserved(name)) {
+    diagnostics()->report_warning(klass->name(),
+                                  "Name '%s' will be reserved in future releases",
+                                  name.c_str());
   }
 }
 
@@ -1594,7 +1642,8 @@ void Resolver::fill_classes_with_skeletons(std::vector<Module*> modules) {
           auto method = member->as_Method();
           auto method_is_abstract = method->is_abstract();
 
-          check_method(method, ir_class, &member_name, &kind);
+          bool allow_future_reserved;
+          check_method(method, ir_class, &member_name, &kind, allow_future_reserved = false);
 
           auto position = method->range();
           ir::Method* ir_method = null;

--- a/src/compiler/resolver.h
+++ b/src/compiler/resolver.h
@@ -82,8 +82,9 @@ class Resolver {
 
   void check_clashing_or_conflicting(Symbol name, List<ir::Node*> declarations);
   void check_clashing_or_conflicting(std::vector<Module*> modules);
+  void check_future_reserved_globals(std::vector<Module*> modules);
 
-  void mark_runtime_classes(Module* core_module);
+  void mark_runtime(Module* core_module);
   void mark_non_returning(Module* core_module);
 
   void setup_inheritance(std::vector<Module*> modules, int core_module_index);
@@ -95,7 +96,8 @@ class Resolver {
   List<ir::Type> find_literal_types(Module* core_module);
   ir::Constructor* build_default_constructor(ir::Class* klass, bool* detected_error);
   void check_method(ast::Method* method, ir::Class* holder,
-                    Symbol* name, ir::Method::MethodKind* kind);
+                    Symbol* name, ir::Method::MethodKind* kind,
+                    bool allow_future_reserved);
   void check_field(ast::Field* method, ir::Class* holder);
   void check_class(ast::Class* klass);
   void fill_classes_with_skeletons(std::vector<Module*> modules);

--- a/src/compiler/resolver_method.cc
+++ b/src/compiler/resolver_method.cc
@@ -1250,6 +1250,9 @@ void MethodResolver::_resolve_parameters(
     } else if (is_reserved_identifier(name)) {
       report_error(parameter, "Can't use '%s' as name for a parameter", name.c_str());
     } else if (name.is_valid()) {
+      if (is_future_reserved_identifier(name)) {
+        diagnostics()->report_warning(parameter, "Name '%s' will be reserved in future releases", name.c_str());
+      }
       if (existing.contains(name)) {
         diagnostics()->start_group();
         report_error(parameter, "Duplicate parameter '%s'", name.c_str());
@@ -1612,6 +1615,9 @@ void MethodResolver::visit_TryFinally(ast::TryFinally* node) {
       if (name == first_name) {
         report_error(ast_parameter, "Duplicate parameter '%s'", name.c_str());
       }
+    }
+    if (is_future_reserved_identifier(name)) {
+      diagnostics()->report_warning(ast_parameter, "Name '%s' will be reserved in future releases", name.c_str());
     }
 
     bool has_explicit_type = ast_parameter->type() != null;
@@ -3297,6 +3303,9 @@ ir::Expression* MethodResolver::_define(ast::Expression* node,
   if (is_reserved_identifier(ast_name)) {
     report_error(ast_name, "Can't use '%s' as name for a local variable", name.c_str());
   } else {
+    if (is_future_reserved_identifier(name)) {
+      diagnostics()->report_warning(ast_name, "Name '%s' will be reserved in future releases", name.c_str());
+    }
     auto lookup_result = lookup(ast_name);
     auto entry = lookup_result.entry;
     switch (entry.kind()) {

--- a/src/compiler/resolver_method.h
+++ b/src/compiler/resolver_method.h
@@ -201,6 +201,9 @@ class MethodResolver : public ast::Visitor {
   bool is_reserved_identifier(Symbol symbol) {
     return Symbols::is_reserved(symbol);
   }
+  bool is_future_reserved_identifier(Symbol symbol) {
+    return Symbols::is_future_reserved(symbol);
+  }
   bool is_sdk_protected_identifier(Symbol symbol);
 
   void check_sdk_protection(Symbol name,

--- a/src/compiler/token.h
+++ b/src/compiler/token.h
@@ -181,7 +181,9 @@ enum Precedence {
   I(program_failure_)                                          \
   I(locked_)                                                   \
   IN(throw_, "throw")                                          \
-  IN(rethrow, "rethrow")                                       \
+  IN(catch_, "catch")                                          \
+  I(rethrow)                                                   \
+  IN(switch_, "switch")                                        \
   IN(stack_, "<stack>")                                        \
   I(Array_)                                                    \
   I(Box_)                                                      \
@@ -286,6 +288,12 @@ ENTRY_POINTS(E)
         name == Symbols::super ||
         name == Symbols::constructor ||
         name == Symbols::_;
+  }
+  static bool is_future_reserved(Symbol name) {
+    return name == Symbols::throw_ ||
+        name == Symbols::rethrow ||
+        name == Symbols::catch_ ||
+        name == Symbols::switch_;
   }
 };
 

--- a/tests/health/gold/sdk/tests__fuzzer__lib__core__core.toit.gold
+++ b/tests/health/gold/sdk/tests__fuzzer__lib__core__core.toit.gold
@@ -1,3 +1,9 @@
+tests/fuzzer/lib/core/core.toit:7:1: warning: Name 'throw' will be reserved in future releases
+throw exception:
+^~~~~
+tests/fuzzer/lib/core/core.toit:8:1: warning: Name 'rethrow' will be reserved in future releases
+rethrow exception trace:
+^~~~~~~
 tests/fuzzer/lib/core/core.toit:5:9: error: Unresolved identifier: 'fail'
 always: fail  // So that we don't need to worry if a test succeeds.
         ^~~~

--- a/tests/negative/future_reserved_test.toit
+++ b/tests/negative/future_reserved_test.toit
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+class throw:
+  catch := 22
+  throw := 22
+  switch := 22
+  rethrow := 99
+
+class catch:
+class switch:
+class rethrow:
+
+throw catch switch:
+catch x y z:
+switch x y z:
+rethrow x y z:
+
+main:
+  throw := 499
+  catch := 42
+  switch := 0
+  rethrow := 22
+  print throw + catch + switch + rethrow

--- a/tests/negative/gold/future_reserved_test.gold
+++ b/tests/negative/gold/future_reserved_test.gold
@@ -1,0 +1,79 @@
+tests/negative/future_reserved_test.toit:5:7: warning: Name 'throw' will be reserved in future releases
+class throw:
+      ^~~~~
+tests/negative/future_reserved_test.toit:11:7: warning: Name 'catch' will be reserved in future releases
+class catch:
+      ^~~~~
+tests/negative/future_reserved_test.toit:12:7: warning: Name 'switch' will be reserved in future releases
+class switch:
+      ^~~~~~
+tests/negative/future_reserved_test.toit:13:7: warning: Name 'rethrow' will be reserved in future releases
+class rethrow:
+      ^~~~~~~
+tests/negative/future_reserved_test.toit:6:3: warning: Name 'catch' will be reserved in future releases
+  catch := 22
+  ^~~~~
+tests/negative/future_reserved_test.toit:7:3: warning: Name 'throw' will be reserved in future releases
+  throw := 22
+  ^~~~~
+tests/negative/future_reserved_test.toit:8:3: warning: Name 'switch' will be reserved in future releases
+  switch := 22
+  ^~~~~~
+tests/negative/future_reserved_test.toit:9:3: warning: Name 'rethrow' will be reserved in future releases
+  rethrow := 99
+  ^~~~~~~
+tests/negative/future_reserved_test.toit:15:1: error: Redefinition of 'throw' as method
+throw catch switch:
+^~~~~
+tests/negative/future_reserved_test.toit:5:7: note: First definition of 'throw'
+class throw:
+      ^~~~~
+tests/negative/future_reserved_test.toit:16:1: error: Redefinition of 'catch' as method
+catch x y z:
+^~~~~
+tests/negative/future_reserved_test.toit:11:7: note: First definition of 'catch'
+class catch:
+      ^~~~~
+tests/negative/future_reserved_test.toit:17:1: error: Redefinition of 'switch' as method
+switch x y z:
+^~~~~~
+tests/negative/future_reserved_test.toit:12:7: note: First definition of 'switch'
+class switch:
+      ^~~~~~
+tests/negative/future_reserved_test.toit:18:1: error: Redefinition of 'rethrow' as method
+rethrow x y z:
+^~~~~~~
+tests/negative/future_reserved_test.toit:13:7: note: First definition of 'rethrow'
+class rethrow:
+      ^~~~~~~
+tests/negative/future_reserved_test.toit:15:1: warning: Name 'throw' will be reserved in future releases
+throw catch switch:
+^~~~~
+tests/negative/future_reserved_test.toit:16:1: warning: Name 'catch' will be reserved in future releases
+catch x y z:
+^~~~~
+tests/negative/future_reserved_test.toit:17:1: warning: Name 'switch' will be reserved in future releases
+switch x y z:
+^~~~~~
+tests/negative/future_reserved_test.toit:18:1: warning: Name 'rethrow' will be reserved in future releases
+rethrow x y z:
+^~~~~~~
+tests/negative/future_reserved_test.toit:15:7: warning: Name 'catch' will be reserved in future releases
+throw catch switch:
+      ^~~~~
+tests/negative/future_reserved_test.toit:15:13: warning: Name 'switch' will be reserved in future releases
+throw catch switch:
+            ^~~~~~
+tests/negative/future_reserved_test.toit:21:3: warning: Name 'throw' will be reserved in future releases
+  throw := 499
+  ^~~~~
+tests/negative/future_reserved_test.toit:22:3: warning: Name 'catch' will be reserved in future releases
+  catch := 42
+  ^~~~~
+tests/negative/future_reserved_test.toit:23:3: warning: Name 'switch' will be reserved in future releases
+  switch := 0
+  ^~~~~~
+tests/negative/future_reserved_test.toit:24:3: warning: Name 'rethrow' will be reserved in future releases
+  rethrow := 22
+  ^~~~~~~
+Compilation failed.


### PR DESCRIPTION
We probably want to make these reserved identifiers.