### PR TITLE
Fix 3 BLE bugs and enable compilation without CRYPTO

### DIFF
--- a/src/primitive_crypto.cc
+++ b/src/primitive_crypto.cc
@@ -13,6 +13,10 @@
 // The license can be found in the file `LICENSE` in the top level
 // directory of this repository.
 
+#include "top.h"
+
+#if !defined(TOIT_FREERTOS) || CONFIG_TOIT_CRYPTO
+
 #include "mbedtls/gcm.h"
 #include "mbedtls/chachapoly.h"
 
@@ -534,3 +538,5 @@ PRIMITIVE(aes_ecb_close) {
 
 
 }
+
+#endif

--- a/src/primitive_crypto.cc
+++ b/src/primitive_crypto.cc
@@ -15,7 +15,7 @@
 
 #include "top.h"
 
-#if !defined(TOIT_FREERTOS) || CONFIG_TOIT_CRYPTO
+#if !defined(TOIT_FREERTOS) || defined(CONFIG_TOIT_CRYPTO)
 
 #include "mbedtls/gcm.h"
 #include "mbedtls/chachapoly.h"
@@ -535,7 +535,6 @@ PRIMITIVE(aes_ecb_close) {
   context_proxy->clear_external_address();
   return process->program()->null_object();
 }
-
 
 }
 


### PR DESCRIPTION
Fixing 3 errors in BLE. 
 - Init sometimes fails because the sequence of calls were wrong
 - Supporting more devices on peripheral would always fail
 - Connecting as a central would not wait until MTU was negotiation was complete before allowing service discovery, leading to a timeout

Fixing support for compiling without CRYPTO support.