### PR TITLE
Don't chop up UTF-8 byte sequences in messages

### DIFF
--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -50,8 +50,13 @@ class EncodeVisitor : public Visitor {
     encoder_->write_byte('S');
     String::Bytes bytes(string);
     const char* OVERFLOW_DOTS = "...";
-    const int printed = Utils::min(bytes.length(), MAX_NOF_STRING_ELEMENTS);
-    const bool overflow = bytes.length() > MAX_NOF_STRING_ELEMENTS;
+    int printed = bytes.length();
+    const bool overflow = printed > MAX_NOF_STRING_ELEMENTS;
+    if (overflow) {
+      printed = MAX_NOF_STRING_ELEMENTS;
+      // Don't chop up UTF-8 sequences.
+      while ((bytes.at(printed) & 0xc0) == 0x80 && printed > 0) printed--;
+    }
     const int limit = printed + (overflow ? strlen(OVERFLOW_DOTS) : 0);
     encoder_->write_int(limit);
     for (int i = 0; i < printed; i++) {

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -55,7 +55,9 @@ class EncodeVisitor : public Visitor {
     if (overflow) {
       printed = MAX_NOF_STRING_ELEMENTS;
       // Don't chop up UTF-8 sequences.
-      while ((bytes.at(printed) & 0xc0) == 0x80 && printed > 0) printed--;
+      while ((bytes.at(printed) & ~Utils::UTF_8_MASK) == Utils::UTF_8_PAYLOAD && printed > 0) {
+        printed--;
+      }
     }
     const int limit = printed + (overflow ? strlen(OVERFLOW_DOTS) : 0);
     encoder_->write_int(limit);

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -55,7 +55,7 @@ class EncodeVisitor : public Visitor {
     if (overflow) {
       printed = MAX_NOF_STRING_ELEMENTS;
       // Don't chop up UTF-8 sequences.
-      while ((bytes.at(printed) & ~Utils::UTF_8_MASK) == Utils::UTF_8_PAYLOAD && printed > 0) {
+      while ((bytes.at(printed) & ~Utils::UTF_8_MASK) == Utils::UTF_8_PAYLOAD) {
         printed--;
       }
     }

--- a/tests/negative/gold/unicode_expect_failure_test.gold
+++ b/tests/negative/gold/unicode_expect_failure_test.gold
@@ -1,0 +1,17 @@
+: Expected <╒════╤════════╕
+│ no   header │
+╘════╧════════╛
+>, but was <┌────┬────────┐
+│ no   header │
+└────┴────────┘
+>
+ASSERTION_FAILED error. 
+Expected <╒════╤════════╕
+│ no   header │
+╘════╧═══...
+  0: catch.<block>             <sdk>/core/exceptions.toit:124:10
+  1: catch                     <sdk>/core/exceptions.toit:122:1
+  2: catch                     <sdk>/core/exceptions.toit:73:10
+  3: expect                    <sdk>/expect.toit:21:3
+  4: expect_equals             <sdk>/expect.toit:36:5
+  5: main                      tests/negative/unicode_expect_failure_test.toit:4:3

--- a/tests/negative/gold/unicode_expect_failure_test.gold
+++ b/tests/negative/gold/unicode_expect_failure_test.gold
@@ -14,4 +14,4 @@ Expected <╒════╤════════╕
   2: catch                     <sdk>/core/exceptions.toit:73:10
   3: expect                    <sdk>/expect.toit:21:3
   4: expect_equals             <sdk>/expect.toit:36:5
-  5: main                      tests/negative/unicode_expect_failure_test.toit:4:3
+  5: main                      tests/negative/unicode_expect_failure_test.toit:12:3

--- a/tests/negative/unicode_expect_failure_test.toit
+++ b/tests/negative/unicode_expect_failure_test.toit
@@ -1,0 +1,13 @@
+import expect show *
+
+main:
+  expect_equals """
+    ╒════╤════════╕
+    │ no   header │
+    ╘════╧════════╛
+    """
+    """
+    ┌────┬────────┐
+    │ no   header │
+    └────┴────────┘
+    """

--- a/tests/negative/unicode_expect_failure_test.toit
+++ b/tests/negative/unicode_expect_failure_test.toit
@@ -1,3 +1,11 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+// Test that long exceptions with Unicode characters in them don't break the
+// error reporting machinery by being truncated in the middle of a UTF-8
+// character.
+
 import expect show *
 
 main:


### PR DESCRIPTION
Fixes #1322