### PR TITLE
Fix canonicalize on Windows.

### DIFF
--- a/src/compiler/filesystem.cc
+++ b/src/compiler/filesystem.cc
@@ -141,13 +141,14 @@ void Filesystem::canonicalize(char* path) {
       path[canonical_pos++] = path[i++];
     }
   }
-  // Drop trailing path seperator.
-  // There can only be one.
-  if (path[canonical_pos - 1] == path_separator()) {
+  // Drop trailing path seperator unless it's the root.
+  path[canonical_pos] = '\0';
+  if (!(is_absolute && is_root(path)) && path[canonical_pos - 1] == path_separator()) {
+    // There can only be one.
     canonical_pos--;
   }
   if (canonical_pos == 0) {
-    path[canonical_pos++] = is_absolute ? path_separator() : '.';
+    path[canonical_pos++] = '.';
   }
   path[canonical_pos] = '\0';
 }

--- a/src/compiler/filesystem.h
+++ b/src/compiler/filesystem.h
@@ -52,6 +52,9 @@ class Filesystem {
     result[1] = '\0';
     return result;
   }
+  virtual bool is_root(const char* path) {
+    return path[0] == '/' && path[1] == '\0';
+  }
 
   bool is_regular_file(const char* path);
   bool is_directory(const char* path);

--- a/src/compiler/filesystem_hybrid.cc
+++ b/src/compiler/filesystem_hybrid.cc
@@ -43,6 +43,11 @@ char* FilesystemHybrid::root(const char* path) {
   return do_with_active_fs<char*>(f);
 }
 
+bool FilesystemHybrid::is_root(const char* path) {
+  auto f = [&](Filesystem* fs) { return fs->is_root(path); };
+  return do_with_active_fs<bool>(f);
+}
+
 bool FilesystemHybrid::is_absolute(const char* path) {
   auto f = [&](const char* path, Filesystem* fs) { return fs->is_absolute(path); };
   return do_with_active_fs<bool>(path, f);

--- a/src/compiler/filesystem_hybrid.h
+++ b/src/compiler/filesystem_hybrid.h
@@ -39,6 +39,7 @@ class FilesystemHybrid : public Filesystem {
   bool is_absolute(const char* path);
   char path_separator();
   char* root(const char* path);
+  bool is_root(const char* path);
 
  protected:
   bool do_exists(const char* path);

--- a/src/compiler/filesystem_local.h
+++ b/src/compiler/filesystem_local.h
@@ -36,6 +36,7 @@ class FilesystemLocal : public Filesystem {
   bool is_absolute(const char* path);
   char path_separator();
   char* root(const char* path);
+  bool is_root(const char* path);
 
   /// Computes the executable path.
   ///

--- a/src/compiler/filesystem_local_posix.cc
+++ b/src/compiler/filesystem_local_posix.cc
@@ -48,6 +48,10 @@ char* FilesystemLocal::root(const char* path) {
   return Filesystem::root(path);
 }
 
+bool FilesystemLocal::is_root(const char* path) {
+  return Filesystem::is_root(path);
+}
+
 char* FilesystemLocal::to_local_path(const char* path) {
   if (path == null) return null;
   return strdup(path);

--- a/src/compiler/filesystem_local_win.cc
+++ b/src/compiler/filesystem_local_win.cc
@@ -67,6 +67,16 @@ char* FilesystemLocal::root(const char* path) {
   return strdup("\\\\");
 }
 
+bool FilesystemLocal::is_root(const char* path) {
+  // Something like "c:\".
+  if (path[1] == ':') {
+    return path[0] != '\n' && path[1] == ':' && path[2] == '\\' && path[3] == '\0';
+  }
+  // A network path like '\\Machine1'.
+  return path[0] == '\\' && path[1] == '\\' && path[2] == '\0';
+}
+
+
 char* FilesystemLocal::to_local_path(const char* path) {
   if (path == null) return null;
   char* result = strdup(path);


### PR DESCRIPTION
It would trim the trailing '\' of `c:\`.