### PR TITLE
Add warning when '-' is not surrounded by spaces

### DIFF
--- a/examples/http/package.lock
+++ b/examples/http/package.lock
@@ -3,5 +3,5 @@ prefixes:
 packages:
   pkg-http:
     url: github.com/toitlang/pkg-http
-    version: 1.9.0
-    hash: 760f6c93e5b267e04fb687888dce159cc4050be2
+    version: 1.9.3
+    hash: 108c436cc990535f5d70c380ef68081c38840f4c

--- a/examples/http/package.yaml
+++ b/examples/http/package.yaml
@@ -1,4 +1,4 @@
 dependencies:
   http:
     url: github.com/toitlang/pkg-http
-    version: ^1.9.0
+    version: ^1.9.3

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -1720,6 +1720,10 @@ Expression* Parser::parse_precedence(Precedence precedence,
           // A prefix minus.
           goto done;
         }
+        if (is_attached_to_previous || is_attached_to_next) {
+          diagnostics()->report_warning(range.extend(current_range()),
+                                        "Minus operator must be surrounded by spaces");
+        }
         consume();
         Expression* right = at_newline()
             ? parse_expression(allow_colon)

--- a/tests/health/gold/sdk/examples__http__http.toit.gold
+++ b/tests/health/gold/sdk/examples__http__http.toit.gold
@@ -1,3 +1,6 @@
-<pkg:pkg-http>/connection.toit:104:37: warning: Parenthesis should not be attached. Attempted call?
-    content_length := headers.single("Content-Length")
-                                    ^
+<pkg:pkg-http>/web_socket.toit:33:20: warning: Unresolved reference 'web_socket'
+Obtained from the $Client.web_socket or the $Server.web_socket methods.
+                   ^~~~~~~~~~~~~~~~~
+<pkg:pkg-http>/headers.toit:109:13: warning: Deprecated 'string.write_to_byte_array'
+        str.write_to_byte_array bytes 0 it 0
+            ^~~~~~~~~~~~~~~~~~~

--- a/tests/negative/gold/minus_space_test.gold
+++ b/tests/negative/gold/minus_space_test.gold
@@ -1,0 +1,10 @@
+tests/negative/minus_space_test.toit:11:12: warning: Minus operator must be surrounded by spaces
+  print foo-bar
+           ^
+tests/negative/minus_space_test.toit:12:12: warning: Minus operator must be surrounded by spaces
+  print foo- bar
+           ^
+tests/negative/minus_space_test.toit:18:3: error: Unresolved identifier: 'unresolved'
+  unresolved
+  ^~~~~~~~~~
+Compilation failed.

--- a/tests/negative/gold/postfix2_test.gold
+++ b/tests/negative/gold/postfix2_test.gold
@@ -4,6 +4,9 @@ tests/negative/postfix2_test.toit:6:3: error: Invalid name for declaration
 tests/negative/postfix2_test.toit:14:10: error: Expected identifier
     this.- 42 unresolved
          ^
+tests/negative/postfix2_test.toit:14:10: warning: Minus operator must be surrounded by spaces
+    this.- 42 unresolved
+         ^
 tests/negative/postfix2_test.toit:14:15: error: Unresolved identifier: 'unresolved'
     this.- 42 unresolved
               ^~~~~~~~~~

--- a/tests/negative/minus_space_test.toit
+++ b/tests/negative/minus_space_test.toit
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+toto x y: return x - y
+
+main:
+  foo := 1
+  bar := 2
+
+  print foo-bar
+  print foo- bar
+  toto foo -bar  // This is a valid use where only bar is inverted.
+  
+  print foo - bar
+  print (foo - bar)
+
+  unresolved

--- a/tests/package.lock
+++ b/tests/package.lock
@@ -12,16 +12,16 @@ packages:
     hash: 175bcdfd59b2597c0825ef8765a20498a7e6a2db
   pkg-cli:
     url: github.com/toitlang/pkg-cli
-    version: 1.1.0
-    hash: cadcb975d3130b3a154c9bc0c676b1efa997a8c6
+    version: 1.1.1
+    hash: 4cfb8204a27b6eea6c4d1339c96f6e8cb41e43db
   pkg-font-x11-adobe:
     url: github.com/toitlang/pkg-font-x11-adobe
     version: 0.1.0
     hash: f844400722165252148f087cdf189abab0a47f3d
   pkg-host:
     url: github.com/toitlang/pkg-host
