### PR TITLE
Add generic CRC algorithm

### DIFF
--- a/lib/crypto/crc.toit
+++ b/lib/crypto/crc.toit
@@ -13,7 +13,7 @@ Cyclic Redundancy Check (CRC).
 CRC is an error-detection code.
 
 See https://en.wikipedia.org/wiki/Cyclic_redundancy_check
-and https://crccalc.com/
+  and https://crccalc.com/
 */
 
 class Crc extends Checksum:

--- a/lib/crypto/crc.toit
+++ b/lib/crypto/crc.toit
@@ -1,6 +1,9 @@
-// Copyright (C) 2020 Toitware ApS. All rights reserved.
+// Copyright (C) 2022 Toitware ApS. All rights reserved.
 // Use of this source code is governed by an MIT-style license that can be
 // found in the lib/LICENSE file.
+
+import binary show LITTLE_ENDIAN
+import expect show *
 
 import .checksum
 
@@ -9,35 +12,212 @@ Cyclic Redundancy Check (CRC).
 
 CRC is an error-detection code.
 
-See https://en.wikipedia.org/wiki/Cyclic_redundancy_check.
+See https://en.wikipedia.org/wiki/Cyclic_redundancy_check
+and https://crccalc.com/
 */
 
-/** Base for Cyclic Redundancy Check (CRC) algorithms. */
-abstract class CrcBase extends Checksum:
+class Crc extends Checksum:
+  width/int
+  polynomial/int
+  table_/List? := null
+  little_endian/bool
+  xor_result/int
+  static cache_ := {:}
+
   sum_/int := ?
 
-  /** Constructs a CRC state with the given $sum_. */
-  constructor .sum_:
+  hash_code -> int:
+    return width ^ polynomial
 
