### PR TITLE
When rehashing a Set or Map, reduce the peak memory used.

### DIFF
--- a/lib/core/collections.toit
+++ b/lib/core/collections.toit
@@ -845,12 +845,8 @@ abstract class Array_ extends List:
   // Optimized helper method for iterating over the array elements.
   abstract do_ end/int [block] -> none
 
-  /** Create a new array, copying up to old_length elements from this array. */
-  resize_for_list_ old_length/int new_length/int -> Array_:
-    result := Array_ new_length
-    for i := 0; i < old_length and i < new_length; i++:
-      result[i] = this[i]
-    return result
+  /** Create a new array, copying up to $copy_length elements from this array. */
+  abstract resize_for_list_ copy_length/int new_length/int filler -> Array_
 
   /**
   Returns the given $collection as an $Array_.
@@ -914,15 +910,18 @@ class SmallArray_ extends Array_:
       // argument. We force this to throw by doing the same here.
       block.call this[0]
 
-  /// Creates a new array of size $new_length, copying up to $old_length elements from this array.
-  resize_for_list_ old_length/int new_length/int -> Array_:
+  /// Creates a new array of size $new_length, copying up to $copy_length elements from this array.
+  resize_for_list_ copy_length/int new_length/int filler -> Array_:
     #primitive.core.array_expand:
       // Fallback if the primitive fails.  For example, the primitive can only
       // create SmallArray_ so we hit this on the border between SmallArray_
       // and LargeArray_.
-      if old_length == LargeArray_.ARRAYLET_SIZE:
-        return LargeArray_.with_arraylet_ this new_length
-      return super old_length new_length
+
+      result := Array_ new_length filler
+      limit := min copy_length new_length
+      for i := 0; i < limit; i++:
+        result[i] = this[i]
+      return result
 
   replace index/int source from/int to/int -> none:
     #primitive.core.array_replace:
@@ -944,6 +943,7 @@ class LargeArray_ extends Array_:
     return LargeArray_ size null
 
   constructor .size_/int filler/any:
+    if size_ <= ARRAYLET_SIZE: throw "OUT_OF_RANGE"
     full_arraylets := size_ / ARRAYLET_SIZE
     left := size_ % ARRAYLET_SIZE
     if left == 0:
@@ -970,24 +970,31 @@ class LargeArray_ extends Array_:
     vector_[1] = Array_ new_size - ARRAYLET_SIZE
     super.from_subclass_
 
-  // An expand that uses the backing arraylets from the old array.  Used by List.
-  resize_for_list_ old_size/int new_size/int:
+  // An expansion or shrinking that uses the backing arraylets from the old
+  // array.  Used by List, Set, and Map.
+  resize_for_list_ copy_size/int new_size/int filler:
     // Rounding up division.
     number_of_arraylets := ((new_size - 1) / ARRAYLET_SIZE) + 1
-    new_vector := Array_ number_of_arraylets
+    if number_of_arraylets == 1:
+      return vector_[0].resize_for_list_ copy_size new_size filler
+    new_vector := Array_ number_of_arraylets  // new_vector may be a LargeArray_!
     left := new_size
+    pos := 0
     number_of_arraylets.repeat:
-      if (it + 1) * ARRAYLET_SIZE <= old_size:
-        new_vector[it] = vector_[it]
-        left -= ARRAYLET_SIZE
+      arraylet := ?
+      limit := min left ARRAYLET_SIZE
+      if pos + limit <= size:
+        arraylet = vector_[it]
+        if pos + limit > copy_size:
+          arraylet.fill --from=(max 0 (copy_size - pos)) --to=limit filler
       else:
-        limit := min left ARRAYLET_SIZE
-        arraylet := Array_ limit
-        new_vector[it] = arraylet
-        if it * ARRAYLET_SIZE < old_size:
+        arraylet = Array_ limit filler
+        if pos < copy_size:
           old_arraylet := vector_[it]
-          arraylet.replace 0 old_arraylet 0 (old_size % ARRAYLET_SIZE)
-        left -= limit
+          arraylet.replace 0 old_arraylet 0 (min limit (copy_size - pos))
+      new_vector[it] = arraylet
+      left -= limit
+      pos += ARRAYLET_SIZE
     assert: left == 0
     return LargeArray_.internal_ new_vector new_size
 
@@ -1017,7 +1024,7 @@ class LargeArray_ extends Array_:
       vector_[full_arraylets].do_ left block
 
   size_ /int ::= 0
-  vector_ /Array_ ::= ?
+  vector_ /Array_ ::= ?  // This is the array of arraylets.  It may itself be a LargeArray_!
 
 /**
 A container specialized for bytes.
@@ -1762,12 +1769,12 @@ class List_ extends List:
           : (round_up (array_size + 1 + (array_size >> 4)) LargeArray_.ARRAYLET_SIZE)
         if new_array_size < LIST_INITIAL_LENGTH_: new_array_size = LIST_INITIAL_LENGTH_
         while new_array_size < new_size: new_array_size += 1 + (new_array_size >> 1)
-        array_ = array_.resize_for_list_ size_ new_array_size
+        array_ = array_.resize_for_list_ size_ new_array_size null
 
       size_ = new_size
     else:
       if new_size < array_.size - LargeArray_.ARRAYLET_SIZE:
-        array_ = array_.resize_for_list_ size_ (round_up new_size LargeArray_.ARRAYLET_SIZE)
+        array_ = array_.resize_for_list_ size_ (round_up new_size LargeArray_.ARRAYLET_SIZE) null
       // Clear entries so they can be GC'ed.
       limit := min size_ array_.size
       for i := new_size; i < limit; i++:
@@ -2011,7 +2018,8 @@ abstract class HashedInsertionOrderedCollection_:
   //   initial slot in the index.  Since sizes are a power of 2 we merely take
   //   the modulus of the size, which can be done by bitwise and-ing with the
   //   size - 1.
-  pick_new_index_size_ old_size --allow_shrink/bool:
+  // Returns the new index size.
+  pick_new_index_size_ old_size --allow_shrink/bool -> int:
     minimum := allow_shrink ? 2 : index_.size * 2
     enough := 1 + old_size + (old_size >> 3)  // old_size * 1.125.
     new_index_size := max
@@ -2021,7 +2029,7 @@ abstract class HashedInsertionOrderedCollection_:
     index_spaces_left_ = (new_index_size * 0.85).to_int
     if index_spaces_left_ <= old_size: index_spaces_left_ = old_size + 1
     // Found large enough index size.
-    index_ = Array_ new_index_size 0
+    return new_index_size
 
   /// We store this much of the hash code in each slot.
   static HASH_MASK_ ::= 0xfff
@@ -2168,10 +2176,19 @@ abstract class HashedInsertionOrderedCollection_:
           backing_[i++] = it
       length := size_ * step
       backing_.resize size_ * step
-    old_index := index_
-    pick_new_index_size_ old_size --allow_shrink=allow_shrink
-    index_mask := index_.size - 1
-    if not old_index or index_mask > HASH_MASK_ or rebuild_backing:
+    new_index_size := pick_new_index_size_ old_size --allow_shrink=allow_shrink
+    index_mask := new_index_size - 1
+    if not index_ or index_mask > HASH_MASK_ or rebuild_backing:
+      // Rebuild the index using the backing array.
+      // By using resize_for_list_ we reuse the arraylets when growing large
+      // arrays.  This reduces GC churn and, more importantly, peak memory
+      // usage.
+      if index_:
+        index_ = index_.resize_for_list_ /*copy_size=*/ 0 new_index_size /*filler=*/0
+        index_.fill 0
+      else:
+        index_ = Array_ new_index_size 0
+      if index_.size != new_index_size: throw "foo"
       // Rebuild the index by iterating over the backing and entering each key
       // into the index in the conventional way.  During this operation, the
       // index is big enough and the backing does not change.  The find_ operation
