### PR TITLE
Break down the components of Toit memory use in OOM message.

### DIFF
--- a/src/process.cc
+++ b/src/process.cc
@@ -47,7 +47,8 @@ Process::Process(Program* program, ProcessRunner* runner, ProcessGroup* group, S
         program,
         this,
         initial_memory ? initial_memory->initial_chunk : null,
-        initial_memory ? initial_memory->global_variables : null)
+        initial_memory ? initial_memory->global_variables : null,
+        initial_memory ? initial_memory->heap_mutex : null)
     , last_bytes_allocated_(0)
     , termination_message_(termination)
     , random_seeded_(false)

--- a/src/program_heap.h
+++ b/src/program_heap.h
@@ -74,32 +74,6 @@ class ProgramHeap : public ProgramRawHeap {
 
   int64 total_bytes_allocated() const { return total_bytes_allocated_; }
 
-#ifndef TOIT_DEPLOY
-  void enter_gc() {
-    ASSERT(!in_gc_);
-    ASSERT(gc_allowed_);
-    in_gc_ = true;
-  }
-  void leave_gc() {
-    ASSERT(in_gc_);
-    in_gc_ = false;
-  }
-  void enter_no_gc() {
-    ASSERT(!in_gc_);
-    ASSERT(gc_allowed_);
-    gc_allowed_ = false;
-  }
-  void leave_no_gc() {
-    ASSERT(!gc_allowed_);
-    gc_allowed_ = true;
-  }
-#else
-  void enter_gc() {}
-  void leave_gc() {}
-  void enter_no_gc() {}
-  void leave_no_gc() {}
-#endif
-
   bool system_refused_memory() const {
     return last_allocation_result_ == ALLOCATION_OUT_OF_MEMORY;
   }

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -936,6 +936,16 @@ Process* Scheduler::find_process(Locker& locker, int pid) {
   return null;
 }
 
+void Scheduler::iterate_process_chunks(void* context, process_chunk_callback_t* callback) {
+  Locker locker(mutex_);
+  for (ProcessGroup* group : groups_) {
+    ProcessListFromProcessGroup& processes = group->processes();
+    for (auto it : processes) {
+      it->object_heap()->iterate_chunks(context, callback);
+    }
+  }
+}
+
 bool Scheduler::has_ready_processes(Locker& locker) {
   for (int i = 0; i < NUMBER_OF_READY_QUEUES; i++) {
     if (!ready_queue_[i].is_empty()) return true;

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -158,6 +158,8 @@ class Scheduler {
   bool is_locked() const { return OS::is_locked(mutex_); }
   bool is_boot_process(Process* process) const { return boot_process_ == process; }
 
+  void iterate_process_chunks(void* context, process_chunk_callback_t callback);
+
  private:
   // Introduce a new process to the scheduler. The scheduler will not terminate until
   // all processes has completed.

--- a/src/third_party/dartino/gc_metadata.cc
+++ b/src/third_party/dartino/gc_metadata.cc
@@ -20,6 +20,11 @@ void GcMetadata::tear_down() {
   OS::free_pages(singleton_.metadata_, singleton_.metadata_size_);
 }
 
+void GcMetadata::get_metadata_extent(uword* address_return, uword* size_return) {
+  *address_return = reinterpret_cast<uword>(singleton_.metadata_);
+  *size_return = singleton_.metadata_size_;
+}
+
 void GcMetadata::set_up() { singleton_.set_up_singleton(); }
 
 void GcMetadata::set_up_singleton() {

--- a/src/third_party/dartino/gc_metadata.h
+++ b/src/third_party/dartino/gc_metadata.h
@@ -24,6 +24,7 @@ class GcMetadata {
  public:
   static void set_up();
   static void tear_down();
+  static void get_metadata_extent(uword* address_return, uword* size_return);
 
   // When calculating the locations of compacted objects we want to use the
   // object starts array, which is arranged in card sizes for the remembered

--- a/src/third_party/dartino/object_memory.cc
+++ b/src/third_party/dartino/object_memory.cc
@@ -119,6 +119,13 @@ void Space::iterate_overflowed_objects(RootCallback* visitor, MarkingStack* stac
   }
 }
 
+void Space::iterate_chunks(void* context, Process* process, process_chunk_callback_t* callback) {
+  if (is_empty()) return;
+  for (auto chunk : chunk_list_) {
+    callback(context, process, chunk->start(), chunk->size());
+  }
+}
+
 void Space::iterate_objects(HeapObjectVisitor* visitor, LivenessOracle* filter) {
   if (is_empty()) return;
   flush();
@@ -295,7 +302,7 @@ void ObjectMemory::set_up() {
   spare_chunk_ = allocate_chunk(null, TOIT_PAGE_SIZE);
   if (!spare_chunk_) FATAL("Can't allocate initial spare chunk");
   if (spare_chunk_mutex_) FATAL("Can't call ObjectMemory::set_up twice");
-  spare_chunk_mutex_ = OS::allocate_mutex(6, "Spare memory chunk");
+  spare_chunk_mutex_ = OS::allocate_mutex(7, "Spare memory chunk");
 }
 
 }  // namespace toit

--- a/src/third_party/dartino/object_memory.h
+++ b/src/third_party/dartino/object_memory.h
@@ -178,6 +178,8 @@ class Space : public LivenessOracle {
   // Iterate all the objects that are grey, after a mark stack overflow.
   void iterate_overflowed_objects(RootCallback* visitor, MarkingStack* stack);
 
+  void iterate_chunks(void* context, Process* process, process_chunk_callback_t* callback);
+
   // Returns true if the address is inside this space.  Not particularly fast.
   // See GcMetadata::PageType for a faster possibility.
   bool includes(uword address);

--- a/src/third_party/dartino/two_space_heap.h
+++ b/src/third_party/dartino/two_space_heap.h
@@ -72,6 +72,11 @@ class TwoSpaceHeap {
     iterate_objects(&visitor);
   }
 
+  void iterate_chunks(void* context, process_chunk_callback_t* callback) {
+    semi_space_.iterate_chunks(context, process(), callback);
+    old_space_.iterate_chunks(context, process(), callback);
+  }
+
   // Flush will write cached values back to object memory.
   // Flush must be called before traveral of heap.
   void flush() {

--- a/src/top.h
+++ b/src/top.h
@@ -288,6 +288,7 @@ void fail(const char* format, ...) __attribute__ ((__noreturn__));
 // Common forward declarations.
 class AlignedMemory;
 class Block;
+class Chunk;
 class ProgramBlock;
 class ConditionVariable;
 class Encoder;
@@ -406,5 +407,7 @@ static const word ITERATE_TAG_HEAP_OVERHEAD = -2;
 static const word ITERATE_CUSTOM_TAGS = -100;
 
 static const int DEFAULT_OPTIMIZATION_LEVEL = 1;
+
+typedef void process_chunk_callback_t(void* context, Process* process, uword address, uword size);
 
 } // namespace toit


### PR DESCRIPTION
The same message is produced by the
serial_print_heap_report function.