-    version: 1.6.0
-    hash: d05b91390e76c3543a9968b042aed330210bafa4
+    version: 1.8.1
+    hash: 7f0cc4280065fb18ee09d3803f12180cec852d32
   pkg-tar:
     url: github.com/toitlang/pkg-tar
     version: 1.0.0

--- a/tests/package.yaml
+++ b/tests/package.yaml
@@ -4,13 +4,13 @@ dependencies:
     version: ^1.0.0
   cli:
     url: github.com/toitlang/pkg-cli
-    version: ^1.1.0
+    version: ^1.1.1
   font_x11_adobe:
     url: github.com/toitlang/pkg-font-x11-adobe
     version: ^0.1.0
   host:
     url: github.com/toitlang/pkg-host
-    version: ^1.6.0
+    version: ^1.8.1
   tar:
     url: github.com/toitlang/pkg-tar
     version: ^1.0.0

--- a/third_party/benchmarks/toit/pystone.toit
+++ b/third_party/benchmarks/toit/pystone.toit
@@ -162,7 +162,7 @@ Proc8 Array1Par Array2Par IntParI1 IntParI2:
   Array1Par[IntLoc+30] = IntLoc
   2.repeat:
     Array2Par[IntLoc][IntLoc + it] = IntLoc
-  Array2Par[IntLoc][IntLoc-1] = Array2Par[IntLoc][IntLoc-1] + 1
+  Array2Par[IntLoc][IntLoc - 1] = Array2Par[IntLoc][IntLoc - 1] + 1
   Array2Par[IntLoc+20][IntLoc] = Array1Par[IntLoc]
   IntGlob = 5
 
@@ -178,7 +178,7 @@ Func2 StrParI1 StrParI2:
   IntLoc := 1
   CharLoc := null
   while IntLoc <= 1:
-    if (Func1 StrParI1[IntLoc] StrParI2[IntLoc+1]) == Ident1:
+    if (Func1 StrParI1[IntLoc] StrParI2[IntLoc + 1]) == Ident1:
       CharLoc = 'A'
       IntLoc = IntLoc + 1
   if CharLoc >= 'W' and CharLoc <= 'Z':

--- a/tools/lsp/server/package.lock
+++ b/tools/lsp/server/package.lock
@@ -6,12 +6,12 @@ prefixes:
 packages:
   pkg-cli:
     url: github.com/toitlang/pkg-cli
-    version: 1.1.0
-    hash: cadcb975d3130b3a154c9bc0c676b1efa997a8c6
+    version: 1.1.1
+    hash: 4cfb8204a27b6eea6c4d1339c96f6e8cb41e43db
   pkg-host:
     url: github.com/toitlang/pkg-host
-    version: 1.4.1
-    hash: 444a69af53c5c2010074bceaef1afef615f14047
+    version: 1.8.1
+    hash: 7f0cc4280065fb18ee09d3803f12180cec852d32
   pkg-tar:
     url: github.com/toitlang/pkg-tar
     version: 1.0.0

--- a/tools/lsp/server/package.yaml
+++ b/tools/lsp/server/package.yaml
@@ -1,10 +1,10 @@
 dependencies:
   cli:
     url: github.com/toitlang/pkg-cli
-    version: ^1.1.0
+    version: ^1.1.1
   host:
     url: github.com/toitlang/pkg-host
-    version: ^1.4.1
+    version: ^1.8.1
   tar:
     url: github.com/toitlang/pkg-tar
     version: ^1.0.0

--- a/tools/package.lock
+++ b/tools/package.lock
@@ -10,8 +10,8 @@ packages:
     hash: 175bcdfd59b2597c0825ef8765a20498a7e6a2db
   pkg-cli:
     url: github.com/toitlang/pkg-cli
-    version: 1.1.0
-    hash: cadcb975d3130b3a154c9bc0c676b1efa997a8c6
+    version: 1.1.1
+    hash: 4cfb8204a27b6eea6c4d1339c96f6e8cb41e43db
   pkg-host:
     url: github.com/toitlang/pkg-host
     version: 1.8.1

--- a/tools/package.yaml
+++ b/tools/package.yaml
@@ -4,7 +4,7 @@ dependencies:
     version: ^1.0.0
   cli:
     url: github.com/toitlang/pkg-cli
-    version: ^1.1.0
+    version: ^1.1.1
   host:
     url: github.com/toitlang/pkg-host
     version: ^1.8.1


### PR DESCRIPTION
This is in preparation for allowing `foo-bar` identifiers.