### PR TITLE
Allow json.decode_stream to take a BufferedReader.

### DIFF
--- a/lib/reader.toit
+++ b/lib/reader.toit
@@ -589,6 +589,7 @@ class BufferedReader implements Reader:
   This causes the $consumed count to go backwards.
   */
   unget value/ByteArray -> none:
+    if value.size == 0: return
     if first_array_position_ != 0:
       first := arrays_.first
       arrays_.remove_first


### PR DESCRIPTION
By using a BufferedReader instead of a plain Reader this means you can stream more than one JSON object from a source.