-  abstract crc_table_ -> List
+  operator == other -> bool:
+    if not other is Crc: return false
+    return polynomial == other.polynomial
+        and little_endian == other.little_endian
+        and width == other.width
+
+  /**
+  Construct a CRC that processes bits in little-endian-first order.
+  The $polynomial is an integer encoding of width $width with the most
+    significant bit representing the x^0 term, and the least significant
+    bit representing the x^width-1 term.  This is the little endian
+    (reversed) ordering for the polynomial.
+
+  # Example
+  ```
+  // The popular CRC-32 used in PNG.
+  crc := Crc.little_endian 32 --polynomial=0xEDB88320 --initial_state=0xffff_ffff --xor_result=0xffff_ffff
+  ```
+  */
+  constructor.little_endian .width/int --.polynomial/int --initial_state/int=0 --.xor_result/int=0:
+    if polynomial > 1 << width: throw "Polynomial and width don't match"
+    little_endian = true
+    sum_=initial_state
+    if cache_.contains this:
+      table_ = cache_[this]
+    else:
+      table_ = calculate_table_little_endian_ width polynomial
+      cache_[this] = table_
+
+  /**
+  Construct a CRC that processes bits in little-endian-first order.
+  The $normal_polynomial is an integer encoding of width $width with the least
+    significant bit representing the x^0 term, and the most significant bit
+    representing the x^width-1 term.  This is the normal ordering for the
+    polynomial.
+
+  # Example
+  ```
+  // The popular CRC-32 used in PNG.
+  crc := Crc.little_endian 32 --normal_polynomial=0x04C11DB7 --initial_state=0xffff_ffff --xor_result=0xffff_ffff
+  ```
+  */
+  constructor.little_endian width/int --normal_polynomial/int --initial_state/int=0 --xor_result/int=0:
+    polynomial := 0
+    for i := 0; i < width; i++:
+      if (normal_polynomial >> i) & 1 == 1:
+        polynomial |= 1 << (width - 1 - i)
+    return Crc.little_endian width --polynomial=polynomial --initial_state=initial_state --xor_result=xor_result
+
+  /**
+  Construct a CRC that processes bits in little-endian-first order.
+  The $powers are a list of the powers in the representation of the
+    CRC polynormial.
+  The power corresponding to the width (32 for the x³² term in CRC-32)
+    can be omitted since it is implied by the width of the CRC.
+
+  # Example
+  ```
+  // The popular CRC-32 used in PNG.
+  // x³² + x²⁶ + x²³ + x²² + x¹⁶ + x¹² + x¹¹ + x¹⁰ + x⁸ + x⁷ + x⁵ + x⁴ + x² + x + 1.
+  crc := Crc.little_endian 32
+      --powers=[26, 23, 22, 16, 12, 11, 10, 8, 7, 5, 4, 2, 1, 0]
+      --initial_state=0xffff_ffff
+      --xor_result=0xffff_ffff
+  // Equivalently:
+  crc := Crc.little_endian 32
+      --powers=[32, 26, 23, 22, 16, 12, 11, 10, 8, 7, 5, 4, 2, 1, 0]
+      --initial_state=0xffff_ffff
+      --xor_result=0xffff_ffff
+  ```
+  */
+  constructor.little_endian width/int --powers/List --initial_state/int=0 --xor_result/int=0:
+    polynomial := 1 << (width - 1)
+    powers.do:
+      if 0 <= it < width:
+        polynomial |= 1 << width - 1 - it
+    return Crc.little_endian width --polynomial=polynomial --initial_state=initial_state --xor_result=xor_result
+
+  /**
+  Construct a CRC that processes bits in big-endian-first order.
+  The $polynomial is an integer encoding of width $width with the most
+    significant bit representing the x^0 term, and the least significant
+    bit representing the x^width-1 term.
+
+  # Example
+  ```
+  // The popular CRC-16 used in Xmodem.
+  crc := Crc.big_endian 16 --polynomial=0x1021
+  ```
+  */
+  constructor.big_endian .width/int --.polynomial/int --initial_state/int=0 --.xor_result/int=0:
+    if polynomial > 1 << width: throw "Polynomial and width don't match"
+    little_endian = false
+    sum_ = initial_state
+    if cache_.contains this:
+      table_ = cache_[this]
+    else:
+      table_ = calculate_table_big_endian_ width polynomial
+      cache_[this] = table_
+
+  /**
+  Construct a CRC that processes bits in big-endian-first order.
+  The $powers are a list of the powers in the representation of the
+    CRC polynormial.
+  The power corresponding to the width (32 for the x³² term in CRC-32)
+    can be omitted since it is implied by the width of the CRC.
+
+  # Example
+  ```
+  // The popular CRC-16 used in Xmodem.
+  crc := Crc.big_endian 16 --powers=[12, 5, 0]
+  // Equivalently:
+  crc := Crc.big_endian 16 --powers=[16, 12, 5, 0]
+  ```
+  */
+  constructor.big_endian width/int --powers/List --initial_state/int=0 --xor_result/int=0:
+    polynomial := 0
+    powers.do:
+      if 0 <= it < width:
+        polynomial |= 1 << it
+    return Crc.big_endian width --polynomial=polynomial --initial_state=initial_state --xor_result=xor_result
+
+  calculate_table_little_endian_ width/int polynomial/int -> List:
+    result := ?
+    if width <= 8:
+      result = ByteArray 256 --filler=0
+    else:
+      result = List 256: 0
+    crc := 1
+    for i := 128; i > 0 ; i >>= 1:
+      if crc & 1 == 0:
+        crc >>= 1
+      else:
+        crc = (crc >> 1) ^ polynomial
+      for j := 0; j < 256; j += i + i:
+        result[i + j] = crc ^ result[j]
+    return result
+
+  calculate_table_big_endian_ width/int polynomial/int -> List:
+    result := ?
+    if width <= 8:
+      result = ByteArray 256 --filler=0
+    else:
+      result = List 256: 0
+    hi_bit := 1 << (width - 1)
+    mask := width == 64 ? -1 : ((1 << width) - 1)
+    crc := hi_bit
+    for i := 1; i < 256 ; i <<= 1:
+      if crc & hi_bit == 0:
+        crc <<= 1
+      else:
+        crc = (crc << 1) ^ polynomial
+      crc &= mask
+      i.repeat:
+        result[i + it] = crc ^ result[it]
+    return result
 
   /** See $super. */
   add data from/int to/int -> none:
