### PR TITLE
Keep asserts when running the compiler for analysis.

### DIFF
--- a/external/gold/toit-r46ca01__examples__main.toit.gold
+++ b/external/gold/toit-r46ca01__examples__main.toit.gold
@@ -1,9 +1,0 @@
-<pkg:toit-rs485>/rs485.toit:180:9: warning: Deprecated 'Pin.config'
-    rts.config --output
-        ^~~~~~
-<pkg:toit-rs485>/rs485.toit:206:17: warning: Deprecated 'Pin.config'
-    read_enable.config --output
-                ^~~~~~
-<pkg:toit-rs485>/rs485.toit:207:18: warning: Deprecated 'Pin.config'
-    write_enable.config --output
-                 ^~~~~~

--- a/external/gold/toit-r46ca01__tests__test_baudrate_esp32.toit.gold
+++ b/external/gold/toit-r46ca01__tests__test_baudrate_esp32.toit.gold
@@ -1,9 +1,0 @@
-<pkg:toit-rs485>/rs485.toit:180:9: warning: Deprecated 'Pin.config'
-    rts.config --output
-        ^~~~~~
-<pkg:toit-rs485>/rs485.toit:206:17: warning: Deprecated 'Pin.config'
-    read_enable.config --output
-                ^~~~~~
-<pkg:toit-rs485>/rs485.toit:207:18: warning: Deprecated 'Pin.config'
-    write_enable.config --output
-                 ^~~~~~

--- a/external/gold/toit-r46ca01__tests__test_esp32.toit.gold
+++ b/external/gold/toit-r46ca01__tests__test_esp32.toit.gold
@@ -1,9 +1,0 @@
-<pkg:toit-rs485>/rs485.toit:180:9: warning: Deprecated 'Pin.config'
-    rts.config --output
-        ^~~~~~
-<pkg:toit-rs485>/rs485.toit:206:17: warning: Deprecated 'Pin.config'
-    read_enable.config --output
-                ^~~~~~
-<pkg:toit-rs485>/rs485.toit:207:18: warning: Deprecated 'Pin.config'
-    write_enable.config --output
-                 ^~~~~~

--- a/external/gold/toit-tl19a08__examples__main.toit.gold
+++ b/external/gold/toit-tl19a08__examples__main.toit.gold
@@ -1,9 +1,0 @@
-<pkg:toit-rs485>/rs485.toit:180:9: warning: Deprecated 'Pin.config'
-    rts.config --output
-        ^~~~~~
-<pkg:toit-rs485>/rs485.toit:206:17: warning: Deprecated 'Pin.config'
-    read_enable.config --output
-                ^~~~~~
-<pkg:toit-rs485>/rs485.toit:207:18: warning: Deprecated 'Pin.config'
-    write_enable.config --output
-                 ^~~~~~

--- a/external/gold/toit-tl19a08__src__tl19a08.toit.gold
+++ b/external/gold/toit-tl19a08__src__tl19a08.toit.gold
@@ -1,9 +1,0 @@
-<pkg:toit-rs485>/rs485.toit:180:9: warning: Deprecated 'Pin.config'
-    rts.config --output
-        ^~~~~~
-<pkg:toit-rs485>/rs485.toit:206:17: warning: Deprecated 'Pin.config'
-    read_enable.config --output
-                ^~~~~~
-<pkg:toit-rs485>/rs485.toit:207:18: warning: Deprecated 'Pin.config'
-    write_enable.config --output
-                 ^~~~~~

--- a/external/gold/toit-tl19a08__tests__test_esp32.toit.gold
+++ b/external/gold/toit-tl19a08__tests__test_esp32.toit.gold
@@ -1,9 +1,0 @@
-<pkg:toit-rs485>/rs485.toit:180:9: warning: Deprecated 'Pin.config'
-    rts.config --output
-        ^~~~~~
-<pkg:toit-rs485>/rs485.toit:206:17: warning: Deprecated 'Pin.config'
-    read_enable.config --output
-                ^~~~~~
-<pkg:toit-rs485>/rs485.toit:207:18: warning: Deprecated 'Pin.config'
-    write_enable.config --output
-                 ^~~~~~

--- a/src/compiler/compiler.cc
+++ b/src/compiler/compiler.cc
@@ -1543,6 +1543,13 @@ toit::Program* construct_program(ir::Program* ir_program,
 }
 
 Pipeline::Result Pipeline::run(List<const char*> source_paths, bool propagate) {
+  // TODO(florian): this is hackish. We want to analyze asserts also in release mode,
+  // but then remove the code when we generate code.
+  // For now just enable asserts when we are analyzing.
+  if (configuration_.is_for_analysis) {
+    Flags::enable_asserts = true;
+  }
+
   auto fs = configuration_.filesystem;
   fs->initialize(diagnostics());
   source_paths = adjust_source_paths(source_paths);

--- a/tests/lsp/basic_completion_test.toit
+++ b/tests/lsp/basic_completion_test.toit
@@ -52,3 +52,10 @@ main:
   + ImportedClass, ImportedInterface
   - *
 */
+
+  // Make sure it also works inside asserts
+  assert: block.call
+/*              ^~~~
+  + call
+  - member, ==, true, null, false
+*/

--- a/tests/lsp/basic_definition_test.toit
+++ b/tests/lsp/basic_definition_test.toit
@@ -62,3 +62,9 @@ main:
 /*                    ^
   [ImportedClass]
 */
+
+  // Make sure it also works inside asserts.
+  assert: imported = ImportedClass
+/*                     ^
+  [ImportedClass]
+*/


### PR DESCRIPTION
We would also like to analyze asserts when compiling, but that's harder to do.