### PR TITLE
GC compaction: Don't fix pointers from dead objects.

### DIFF
--- a/src/third_party/dartino/object_memory.cc
+++ b/src/third_party/dartino/object_memory.cc
@@ -132,7 +132,15 @@ void Space::iterate_objects(HeapObjectVisitor* visitor, LivenessOracle* filter) 
         ASSERT(size > 0);
         current += size;
       } else {
-        current += object->size(program_);
+        word size = object->size(program_);
+#ifdef DEBUG
+        // Zapping words after the header should be harmless in new-space.
+        // In old-space this would interfere with the remembered set scanning,
+        // but there we don't use this call with a non-null filter.
+        uword address = object->_raw();
+        memset(reinterpret_cast<void*>(address + WORD_SIZE), 0x55, size - WORD_SIZE);
+#endif
+        current += size;
       }
     }
     visitor->chunk_end(chunk, current);

--- a/src/third_party/dartino/object_memory_mark_sweep.cc
+++ b/src/third_party/dartino/object_memory_mark_sweep.cc
@@ -261,13 +261,6 @@ class RememberedSetRebuilder : public HeapObjectVisitor {
   RememberedSetRebuilder2 pointer_callback;
 };
 
-// Until we have a write barrier we have to iterate the whole
-// of old space.
-void OldSpace::rebuild_remembered_set() {
-  RememberedSetRebuilder rebuilder(program_);
-  iterate_objects(&rebuilder);
-}
-
 void OldSpace::visit_remembered_set(ScavengeVisitor* visitor) {
   flush();
   for (auto chunk : chunk_list_) {


### PR DESCRIPTION
Previously we fixed pointers in dead new-space objects that seemed to point into old space after compaction. Now we skip those objects.  They will never be touched by the system again:
* The mutator can't reach them.
* Remembered-set object scans only happen in old space.
* Mark stack overflow object scans only look at gray objects.
* Scavenges don't look at dead objects.
* Finalizers only determine that objects are dead, they don't look inside them at their pointers.