-    /* Karl Malbrain's compact CRC-32. See "A compact CCITT crc16 and crc32 C
-     * implementation that balances processor cache usage against speed":
-     * http://www.geocities.com/malbrain/
-     */
-    table ::= crc_table_
     sum := sum_
-    if data is string:
-      (to - from).repeat:
-        b := data.at --raw from + it
-        sum = (sum >> 4) ^ table[(sum & 0xF) ^ (b & 0xF)];
-        sum = (sum >> 4) ^ table[(sum & 0xF) ^ (b >> 4)];
+    if little_endian:
+      if data is string:
+        (to - from).repeat:
+          b := data.at --raw from + it
+          sum = (sum >>> 8) ^ table_[(b ^ sum) & 0xff]
+      else:
+        if data is not ByteArray: throw "WRONG_OBJECT_TYPE"
+        (to - from).repeat:
+          b := data[from + it]
+          sum = (sum >>> 8) ^ table_[(b ^ sum) & 0xff]
     else:
-      if data is not ByteArray: throw "WRONG_OBJECT_TYPE"
-      (to - from).repeat:
-        b := data[from + it]
-        sum = (sum >> 4) ^ table[(sum & 0xF) ^ (b & 0xF)];
-        sum = (sum >> 4) ^ table[(sum & 0xF) ^ (b >> 4)];
+      // Big endian.
+      mask := width == 64 ? -1 : ((1 << width) - 1)
+      if data is string:
+        (to - from).repeat:
+          b := data.at --raw from + it
+          sum = ((sum << 8) & mask) ^ table_[b ^ (sum >>> (width - 8))]
+      else:
+        if data is not ByteArray: throw "WRONG_OBJECT_TYPE"
+        (to - from).repeat:
+          b := data[from + it]
+          sum = ((sum << 8) & mask) ^ table_[b ^ (sum >>> (width - 8))]
     sum_ = sum
+
+  /**
+  See $super.
+
+  Returns the checksum as a width/4 element byte array in little-endian order.
+  */
+  get -> ByteArray:
+    checksum := sum_ ^ xor_result
+    return ByteArray (width + 7) / 8: (checksum >> (8 * it)) & 0xff

--- a/lib/crypto/crc.toit
+++ b/lib/crypto/crc.toit
@@ -44,19 +44,16 @@ class Crc extends Checksum:
 
   # Example
   ```
-  // The popular CRC-32 used in PNG.
+  // The CRC-32 used in PNG.
   crc := Crc.little_endian 32 --polynomial=0xEDB88320 --initial_state=0xffff_ffff --xor_result=0xffff_ffff
   ```
   */
   constructor.little_endian .width/int --.polynomial/int --initial_state/int=0 --.xor_result/int=0:
     if polynomial > 1 << width: throw "Polynomial and width don't match"
     little_endian = true
-    sum_=initial_state
-    if cache_.contains this:
-      table_ = cache_[this]
-    else:
-      table_ = calculate_table_little_endian_ width polynomial
-      cache_[this] = table_
+    sum_ = initial_state
+    table_ = cache_.get this
+        --init=: calculate_table_little_endian_ width polynomial
 
   /**
   Construct a CRC that processes bits in little-endian-first order.
@@ -67,7 +64,7 @@ class Crc extends Checksum:
 
   # Example
   ```
-  // The popular CRC-32 used in PNG.
+  // The CRC-32 used in PNG.
   crc := Crc.little_endian 32 --normal_polynomial=0x04C11DB7 --initial_state=0xffff_ffff --xor_result=0xffff_ffff
   ```
   */
@@ -87,7 +84,7 @@ class Crc extends Checksum:
 
   # Example
   ```
-  // The popular CRC-32 used in PNG.
+  // The CRC-32 used in PNG.
   // x³² + x²⁶ + x²³ + x²² + x¹⁶ + x¹² + x¹¹ + x¹⁰ + x⁸ + x⁷ + x⁵ + x⁴ + x² + x + 1.
   crc := Crc.little_endian 32
       --powers=[26, 23, 22, 16, 12, 11, 10, 8, 7, 5, 4, 2, 1, 0]
@@ -115,7 +112,7 @@ class Crc extends Checksum:
 
   # Example
   ```
