### PR TITLE
Ble extra params

### DIFF
--- a/lib/ble.toit
+++ b/lib/ble.toit
@@ -115,13 +115,13 @@ class AdvertisementData:
   */
   connectable/bool
 
-  constructor --.name=null --.service_classes=[] --.manufacturer_data=#[] --.connectable=false:
+  constructor --.name=null --.service_classes=[] --.manufacturer_data=#[] --.connectable=false --check_size=true:
     size := 0
     if name: size += 2 + name.size
     service_classes.do: | uuid/BleUuid |
       size += 2 + uuid.to_byte_array.size
     if not manufacturer_data.is_empty: size += 2 + manufacturer_data.size
-    if size > 31: throw "PACKET_SIZE_EXCEEDED"
+    if size > 31 and check_size: throw "PACKET_SIZE_EXCEEDED"
 
 /**
 A remote device discovered by a scanning.
@@ -607,6 +607,7 @@ class Central extends Resource_:
             --service_classes=service_classes
             --manufacturer_data=(next[4]?next[4]:#[])
             --connectable=next[5]
+            --check_size=false
         block.call discovery
     finally:
       ble_scan_stop_ resource_

--- a/lib/ble.toit
+++ b/lib/ble.toit
@@ -82,11 +82,15 @@ Conceptually, attributes are on the server, and can be accessed (read and/or wri
 interface Attribute:
   uuid -> BleUuid
 
-BLE_CONNECT_MODE_NONE          ::= 0
-BLE_CONNECT_MODE_DIRECTIONAL   ::= 1
-BLE_CONNECT_MODE_UNDIRECTIONAL ::= 2
+BLE_CONNECT_MODE_NONE                  ::= 0
+BLE_CONNECT_MODE_DIRECTIONAL           ::= 1
+BLE_CONNECT_MODE_UNDIRECTIONAL         ::= 2
 
-BLE_DEFAULT_PREFERRED_MTU_     ::= 23
+BLE_ADVERTISE_FLAGS_LIMITIED_DISCOVERY ::= 0x01
+BLE_ADVERTISE_FLAGS_GENERAL_DISCOVERY  ::= 0x02
+BLE_ADVERTISE_FLAGS_BREDR_UNSUPPORTED  ::= 0x04
+
+BLE_DEFAULT_PREFERRED_MTU_             ::= 23
 
 /**
 Advertisement data as either sent by advertising or received through scanning.
@@ -115,7 +119,14 @@ class AdvertisementData:
   */
   connectable/bool
 
-  constructor --.name=null --.service_classes=[] --.manufacturer_data=#[] --.connectable=false --check_size=true:
+  /**
+  Advertise flags. This must be a bitwise or of the BLE_ADVERTISE_FLAG_* constants
+    (see $BLE_ADVERTISE_FLAGS_GENERAL_DISCOVERY and similar).
+  */
+  flags/int
+
+  constructor --.name=null --.service_classes=[] --.manufacturer_data=#[]
+              --.connectable=false --.flags=0 --check_size=true:
     size := 0
     if name: size += 2 + name.size
     service_classes.do: | uuid/BleUuid |
