### PR TITLE
AesGcm: Concatenate the rest of the ciphertext and the tag concatenated.

### DIFF
--- a/lib/crypto/aes.toit
+++ b/lib/crypto/aes.toit
@@ -293,17 +293,15 @@ class AesGcm:
   /**
   Finishes encrypting.
   Can be called after $start and $add.
-  Returns a two-element list with the last encrypted bytes and the verification
-    tag.  The last encrypted bytes will be a zero length ByteArray if the
-    size of the plaintext was a multiple of 16.
+  Returns a concatenation of the last encrypted bytes and the verification
+    tag.  The last encrypted bytes will have zero length if the size of the
+    plaintext was a multiple of 16.
   Closes this instance.
   */
-  finish -> List:
+  finish -> ByteArray:
     result := gcm_finish_ gcm_aes_
     close
-    cut := result.size - BLOCK_SIZE_
-    assert: cut == size % BLOCK_SIZE_
-    return [result[..cut], result[cut..]]
+    return result
 
   /**
   Finishes decrypting.

--- a/src/third_party/dartino/object_memory.h
+++ b/src/third_party/dartino/object_memory.h
@@ -276,8 +276,6 @@ class SemiSpace : public Space {
 
   virtual bool is_flushed();
 
-  void trigger_gc_soon() { limit_ = top_ + SENTINEL_SIZE; }
-
   // Allocate raw object. Returns 0 if a garbage collection is needed
   // and causes a fatal error if no garbage collection is needed and
   // there is no room to allocate the object.

--- a/tests/crypto_vectors_test.toit
+++ b/tests/crypto_vectors_test.toit
@@ -112,9 +112,9 @@ test_aes_gcm test/Test -> none:
   // Use the simple all-at-once methods that just append the verification
   // tag to the ciphertext.
   ciphertext_and_tag := (AesGcm.encryptor key nonce).encrypt expected_plaintext --authenticated_data=authenticated
-  cut := ciphertext_and_tag.size - 16
-  verification_tag := ciphertext_and_tag[cut..]
-  ciphertext := ciphertext_and_tag[..cut]
+  end := ciphertext_and_tag.size - AesGcm.TAG_SIZE
+  verification_tag := ciphertext_and_tag[end..]
+  ciphertext := ciphertext_and_tag[..end]
   expect_equals expected_ciphertext ciphertext
   expect_equals expected_verification_tag verification_tag
   plaintext := (AesGcm.decryptor key nonce).decrypt ciphertext_and_tag --authenticated_data=authenticated
@@ -146,8 +146,9 @@ test_aes_gcm test/Test -> none:
       parts.add (encryptor.add part2)
       parts.add (encryptor.add part3)
       finish := encryptor.finish
-      parts.add finish[0]
-      verification_tag = finish[1]
+      end = finish.size - AesGcm.TAG_SIZE
+      parts.add finish[0..end]
+      verification_tag = finish[end..]
       ciphertext = parts.reduce: | a b | a + b  // Byte array concatenation.
       expect_equals expected_verification_tag verification_tag
       expect_equals expected_ciphertext ciphertext


### PR DESCRIPTION
It just turns out this is a nicer API when finishing an AesGcm encryption most of the time.