-  // The popular CRC-16 used in Xmodem.
+  // The CRC-16 used in Xmodem.
   crc := Crc.big_endian 16 --polynomial=0x1021
   ```
   */
@@ -123,11 +120,8 @@ class Crc extends Checksum:
     if polynomial > 1 << width: throw "Polynomial and width don't match"
     little_endian = false
     sum_ = initial_state
-    if cache_.contains this:
-      table_ = cache_[this]
-    else:
-      table_ = calculate_table_big_endian_ width polynomial
-      cache_[this] = table_
+    table_ = cache_.get this
+        --init=: calculate_table_big_endian_ width polynomial
 
   /**
   Construct a CRC that processes bits in big-endian-first order.
@@ -158,7 +152,7 @@ class Crc extends Checksum:
     else:
       result = List 256: 0
     crc := 1
-    for i := 128; i > 0 ; i >>= 1:
+    for i := 128; i > 0; i >>= 1:
       if crc & 1 == 0:
         crc >>= 1
       else:
@@ -176,7 +170,7 @@ class Crc extends Checksum:
     hi_bit := 1 << (width - 1)
     mask := width == 64 ? -1 : ((1 << width) - 1)
     crc := hi_bit
-    for i := 1; i < 256 ; i <<= 1:
+    for i := 1; i < 256; i <<= 1:
       if crc & hi_bit == 0:
         crc <<= 1
       else:

--- a/lib/crypto/crc16.toit
+++ b/lib/crypto/crc16.toit
@@ -3,6 +3,7 @@
 // found in the lib/LICENSE file.
 
 import .checksum
+import .crc
 
 /**
 16-bit Cyclic redundancy check (CRC-16/XMODEM).
@@ -17,40 +18,11 @@ The $data must be a string or byte array.
 Returns the checksum as a 2 element byte array in little-endian order.
 */
 crc16 data from/int=0 to/int=data.size -> ByteArray:
-  return checksum Crc16 data from to
+  crc := Crc.big_endian 16 --polynomial=0x1021
+  crc.add data from to
+  return crc.get
 
 /** CRC-16/XMODEM checksum state. */
-class Crc16 extends Checksum:
-  sum_/int := 0
-
-  /** See $super. */
-  add data from/int to/int -> none:
-    sum := sum_
-    if data is string:
-      (to - from).repeat:
-        b := data.at --raw from + it
-        sum = update_ sum b
-    else:
-      if data is not ByteArray: throw "WRONG_OBJECT_TYPE"
-      (to - from).repeat:
-        b := data[from + it]
-        sum = update_ sum b
-    sum_ = sum
-
-  static update_ crc/int byte/int -> int:
-    crc = crc ^ (byte << 8)
-    8.repeat:
-      if crc & 0x8000 == 0:
-        crc <<= 1
-      else:
-        crc = (crc << 1) ^ 0x1021
-    return crc
-
-  /**
-  See $super.
-
-  Returns the CRC16 checksum as a 2 element byte array in little-endian order.
-  */
-  get -> ByteArray:
-    checksum := sum_
-    return ByteArray 2: (checksum >> (8 * it)) & 0xff
+class Crc16 extends Crc:
+  constructor:
+    super.big_endian 16 --polynomial=0x1021

--- a/lib/crypto/crc32.toit
+++ b/lib/crypto/crc32.toit
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Toitware ApS. All rights reserved.
+// Copyright (C) 2022 Toitware ApS. All rights reserved.
 // Use of this source code is governed by an MIT-style license that can be
 // found in the lib/LICENSE file.
 
@@ -14,26 +14,17 @@ The $data must be a string or byte array.
 Returns the checksum as a 4 element byte array in little-endian order.
 */
 crc32 data from/int=0 to/int=data.size -> ByteArray:
-  return checksum Crc32 data from to
-
-CRC32_TABLE_ ::= [
-  0, 0x1db71064, 0x3b6e20c8, 0x26d930ac, 0x76dc4190, 0x6b6b51f4, 0x4db26158,
-  0x5005713c, 0xedb88320, 0xf00f9344, 0xd6d6a3e8, 0xcb61b38c, 0x9b64c2b0,
-  0x86d3d2d4, 0xa00ae278, 0xbdbdf21c ]
+  crc := Crc.little_endian 32
+      --polynomial=0xEDB88320
+      --initial_state=0xffff_ffff
+      --xor_result=0xffff_ffff
+  crc.add data from to
+  return crc.get
 
 /** CRC-32 checksum state. */
-class Crc32 extends CrcBase:
-  /** Constructs a CRC-32 state. */
+class Crc32 extends Crc:
   constructor:
-    super 0xffffffff
-
-  crc_table_ -> List: return CRC32_TABLE_
-
-  /**
-  See $super.
-
-  Returns the CRC32 checksum as a 4 element byte array in little-endian order.
-  */
-  get -> ByteArray:
-    checksum := sum_ ^ 0xffffffff
-    return ByteArray 4: (checksum >> (8 * it)) & 0xff
+    super.little_endian 32
+        --polynomial=0xEDB88320
+        --initial_state=0xffff_ffff
+        --xor_result=0xffff_ffff

--- a/tests/crc_test.toit
+++ b/tests/crc_test.toit
@@ -1,0 +1,62 @@
+// Copyright (C) 2022 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import binary show LITTLE_ENDIAN
+import expect show *
+
+import crypto.crc show Crc
+import crypto.crc16 show Crc16
+import crypto.crc32 show Crc32
+
+main:
+  crc_polynomial_test
+
+  crc_32_test
+
+  crc_xmodem_test
+
+crc_polynomial_test -> none:
+  crc1 := Crc.little_endian 32 --polynomial=0xEDB88320
+  crc2 := Crc.little_endian 32 --normal_polynomial=0x04C11DB7
+  crc3 := Crc.little_endian 32 --powers=[26, 23, 22, 16, 12, 11, 10, 8, 7, 5, 4, 2, 1]
+  crc4 := Crc.little_endian 32 --powers=[32, 26, 23, 22, 16, 12, 11, 10, 8, 7, 5, 4, 2, 1, 0]
+
+  expect_equals crc1.polynomial crc2.polynomial
+  expect_equals crc1.polynomial crc3.polynomial
+  expect_equals crc1.polynomial crc4.polynomial
+  expect
+      identical crc1.table_ crc2.table_
+  expect
+      identical crc1.table_ crc3.table_
+  expect
+      identical crc1.table_ crc4.table_
+
+  crc5 := Crc.big_endian 16 --polynomial=0x1021
+  crc6 := Crc.big_endian 16 --powers=[12, 5, 0]
+  crc7 := Crc.big_endian 16 --powers=[16, 12, 5, 0]
+  expect_equals crc5.polynomial crc6.polynomial
+  expect_equals crc5.polynomial crc7.polynomial
+  expect
+      identical crc5.table_ crc6.table_
+  expect
+      identical crc5.table_ crc7.table_
+
+crc_32_test -> none:
+  [true, false].do: | manual |
+    [true, false].do: | use_string |
+      crc := ?
+      if manual:
+        crc = Crc.little_endian 32 --polynomial=0xEDB88320 --initial_state=0xffff_ffff --xor_result=0xffff_ffff
+      else:
+        crc = Crc32
+      if use_string:
+        crc.add "Hello, World!"
+      else:
+        crc.add #['H', 'e', 'l', 'l', 'o', ',', ' ', 'W', 'o', 'r', 'l', 'd', '!']
+      expect_equals 0xec4ac3d0 (LITTLE_ENDIAN.uint32 crc.get 0)
+
+crc_xmodem_test -> none:
+  crc := Crc16
+  crc.add "Hello, World!"
+  expect_equals #[0xd6, 0x4f] crc.get


### PR DESCRIPTION
Replaces the nibble-at-a-time CRC32 algorithm with a byte-at-a-time generic algorithm.
Replaces the bit-at-a-time CRC16 algorithm with a byte-at-a-time generic algorithm.