@@ -606,7 +617,8 @@ class Central extends Resource_:
             --name=next[2]
             --service_classes=service_classes
             --manufacturer_data=(next[4]?next[4]:#[])
-            --connectable=next[5]
+            --flags=next[5]
+            --connectable=next[6]
             --check_size=false
         block.call discovery
     finally:
@@ -657,6 +669,7 @@ class Peripheral extends Resource_:
       data.manufacturer_data
       interval.in_us
       connection_mode
+      data.flags
 
     state := resource_state_.wait_for_state ADVERTISE_START_SUCEEDED_EVENT_ | ADVERTISE_START_FAILED_EVENT_
     if state & ADVERTISE_START_FAILED_EVENT_ != 0: throw "Failed to start advertising"
@@ -913,7 +926,7 @@ ble_write_value__ characteristic value with_response:
 ble_set_characteristic_notify_ characteristic value:
   #primitive.ble.set_characteristic_notify
 
-ble_advertise_start_ peripheral_manager name services manufacturer_data interval connection_mode:
+ble_advertise_start_ peripheral_manager name services manufacturer_data interval connection_mode flags:
   #primitive.ble.advertise_start
 
 ble_advertise_stop_ peripheral_manager:

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -341,7 +341,7 @@ namespace toit {
   PRIMITIVE(get_value, 1)                    \
   PRIMITIVE(write_value, 3)                  \
   PRIMITIVE(set_characteristic_notify, 2)    \
-  PRIMITIVE(advertise_start, 6)              \
+  PRIMITIVE(advertise_start, 7)              \
   PRIMITIVE(advertise_stop, 1)               \
   PRIMITIVE(add_service, 2)                  \
   PRIMITIVE(add_characteristic, 5)           \

--- a/src/resources/ble_darwin.mm
+++ b/src/resources/ble_darwin.mm
@@ -817,7 +817,7 @@ PRIMITIVE(scan_next) {
   DiscoveredPeripheral* peripheral = central_manager->next_discovered_peripheral();
   if (!peripheral) return process->program()->null_object();
 
-  Array* array = process->object_heap()->allocate_array(6, process->program()->null_object());
+  Array* array = process->object_heap()->allocate_array(7, process->program()->null_object());
   if (!array) ALLOCATION_FAILED;
 
   const char* address = [[[peripheral->peripheral() identifier] UUIDString] UTF8String];
@@ -868,8 +868,10 @@ PRIMITIVE(scan_next) {
     array->at_put(4, custom_data);
   }
 
+  array->at_put(5, Smi::from(0)); // flags not available on Darwin
+
   NSNumber* is_connectable = peripheral->connectable();
-  array->at_put(5, (is_connectable != nil && is_connectable.boolValue == YES)
+  array->at_put(6, (is_connectable != nil && is_connectable.boolValue == YES)
                    ? process->program()->true_object()
                    : process->program()->false_object());
 
@@ -1111,9 +1113,10 @@ PRIMITIVE(set_characteristic_notify) {
 
 PRIMITIVE(advertise_start) {
   ARGS(BLEPeripheralManagerResource, peripheral_manager, Blob, name, Array, service_classes,
-       Blob, manufacturing_data, int, interval_us, int, conn_mode);
+       Blob, manufacturing_data, int, interval_us, int, conn_mode, int, flags);
   USE(interval_us);
   USE(conn_mode);
+  USE(flags);
 
   NSMutableDictionary* data = [NSMutableDictionary new];
 

--- a/src/resources/ble_darwin.mm
+++ b/src/resources/ble_darwin.mm
@@ -1101,7 +1101,7 @@ PRIMITIVE(write_value) {
 
 PRIMITIVE(set_characteristic_notify) {
   ARGS(BLECharacteristicResource, characteristic, bool, enable);
-  printf("enable: %d, %s\n",enable,[[[characteristic->characteristic() UUID] UUIDString] UTF8String]);
+
   [characteristic->characteristic().service.peripheral
       setNotifyValue:enable
    forCharacteristic:characteristic->characteristic()];

--- a/src/resources/ble_esp32.cc
+++ b/src/resources/ble_esp32.cc
@@ -1279,7 +1279,7 @@ PRIMITIVE(scan_next) {
   DiscoveredPeripheral* next = central_manager->get_discovered_peripheral();
   if (!next) return process->program()->null_object();
 
-  Array* array = process->object_heap()->allocate_array(6, process->program()->null_object());
+  Array* array = process->object_heap()->allocate_array(7, process->program()->null_object());
   if (!array) ALLOCATION_FAILED;
 
   ByteArray* id = process->object_heap()->allocate_internal_byte_array(7);
@@ -1338,9 +1338,11 @@ PRIMITIVE(scan_next) {
         memcpy(custom_data_bytes.address(), fields.mfg_data, fields.mfg_data_len);
         array->at_put(4, custom_data);
       }
+
+      array->at_put(5, Smi::from(fields.flags));
     }
 
-    array->at_put(5, BOOL(next->event_type() == BLE_HCI_ADV_RPT_EVTYPE_ADV_IND ||
+    array->at_put(6, BOOL(next->event_type() == BLE_HCI_ADV_RPT_EVTYPE_ADV_IND ||
                           next->event_type() == BLE_HCI_ADV_RPT_EVTYPE_DIR_IND));
   }
 
@@ -1686,7 +1688,7 @@ PRIMITIVE(set_characteristic_notify) {
 
 PRIMITIVE(advertise_start) {
   ARGS(BLEPeripheralManagerResource, peripheral_manager, Blob, name, Array, service_classes,
-       Blob, manufacturing_data, int, interval_us, int, conn_mode)
+       Blob, manufacturing_data, int, interval_us, int, conn_mode, int, flags)
 
   if (BLEPeripheralManagerResource::is_advertising()) ALREADY_EXISTS;
 
@@ -1696,6 +1698,8 @@ PRIMITIVE(advertise_start) {
     fields.name_len = name.length();
     fields.name_is_complete = 1;
   }
+
+  fields.flags = flags;
 
   ble_uuid16_t uuids_16[service_classes->length()];
   ble_uuid32_t uuids_32[service_classes->length()];


### PR DESCRIPTION
Added support for manipulating and reading advertising flags on ESP32. (Ignored on Darwin)

Darwin's lowlevel scan returns data that can not be length checked, so disabling length check when reading advertised data.

Fix a bug in darwin that caused a segfault when exiting the vm without properly closing ble resources.