### PR TITLE
Improve Windows support.

### DIFF
--- a/src/compiler/filesystem_local_win.cc
+++ b/src/compiler/filesystem_local_win.cc
@@ -29,7 +29,14 @@
 namespace toit {
 namespace compiler {
 
+// We need to pick between '\' and '/'. As much as I hate it,
+// '\' is still more common on Windows.
 static char PATH_SEPARATOR = '\\';
+
+// We accept both '/' and '\' as path separators.
+static bool is_path_separator(char c) {
+  return c == '/' || c == '\\';
+}
 
 char* FilesystemLocal::get_executable_path() {
   char* path = _new char[MAX_PATH];
@@ -44,8 +51,8 @@ bool FilesystemLocal::is_absolute(const char* path) {
   if (length < 3) return false;
   // Either a Windows drive like "c:\", or a network path "\\Machine1".
   // Network paths also include the WSL drive.
-  return (path[1] == ':' && path[2] == PATH_SEPARATOR) ||
-      (path[0] == PATH_SEPARATOR && path[1] == PATH_SEPARATOR);
+  return (path[1] == ':' && is_path_separator(path[2])) ||
+      (is_path_separator(path[0]) && is_path_separator(path[1]));
 }
 
 char FilesystemLocal::path_separator() {
@@ -70,10 +77,10 @@ char* FilesystemLocal::root(const char* path) {
 bool FilesystemLocal::is_root(const char* path) {
   // Something like "c:\".
   if (path[1] == ':') {
-    return path[0] != '\n' && path[1] == ':' && path[2] == '\\' && path[3] == '\0';
+    return path[0] != '\n' && path[1] == ':' && is_path_separator(path[2]) && path[3] == '\0';
   }
   // A network path like '\\Machine1'.
-  return path[0] == '\\' && path[1] == '\\' && path[2] == '\0';
+  return is_path_separator(path[0]) && is_path_separator(path[1]) && path[2] == '\0';
 }
 
 

--- a/src/compiler/filesystem_lsp.h
+++ b/src/compiler/filesystem_lsp.h
@@ -40,7 +40,9 @@ class FilesystemLsp : public Filesystem {
 
   const char* sdk_path();
   List<const char*> package_cache_paths();
-  bool is_absolute(const char* path) { return path[0] == '/'; }
+  bool is_absolute(const char* path) {
+    return path[0] == '/';
+  }
 
  protected:
   bool do_exists(const char* path);

--- a/src/primitive_file_win.cc
+++ b/src/primitive_file_win.cc
@@ -497,8 +497,9 @@ PRIMITIVE(is_open_file) {
   ARGS(int, fd);
   int result = lseek(fd, 0, SEEK_CUR);
   if (result < 0) {
-    if (errno == ESPIPE) return process->program()->false_object();
-    if (errno == EBADF) INVALID_ARGUMENT;
+    if (errno == ESPIPE || errno == EINVAL || errno == EBADF) {
+      return process->program()->false_object();
+    }
     OTHER_ERROR;
   }
   return process->program()->true_object();

--- a/tests/lsp/fail.cmake
+++ b/tests/lsp/fail.cmake
@@ -86,6 +86,7 @@ if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" OR "${CMAKE_SYSTEM_NAME}" STREQUAL
     tests/lsp/export_summary_compiler_test.toit
     tests/lsp/incomplete_compiler_test.toit
     tests/lsp/invalid_symbol_compiler_test.toit
+    tests/lsp/lsp_filesystem_compiler_test.toit
     tests/lsp/lsp_ubjson_rpc_compiler_test.toit
     tests/lsp/null_char_compiler_test.toit
     tests/lsp/open_many_compiler_test.toit

--- a/tests/lsp/goto_definition_test_runner.toit
+++ b/tests/lsp/goto_definition_test_runner.toit
@@ -33,7 +33,8 @@ class GotoDefinitionRunner extends LocationCompilerTestRunner:
     target := core_lib_entry.trim --left "core."
     expect
       actuals.any:
-        it.path.ends_with "core/$(target).toit"
+        path_slash := it.path.replace --all "\\" "/"
+        path_slash.ends_with "core/$(target).toit"
           and it.column == 0
           and it.line == 0
 

--- a/tests/lsp/location_compiler_test_runner_base.toit
+++ b/tests/lsp/location_compiler_test_runner_base.toit
@@ -35,6 +35,7 @@ abstract class LocationCompilerTestRunner:
     client.send_did_open --path=test_path --text=content
 
     lines := (content.trim --right "\n").split "\n"
+    lines = lines.map --in_place: it.trim --right "\r"
     for i := 0; i < lines.size; i++:
       line := lines[i]
       is_test_line := false

--- a/tests/lsp/mock_compiler.cc
+++ b/tests/lsp/mock_compiler.cc
@@ -3,9 +3,13 @@
 // be found in the tests/LICENSE file.
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdint.h>
 #include <string.h>
 #include <signal.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #include "../../src/top.h"
 #include "../../src/compiler/tar.h"
@@ -19,12 +23,63 @@
 #include "../../src/compiler/package.h"
 
 #ifdef TOIT_WINDOWS
-// Make the mock-compiler compile on Windows.
-// Clearly doesn't work yet.
-size_t getline (char** line_ptr,
-                size_t* n,
-                FILE* stream) {
-  UNIMPLEMENTED();
+// https://stackoverflow.com/a/47229318
+// /* The original code is public domain -- Will Hartung 4/9/09 */
+// /* Modifications, public domain as well, by Antti Haapala, 11/10/17
+//    - Switched to getc on 5/23/19 */
+// Slightly modified (floitsch):
+//  - avoid warnings with malloc
+//  - indentation
+//  - discard trailing '\r'.
+ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
+  size_t pos;
+  int c;
+
+  if (lineptr == NULL || stream == NULL || n == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  c = getc(stream);
+  if (c == EOF) {
+    return -1;
+  }
+
+  if (*lineptr == NULL) {
+    *lineptr = toit::unvoid_cast<char*>(malloc(128));
+    if (*lineptr == NULL) {
+      return -1;
+    }
+    *n = 128;
+  }
+
+  pos = 0;
+  while(c != EOF) {
+    if (pos + 1 >= *n) {
+      size_t new_size = *n + (*n >> 2);
+      if (new_size < 128) {
+        new_size = 128;
+      }
+      char *new_ptr = toit::unvoid_cast<char*>(realloc(*lineptr, new_size));
+      if (new_ptr == NULL) {
+        return -1;
+      }
+      *n = new_size;
+      *lineptr = new_ptr;
+    }
+
+    ((unsigned char *)(*lineptr))[pos ++] = c;
+    if (c == '\n') {
+      break;
+    }
+    c = getc(stream);
+  }
+
+  if (pos != 0 && (*lineptr)[pos - 1] == '\r') {
+    pos --;
+  }
+  (*lineptr)[pos] = '\0';
+  return pos;
 }
 #define SIGKILL 9
 #endif
@@ -53,6 +108,13 @@ void writer_printf(LspWriter* writer, const char* format, ...) {
 }
 
 int main(int argc, char** argv) {
+#ifdef TOIT_WINDOWS
+  // On Windows, we need to set the stdout to binary mode.
+  // Otherwise, the any '\n' we print becomes '\r\n'.
+  setmode(fileno(stdout), O_BINARY);
+  setmode(fileno(stdin), O_BINARY);
+  setmode(fileno(stderr), O_BINARY);
+#endif
   toit::throwing_new_allowed = true;
   const char* MOCK_PREFIX = "///mock:";
 
@@ -67,7 +129,10 @@ int main(int argc, char** argv) {
     // We only care for the first one, but will read all the remaining ones.
     ASSERT(path_count > 0);
     path = read_line();
-    for (int i = 1; i < path_count; i++) read_line();
+    for (int i = 1; i < path_count; i++) {
+      char* ignored_line = read_line();
+      free(ignored_line);
+    }
   } else {
     path = read_line();
     if (strcmp(command, "DUMP_FILE_NAMES") == 0) {

--- a/tests/lsp/utils.toit
+++ b/tests/lsp/utils.toit
@@ -25,10 +25,15 @@ class Location:
   constructor .path .line .column:
 
   operator== other/Location:
-    return path == other.path and line == other.line and column == other.column
+    return (to_slash_ path) == (to_slash_ other.path) and line == other.line and column == other.column
 
   stringify -> string:
     return "$path:$line:$column"
+
+  static to_slash_ path -> string:
+    if platform == PLATFORM_WINDOWS:
+      return path.replace --all "\\" "/"
+    return path
 
 // Also imports all relatively imported files.
 // Fails if there is an indirect recursion (directly importing itself is ok).

--- a/tools/lsp/server/file_server.toit
+++ b/tools/lsp/server/file_server.toit
@@ -27,10 +27,22 @@ import .utils
 import .verbose
 
 sdk_path_from_compiler compiler_path/string -> string:
+  is_absolute/bool := ?
+  if platform == PLATFORM_WINDOWS:
+    compiler_path = compiler_path.replace "\\" "/"
+    if compiler_path.starts_with "/":
+      is_absolute = true
+    else if compiler_path.size >= 3 and compiler_path[1] == ':' and compiler_path[2] == '/':
+      is_absolute = true
+    else:
+      is_absolute = false
+  else:
+    is_absolute = compiler_path.starts_with "/"
+
   index := compiler_path.index_of --last "/"
   if index < 0: throw "Couldn't determine SDK path"
   result := compiler_path.copy 0 index
-  if not result.starts_with "/":
+  if not is_absolute:
     // Make it absolute.
     result = "$directory.cwd/$result"
   return result


### PR DESCRIPTION
- allow '/' as path separators.
- add 'getline' function to tests.
- allow to use stdin from pipe package.