### PR TITLE
Disallow use of some GPIO pins.

### DIFF
--- a/src/primitive.h
+++ b/src/primitive.h
@@ -505,7 +505,7 @@ namespace toit {
 
 #define MODULE_GPIO(PRIMITIVE)               \
   PRIMITIVE(init, 0)                         \
-  PRIMITIVE(use, 2)                          \
+  PRIMITIVE(use, 3)                          \
   PRIMITIVE(unuse, 2)                        \
   PRIMITIVE(config, 6)                       \
   PRIMITIVE(get, 1)                          \


### PR DESCRIPTION
When using one of the flash/PSRAM pins the system crashes.

Resources for the documentation:
ESP32: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html
ESP32C3: https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-reference/peripherals/gpio.html
ESP32S3: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/gpio.html