### PR TITLE
feat(dns): Query AAAA records from DNS resolver

### DIFF
--- a/lib/net/modules/dns.toit
+++ b/lib/net/modules/dns.toit
@@ -60,19 +60,17 @@ class DnsQuery_:
     id = random 0x10000
 
   /**
-  Look up a domain name.
+  Look up a domain name and return A or AAAA record.
 
   If given a numeric address like "127.0.0.1" it merely parses
     the numbers without a network round trip.
 
   By default the server is "8.8.8.8" which is the Google DNS
     service.
-
-  Currently only works for IPv4, not IPv6.
   */
   get -> net.IpAddress
       --server/string="8.8.8.8"
-      --accept_aaaa/bool=false
+      --accept_ipv6/bool=false
       --timeout/Duration=DNS_DEFAULT_TIMEOUT:
     if ip_string_:
       return net.IpAddress.parse name
@@ -83,7 +81,7 @@ class DnsQuery_:
     if hit: return hit
 
     query := create_query name id RECORD_A
-    if accept_aaaa:
+    if accept_ipv6:
       query = create_query name id RECORD_AAAA
 
     socket := udp.Socket

--- a/tests/dns_test.toit
+++ b/tests/dns_test.toit
@@ -32,9 +32,9 @@ ipv6_address_test:
   expect_equals "102:304:506:708:90a:b0c:d0e:f10" addr.stringify
 
 ipv6_dns_test:
-  dns_query := DnsQuery_ "ipv6.google.com"
-  ipv6 := dns_query.get --server="8.8.8.8" --accept_aaaa=true
-  expect ipv6.stringify == "2a00:1450:4005:802:0:0:0:200e"
+  dns_query := DnsQuery_ "google.com"
+  ipv6 := dns_query.get --server="8.8.8.8" --accept_ipv6=true
+  expect ipv6.stringify == "2a00:1450:4005:80b:0:0:0:200e"
 
 cache_test:
   // Prime cache.

--- a/tests/dns_test.toit
+++ b/tests/dns_test.toit
@@ -32,9 +32,9 @@ ipv6_address_test:
   expect_equals "102:304:506:708:90a:b0c:d0e:f10" addr.stringify
 
 ipv6_dns_test:
-  dns_query := DnsQuery_ "google.com"
+  dns_query := DnsQuery_ "www.rwth-aachen.de"
   ipv6 := dns_query.get --server="8.8.8.8" --accept_ipv6=true
-  expect ipv6.stringify == "2a00:1450:4005:80b:0:0:0:200e"
+  expect ipv6.stringify == "2a00:8a60:450:0:0:0:107:63"
 
 cache_test:
   // Prime cache.

--- a/tests/dns_test.toit
+++ b/tests/dns_test.toit
@@ -10,6 +10,7 @@ import net
 main:
   localhost_test
   ipv6_address_test
+  ipv6_dns_test
   cache_test
   fail_test
   long_test
@@ -29,6 +30,11 @@ ipv6_address_test:
     9, 10, 11, 12, 13, 14, 15, 16
   ]
   expect_equals "102:304:506:708:90a:b0c:d0e:f10" addr.stringify
+
+ipv6_dns_test:
+  dns_query := DnsQuery_ "ipv6.google.com"
+  ipv6 := dns_query.get --server="8.8.8.8" --accept_aaaa=true
+  expect ipv6.stringify == "2a00:1450:4005:802:0:0:0:200e"
 
 cache_test:
   // Prime cache.


### PR DESCRIPTION
This an initial PR to support IPv6 on the Toit platform. @floitsch @erikcorry