### PR TITLE
Expose names for bundled container images

### DIFF
--- a/lib/system/api/containers.toit
+++ b/lib/system/api/containers.toit
@@ -44,9 +44,9 @@ class ContainerServiceClient extends ServiceClient implements ContainerService:
 
   list_images -> List:
     array := invoke_ ContainerService.LIST_IMAGES_INDEX null
-    return List array.size / 3:
-      cursor := it * 3
-      ContainerImage (uuid.Uuid array[cursor]) array[cursor + 1] array[cursor + 2]
+    return List array.size / 4:
+      cursor := it * 4
+      ContainerImage (uuid.Uuid array[cursor]) array[cursor + 1] array[cursor + 2] array[cursor + 3]
 
   start_image id/uuid.Uuid arguments/any -> int?:
     return invoke_ ContainerService.START_IMAGE_INDEX [id.to_byte_array, arguments]

--- a/lib/system/api/containers.toit
+++ b/lib/system/api/containers.toit
@@ -49,7 +49,11 @@ class ContainerServiceClient extends ServiceClient implements ContainerService:
     array := invoke_ ContainerService.LIST_IMAGES_INDEX null
     return List array.size / 4:
       cursor := it * 4
-      ContainerImage (uuid.Uuid array[cursor]) array[cursor + 1] array[cursor + 2] array[cursor + 3]
+      ContainerImage
+          --id=uuid.Uuid array[cursor]
+          --name=array[cursor + 1]
+          --flags=array[cursor + 2]
+          --data=array[cursor + 3]
 
   load_image id/uuid.Uuid -> int?:
     return invoke_ ContainerService.LOAD_IMAGE_INDEX id.to_byte_array

--- a/lib/system/containers.toit
+++ b/lib/system/containers.toit
@@ -31,9 +31,10 @@ uninstall id/uuid.Uuid -> none:
 
 class ContainerImage:
   id/uuid.Uuid
+  name/string?
   flags/int
   data/int
-  constructor .id .flags .data:
+  constructor .id .name .flags .data:
 
 class Container extends ServiceResourceProxy:
   id/uuid.Uuid

--- a/lib/system/containers.toit
+++ b/lib/system/containers.toit
@@ -39,7 +39,7 @@ class ContainerImage:
   name/string?
   flags/int
   data/int
-  constructor .id .name .flags .data:
+  constructor --.id --.name --.flags --.data:
 
 class Container extends ServiceResourceProxy:
   id/uuid.Uuid

--- a/src/flash_allocation.h
+++ b/src/flash_allocation.h
@@ -94,7 +94,7 @@ class FlashAllocation {
         memcpy(id_, id, id_size());
       }
       pages_in_flash_ = 0;
-      memset(_metadata, 0xFF, METADATA_SIZE);
+      memset(_metadata, 0, METADATA_SIZE);
       set_uuid(uuid);
     }
 

--- a/system/containers.toit
+++ b/system/containers.toit
@@ -16,8 +16,11 @@
 import binary
 import uuid
 import monitor
-import encoding.base64 as base64
 
+import encoding.base64
+import encoding.tison
+
+import system.assets
 import system.services show ServiceDefinition ServiceResource
 import system.api.containers show ContainerService
 
@@ -195,10 +198,16 @@ abstract class ContainerServiceDefinition extends ServiceDefinition
   abstract lookup_image id/uuid.Uuid -> ContainerImage?
 
   list_images -> List:
+    names := {:}
+    assets.decode.get "images" --if_present=: | encoded |
+      map := tison.decode encoded
+      map.do: | name/string id/ByteArray | names[uuid.Uuid id] = name
     raw := images
     result := []
     raw.do: | image/ContainerImage |
-      result.add image.id.to_byte_array
+      id/uuid.Uuid := image.id
+      result.add id.to_byte_array
+      result.add (names.get id)
       result.add image.flags
       result.add image.data
     return result

--- a/tests/negative/gold/illegal_system_call_test.gold
+++ b/tests/negative/gold/illegal_system_call_test.gold
@@ -1,6 +1,6 @@
 As check failed: null is not a ServiceResource.
   0: ServiceDefinition.resource <sdk>/system/services.toit:170:5
-  1: ContainerServiceDefinition.handle <...>/system/containers.toit:185:19
+  1: ContainerServiceDefinition.handle <...>/system/containers.toit:188:19
   2: ServiceManager_.<lambda>  <sdk>/system/services.toit:357:15
   3: RpcRequest_.process.<block> <sdk>/rpc/broker.toit:98:26
   4: RpcRequest_.process       <sdk>/rpc/broker.toit:95:3


### PR DESCRIPTION
It is a little bit inconvenient that the names of dynamically installed container images, do not show up. I'll think about a good way of getting them included, but it is hard to modify the system image assets and there are downsides (mostly size) to encoding the names of the images as assets associated with the individual images.

Jaguar already maintains names for the dynamically installed ones. Not sure if we can use that map somehow or if we need to find a way to provide a name when container images are installed.