@@ -2189,9 +2206,12 @@ abstract class HashedInsertionOrderedCollection_:
             false_block
           assert: action == APPEND_
     else:
-      // We can do an simple rebuild.  There are enough hash bits in the index
-      // slots to tell us where the slot goes in the new index, so we don't need
-      // to call hash_code or equality for the entries in the backing.
+      // We can do an simple index rebuild from the old index.  There are
+      // enough hash bits in the index slots to tell us where the slot goes in
+      // the new index, so we don't need to call hash_code or equality for the
+      // entries in the backing.
+      old_index := index_
+      index_ = Array_ new_index_size 0
       index_spaces_left_ -= size_
       simple_rebuild_hash_index_ old_index index_
 

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -87,7 +87,7 @@ namespace toit {
   PRIMITIVE(array_at, 2)                     \
   PRIMITIVE(array_at_put, 3)                 \
   PRIMITIVE(array_new, 2)                    \
-  PRIMITIVE(array_expand, 3)                 \
+  PRIMITIVE(array_expand, 4)                 \
   PRIMITIVE(array_replace, 5)                \
   PRIMITIVE(list_add, 2)                     \
   PRIMITIVE(smi_unary_minus, 1)              \

--- a/src/primitive_core.cc
+++ b/src/primitive_core.cc
@@ -1598,16 +1598,13 @@ PRIMITIVE(array_at_put) {
   OUT_OF_BOUNDS;
 }
 
-// Must be kept in sync with ARRAYLET_SIZE in the LargeArray_ class.
-static const word ARRAYLET_SIZE = 500;
-
 // Allocates a new array and copies old_length elements from the old array into
 // the new one.
 PRIMITIVE(array_expand) {
   ARGS(Array, old, word, old_length, word, length, Object, filler);
   if (length == 0) return process->program()->empty_array();
   if (length < 0) OUT_OF_BOUNDS;
-  if (length > ARRAYLET_SIZE) OUT_OF_RANGE;
+  if (length > Array::ARRAYLET_SIZE) OUT_OF_RANGE;
   if (old_length < 0 || old_length > old->length()) OUT_OF_RANGE;
   Object* result = process->object_heap()->allocate_array(length, filler);
   if (result == null) ALLOCATION_FAILED;
@@ -1635,7 +1632,7 @@ PRIMITIVE(array_new) {
   ARGS(int, length, Object, filler);
   if (length == 0) return process->program()->empty_array();
   if (length < 0) OUT_OF_BOUNDS;
-  if (length > ARRAYLET_SIZE) OUT_OF_RANGE;
+  if (length > Array::ARRAYLET_SIZE) OUT_OF_RANGE;
   return Primitive::allocate_array(length, filler, process);
 }
 

--- a/src/primitive_core.cc
+++ b/src/primitive_core.cc
@@ -1598,20 +1598,22 @@ PRIMITIVE(array_at_put) {
   OUT_OF_BOUNDS;
 }
 
+// Must be kept in sync with ARRAYLET_SIZE in the LargeArray_ class.
+static const word ARRAYLET_SIZE = 500;
+
 // Allocates a new array and copies old_length elements from the old array into
 // the new one.
 PRIMITIVE(array_expand) {
-  ARGS(Array, old, word, old_length, word, length);
+  ARGS(Array, old, word, old_length, word, length, Object, filler);
   if (length == 0) return process->program()->empty_array();
   if (length < 0) OUT_OF_BOUNDS;
-  if (length > Array::max_length_in_process()) OUT_OF_RANGE;
-  if (old_length < 0 || old_length > old->length() || old_length > length) OUT_OF_RANGE;
-  Object* result = process->object_heap()->allocate_array(length, Smi::from(0));
+  if (length > ARRAYLET_SIZE) OUT_OF_RANGE;
+  if (old_length < 0 || old_length > old->length()) OUT_OF_RANGE;
+  Object* result = process->object_heap()->allocate_array(length, filler);
   if (result == null) ALLOCATION_FAILED;
   Array* new_array = Array::cast(result);
-  new_array->copy_from(old, old_length);
-  Object* filler = process->program()->null_object();
-  new_array->fill(old_length, filler);
+  new_array->copy_from(old, Utils::min(length, old_length));
+  if (old_length < length) new_array->fill(old_length, filler);
   return new_array;
 }
 
@@ -1633,7 +1635,7 @@ PRIMITIVE(array_new) {
   ARGS(int, length, Object, filler);
   if (length == 0) return process->program()->empty_array();
   if (length < 0) OUT_OF_BOUNDS;
-  if (length > Array::max_length_in_process()) OUT_OF_RANGE;
+  if (length > ARRAYLET_SIZE) OUT_OF_RANGE;
   return Primitive::allocate_array(length, filler, process);
 }
 

--- a/tests/array_and_list_test.toit
+++ b/tests/array_and_list_test.toit
@@ -130,6 +130,7 @@ FILLER := 3.1415
 
 
 test_large_array_do:
+ 10.repeat:
   sizes := [ 0, 1, 499, 500, 501, 999, 1000, 1001, 9999, 10000, 10001 ]
   sizes.do: | size |
     sizes.do: | new_size |

--- a/tests/negative/gold/invalid_program_test.gold
+++ b/tests/negative/gold/invalid_program_test.gold
@@ -1,4 +1,4 @@
 INVALID_PROGRAM error. 
-2486
+2463
   0: run_global_initializer_   <sdk>/core/objects.toit:254:1
   1: main                      tests/negative/invalid_program_test.toit:9:3


### PR DESCRIPTION
For large sets or maps we build a new index from scratch when we outgrow the old one.  In this case we reuse the arraylets from the old index, rather than creating new arraylets and keeping the old ones alive during rehashing.

This also changes the rules so that we go to LargeArray_ as soon as we exceed the arraylet size.  Previously we stayed at SmallArray_ until we hit the max size for page allocations.  On embedded this will avoid arrays in the 2-3.9k size range, which could waste memory on fragmentation.