### PR TITLE
Fix UART.

### DIFF
--- a/src/resources/uart_esp32.cc
+++ b/src/resources/uart_esp32.cc
@@ -290,9 +290,9 @@ PRIMITIVE(write) {
 
   int wrote;
   if (break_length > 0) {
-    wrote = uart_write_bytes_with_break_non_blocking(uart->port(), reinterpret_cast<const char*>(tx), to - from, break_length);
+    wrote = uart_write_bytes_with_break(uart->port(), reinterpret_cast<const char*>(tx), to - from, break_length);
   } else {
-    wrote = uart_write_bytes_non_blocking(uart->port(), reinterpret_cast<const char*>(tx), to - from);
+    wrote = uart_write_bytes(uart->port(), reinterpret_cast<const char*>(tx), to - from);
   }
   if (wrote == -1) {
     OUT_OF_RANGE;

--- a/src/resources/uart_posix.cc
+++ b/src/resources/uart_posix.cc
@@ -171,6 +171,9 @@ class UARTResourceGroup : public ResourceGroup {
     // Disable special handling of bytes on receive. Just give the raw data.
     tty.c_iflag &= ~(IGNBRK|BRKINT|PARMRK|ISTRIP|INLCR|IGNCR|ICRNL);
 
+    // Disable software flow control.
+    tty.c_iflag &= ~(IXON|IXOFF|IXANY);
+
     // Disable any special handling for the output.
     tty.c_oflag &= ~OPOST;
     tty.c_oflag &= ~ONLCR;

--- a/tests/esp32/uart_big_data_read.toit
+++ b/tests/esp32/uart_big_data_read.toit
@@ -1,0 +1,33 @@
+// Copyright (C) 2022 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+/**
+Tests sending bigger chunks.
+
+Setup: see uart_big_data_shared.toit.
+*/
+
+import expect show *
+import gpio
+import uart
+import .uart_big_data_shared
+
+main:
+  port/uart.Port := ?
+  if platform == "FreeRTOS":
+    port = uart.Port --rx=(gpio.Pin RX) --tx=null --baud_rate=BAUD_RATE
+  else:
+    port = uart.Port UART_PATH --baud_rate=BAUD_RATE
+
+  data := #[]
+  TEST_ITERATIONS.repeat:
+    while true:
+      chunk := port.read
+      data += chunk
+      if data.size >= TEST_BYTES.size:
+        check_read_data data[..TEST_BYTES.size]
+        data = data[TEST_BYTES.size..]
+        break
+
+  port.close

--- a/tests/esp32/uart_big_data_shared.toit
+++ b/tests/esp32/uart_big_data_shared.toit
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+/**
+Tests sending bigger chunks.
+
+Setup:
+Connect GND of one ESP32 to GND of another ESP32.
+Connect pin 18 of the first ESP32 to pin 19 of the second ESP32.
+Connect pin 19 of the first ESP32 to pin 18 of the second ESP32.
+
+Run uart_big_data_read.toit on one ESP32 and uart_big_data_write.toit on the other.
+
+For the host-test, use a flasher and connect GND to GND of the flasher.
+Connect pin 18 of the ESP32 to the RX pin of the flasher.
+Connect pin 19 of the ESP32 to the TX pin of the flasher.
+If necessary, adjust the $UART_PATH.
+*/
+
+import expect show *
+
+TEST_ITERATIONS := 10
+
+RX ::= 18
+TX ::= 19
+UART_PATH ::= "/dev/ttyUSB1"
+BAUD_RATE ::= 115200
+
+TEST_BYTES := ByteArray 4096:
+  b := it & 0xFF
+  b == 0 ? it >> 8 : b
+
+check_read_data data/ByteArray:
+  expect_equals TEST_BYTES.size data.size
+  if TEST_BYTES != data:
+    for i := 0; i < TEST_BYTES.size; i++:
+      if TEST_BYTES[i] != data[i]:
+        print "Mismatch at $i: $TEST_BYTES[i] != $data[i]"
+        print TEST_BYTES[max 0 (i - 3)..min data.size (i + 3)]
+        print data[max 0 (i - 3)..min data.size (i + 3)]
+  expect_equals TEST_BYTES data

--- a/tests/esp32/uart_big_data_write.toit
+++ b/tests/esp32/uart_big_data_write.toit
@@ -1,0 +1,30 @@
+// Copyright (C) 2022 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+/**
+Tests sending bigger chunks.
+
+Setup: see uart_big_data_shared.toit.
+*/
+
+import expect show *
+import gpio
+import uart
+import writer
+import .uart_big_data_shared
+
+
+main:
+  port/uart.Port := ?
+  if platform == "FreeRTOS":
+    port = uart.Port --rx=null --tx=(gpio.Pin TX) --baud_rate=BAUD_RATE
+  else:
+    port = uart.Port UART_PATH --baud_rate=BAUD_RATE
+
+  TEST_ITERATIONS.repeat:
+    writer := writer.Writer port
+    writer.write TEST_BYTES
+    sleep --ms=200
+
+  port.close


### PR DESCRIPTION
The host was discarding flow-control characters (0x11, 0x13), and the devices were dropping data due to the non-blocking patch.