### PR TITLE
Fix load-global-var bytecode.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,7 +110,7 @@ if (DEFINED ENV{TOIT_CHECK_PROPAGATED_TYPES})
   set(TOIT_INTERPRETER_FLAGS "${TOIT_INTERPRETER_FLAGS};-DTOIT_CHECK_PROPAGATED_TYPES")
 endif()
 
-set_source_files_properties(interpreter_core.cc PROPERTIES COMPILE_OPTIONS "-O3")
+set_source_files_properties(interpreter_core.cc PROPERTIES COMPILE_OPTIONS "-O3;$ENV{LOCAL_INTERPRETER_CXXFLAGS}")
 set_source_files_properties(interpreter_run.cc PROPERTIES COMPILE_OPTIONS "-O3;${TOIT_INTERPRETER_FLAGS};$ENV{LOCAL_INTERPRETER_CXXFLAGS}")
 set_source_files_properties(utils.cc PROPERTIES COMPILE_FLAGS "-DTOIT_MODEL=\"\\\"${TOIT_MODEL}\\\"\" -DVM_GIT_INFO=\"\\\"${VM_GIT_INFO}\\\"\" -DVM_GIT_VERSION=\"\\\"${TOIT_GIT_VERSION}\\\"\"")
 

--- a/src/bytecodes.h
+++ b/src/bytecodes.h
@@ -120,10 +120,10 @@ enum BytecodeFormat {
   BYTECODE(LOAD_METHOD,                5, OP_WU, "load method")                \
   \
   BYTECODE(LOAD_GLOBAL_VAR,            2, OP_BG, "load global var")            \
-  BYTECODE(LOAD_GLOBAL_VAR_DYNAMIC,    1, OP,    "load global var dynamic")    \
   BYTECODE(LOAD_GLOBAL_VAR_WIDE,       3, OP_SG, "load global var wide")       \
   BYTECODE(LOAD_GLOBAL_VAR_LAZY,       2, OP_BG, "load global var lazy")       \
   BYTECODE(LOAD_GLOBAL_VAR_LAZY_WIDE,  3, OP_SG, "load global var lazy wide")  \
+  BYTECODE(LOAD_GLOBAL_VAR_DYNAMIC,    1, OP,    "load global var dynamic")    \
   BYTECODE(STORE_GLOBAL_VAR,           2, OP_BG, "store global var")           \
   BYTECODE(STORE_GLOBAL_VAR_WIDE,      3, OP_SG, "store global var wide")      \
   BYTECODE(STORE_GLOBAL_VAR_DYNAMIC,   1, OP,    "store global var dynamic")   \

--- a/src/bytecodes.h
+++ b/src/bytecodes.h
@@ -144,7 +144,7 @@ enum BytecodeFormat {
   BYTECODE(AS_CLASS_WIDE,              3, OP_SCI, "as class wide")             \
   BYTECODE(AS_INTERFACE,               2, OP_BII, "as interface")              \
   BYTECODE(AS_INTERFACE_WIDE,          3, OP_SII, "as interface wide")         \
-  BYTECODE(AS_LOCAL,                   2, OP_BLC, "load local, as, pop")       \
+  BYTECODE(AS_LOCAL,                   2, OP_BLC, "load local, as class, pop") \
   \
   BYTECODE(INVOKE_STATIC,              3, OP_SD, "invoke static")              \
   BYTECODE(INVOKE_STATIC_TAIL,         5, OP_SD_BS_BU, "invoke static tail")   \

--- a/tests/ctest/bytecode_test.cc
+++ b/tests/ctest/bytecode_test.cc
@@ -1,0 +1,46 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <string>
+
+#include "../../src/top.h"
+#include "../../src/bytecodes.h"
+
+namespace toit {
+
+using namespace compiler;
+
+#define BYTECODE_NAME(name, length, format, print) #name,
+const char* ALL_BYTECODE_NAMES[] {
+  BYTECODES(BYTECODE_NAME) "ILLEGAL"
+};
+#undef BYTECODE_NAME
+
+static bool ends_with(const std::string& str, const std::string& suffix) {
+  return str.size() >= suffix.size() &&
+      str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+int main(int argc, char** argv) {
+  int count = sizeof(ALL_BYTECODE_NAMES) / sizeof(ALL_BYTECODE_NAMES[0]);
+  std::string last;
+  for (int i = 0; i < count; i++) {
+    auto current = std::string(ALL_BYTECODE_NAMES[i]);
+    if (ends_with(current, "WIDE")) {
+      printf("checking %s\n", current.c_str());
+      if (last + "_WIDE" != current) {
+        FATAL("WIDE bytecode must be non-wide + 1");
+      }
+    }
+    last = current;
+  }
+  return 0;
+}
+
+}
+
+int main(int argc, char** argv) {
+  toit::throwing_new_allowed = true;
+  return toit::main(argc, argv);
+}

--- a/tests/toitp/CMakeLists.txt
+++ b/tests/toitp/CMakeLists.txt
@@ -32,9 +32,31 @@ ADD_TOIT_EXE(
   ${TOITP_DEP}
   "")
 
-add_custom_target(build_test_toitp_exe DEPENDS ${TOITP_EXE})
-add_dependencies(check build_test_toitp_exe)
-add_dependencies(check_slow build_test_toitp_exe)
+add_executable(
+  bytecode_lister
+  bytecode_lister.cc
+)
+
+set(BYTECODE_LIST ${TOITP_TEST_DIR}/bytecode.output)
+
+add_custom_target(build_test_toitp_requirements DEPENDS ${TOITP_EXE} ${BYTECODE_LIST})
+add_dependencies(check build_test_toitp_requirements)
+add_dependencies(check_slow build_test_toitp_requirements)
+
+add_custom_command(
+  OUTPUT ${BYTECODE_LIST}
+  COMMAND $<TARGET_FILE:bytecode_lister> > ${BYTECODE_LIST}
+  DEPENDS $<TARGET_FILE:bytecode_lister>
+)
+
+set(BYTECODE_MATCH_TEST ${CMAKE_CURRENT_SOURCE_DIR}/bytecode_match_test.toit)
+file(RELATIVE_PATH BYTECODE_MATCH_TEST_NAME ${TOIT_SDK_SOURCE_DIR} ${BYTECODE_MATCH_TEST})
+set(BYTECODE_MATCH_TEST_NAME tests-toitp-bytecode_match_test)
+add_test(
+  NAME ${BYTECODE_MATCH_TEST_NAME}
+  COMMAND $<TARGET_FILE:toit.run> ${BYTECODE_MATCH_TEST} ${BYTECODE_LIST}
+  DEPENDS ${BYTECODE_LIST}
+  )
 
 foreach(file ${TOITP_TESTS})
   get_filename_component(base ${file} NAME_WE)

--- a/tests/toitp/bytecode_lister.cc
+++ b/tests/toitp/bytecode_lister.cc
@@ -1,0 +1,46 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <string>
+#include <stdio.h>
+
+#include "../../src/bytecodes.h"
+
+namespace toit {
+
+using namespace compiler;
+
+struct Bytecode {
+  const char* name;
+  int length;
+  const char* format;
+  const char* print;
+};
+
+#define BYTECODE_STRUCT(name_, length_, format_, print_) \
+  { .name=#name_, .length=length_, .format=#format_, .print=print_ },
+const Bytecode ALL_BYTECODES[] {
+  BYTECODES(BYTECODE_STRUCT)
+  { .name="ILLEGAL", .length=0, .format="", .print="" }
+};
+#undef BYTECODE_STRUCT
+
+int main(int argc, char** argv) {
+  int count = sizeof(ALL_BYTECODES) / sizeof(ALL_BYTECODES[0]);
+  // Don't print the illegal one.
+  for (int i = 0; i < count - 1; i++) {
+    printf("%s %d %s %s\n",
+            ALL_BYTECODES[i].name,
+            ALL_BYTECODES[i].length,
+            ALL_BYTECODES[i].format,
+            ALL_BYTECODES[i].print);
+  }
+  return 0;
+}
+
+}
+
+int main(int argc, char** argv) {
+  return toit::main(argc, argv);
+}

--- a/tests/toitp/bytecode_match_test.toit
+++ b/tests/toitp/bytecode_match_test.toit
@@ -1,0 +1,38 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+import host.file
+import ...tools.snapshot
+
+parse_bytecodes bytes:
+  str := bytes.to_string
+  lines := str.split "\n"
+  lines.map --in_place: it.trim
+  lines.filter --in_place: it != ""
+  return lines.map: | line/string |
+    space := line.index_of " "
+    name := line[..space]
+    size := int.parse line[space + 1..space + 2]
+    format_space := line.index_of " " (space + 3)
+    format := line[space + 3..format_space]
+    description := line[format_space + 1..]
+    [name, size, format, description]
+
+main args:
+  c_bytecode_list := parse_bytecodes (file.read_content args[0])
+  expect_equals BYTE_CODES.size c_bytecode_list.size
+  used_c_formats := {}
+  format_mapping := {:}
+  BYTE_CODES.size.repeat:
+    toit_bytecode /Bytecode := BYTE_CODES[it]
+    c_bytecode := c_bytecode_list[it]
+    if not format_mapping.contains toit_bytecode.format:
+      format_mapping[toit_bytecode.format] = c_bytecode[2]
+      expect_not (used_c_formats.contains c_bytecode[2])
+      used_c_formats.add c_bytecode[2]
+    expect_equals toit_bytecode.name c_bytecode[0]
+    expect_equals toit_bytecode.size c_bytecode[1]
+    expect_equals format_mapping[toit_bytecode.format] c_bytecode[2]
+    expect_equals toit_bytecode.description c_bytecode[3]

--- a/tests/type_propagation/gold/array_do_test.gold
+++ b/tests/type_propagation/gold/array_do_test.gold
@@ -2,7 +2,7 @@ main tests/type_propagation/array_do_test.toit
   0[025] - load smi 1
   1[053] - invoke static create_array_ <sdk>/core/collections.toit // [{SmallInteger_}] -> {LargeArray_|SmallArray_}
   4[053] - invoke static create_list_literal_from_array_ <sdk>/core/collections.toit // [{LargeArray_|SmallArray_}] -> {List_}
-  7[029] - load [block] in main tests/type_propagation/array_do_test.toit
+  7[029] - load method [block] in main tests/type_propagation/array_do_test.toit
  12[015] - load local 1
  13[038] - load block 1
  15[058] - invoke virtual do // [{List_}, [block]] -> {Null_}

--- a/tests/type_propagation/gold/array_do_test.gold-O2
+++ b/tests/type_propagation/gold/array_do_test.gold-O2
@@ -2,7 +2,7 @@ main tests/type_propagation/array_do_test.toit
   0[025] - load smi 1
   1[053] - invoke static create_array_ <sdk>/core/collections.toit // [{SmallInteger_}] -> {LargeArray_|SmallArray_}
   4[053] - invoke static create_list_literal_from_array_ <sdk>/core/collections.toit // [{LargeArray_|SmallArray_}] -> {List_}
-  7[029] - load [block] in main tests/type_propagation/array_do_test.toit
+  7[029] - load method [block] in main tests/type_propagation/array_do_test.toit
  12[015] - load local 1
  13[038] - load block 1
  15[058] - invoke virtual do // [{List_}, [block]] -> {Null_}

--- a/tests/type_propagation/gold/block_test.gold
+++ b/tests/type_propagation/gold/block_test.gold
@@ -20,7 +20,7 @@ main tests/type_propagation/block_test.toit
 
 test_simple tests/type_propagation/block_test.toit
   0[023] - load smi 0
-  1[029] - load [block] in test_simple tests/type_propagation/block_test.toit
+  1[029] - load method [block] in test_simple tests/type_propagation/block_test.toit
   6[025] - load smi 1
   7[038] - load block 1
   9[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {Null_}
@@ -40,21 +40,21 @@ test_simple tests/type_propagation/block_test.toit
   8[088] - return S1 1
 
 test_invokes tests/type_propagation/block_test.toit
-  0[029] - load [block] in test_invokes tests/type_propagation/block_test.toit
+  0[029] - load method [block] in test_invokes tests/type_propagation/block_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/block_test.toit // [[block]] -> {SmallInteger_}
  10[040] - pop 2
- 12[029] - load [block] in test_invokes tests/type_propagation/block_test.toit
+ 12[029] - load method [block] in test_invokes tests/type_propagation/block_test.toit
  17[020] - load literal horse
  19[038] - load block 1
  21[053] - invoke static invoke tests/type_propagation/block_test.toit // [{String_}, [block]] -> {String_}
  24[040] - pop 2
- 26[029] - load [block] in test_invokes tests/type_propagation/block_test.toit
+ 26[029] - load method [block] in test_invokes tests/type_propagation/block_test.toit
  31[026] - load smi 87
  33[038] - load block 1
  35[053] - invoke static invoke tests/type_propagation/block_test.toit // [{SmallInteger_}, [block]] -> {SmallInteger_}
  38[040] - pop 2
- 40[029] - load [block] in test_invokes tests/type_propagation/block_test.toit
+ 40[029] - load method [block] in test_invokes tests/type_propagation/block_test.toit
  45[020] - load literal true
  47[038] - load block 1
  49[053] - invoke static invoke tests/type_propagation/block_test.toit // [{True_}, [block]] -> {True_}
@@ -80,7 +80,7 @@ test_invokes tests/type_propagation/block_test.toit
 [block] in test_invokes tests/type_propagation/block_test.toit
  - argument 0: [block]
  - argument 1: {SmallInteger_}
-  0[029] - load [block] in [block] in test_invokes tests/type_propagation/block_test.toit
+  0[029] - load method [block] in [block] in test_invokes tests/type_propagation/block_test.toit
   5[017] - load local 3
   6[038] - load block 1
   8[053] - invoke static invoke tests/type_propagation/block_test.toit // [{SmallInteger_}, [block]] -> {SmallInteger_}
@@ -96,7 +96,7 @@ test_invokes tests/type_propagation/block_test.toit
 [block] in test_invokes tests/type_propagation/block_test.toit
  - argument 0: [block]
  - argument 1: {True_}
-  0[029] - load [block] in [block] in test_invokes tests/type_propagation/block_test.toit
+  0[029] - load method [block] in [block] in test_invokes tests/type_propagation/block_test.toit
   5[017] - load local 3
   6[038] - load block 1
   8[053] - invoke static invoke tests/type_propagation/block_test.toit // [{True_}, [block]] -> {True_}
@@ -105,7 +105,7 @@ test_invokes tests/type_propagation/block_test.toit
 
 test_nesting tests/type_propagation/block_test.toit
   0[022] - load null
-  1[029] - load [block] in test_nesting tests/type_propagation/block_test.toit
+  1[029] - load method [block] in test_nesting tests/type_propagation/block_test.toit
   6[038] - load block 0
   8[053] - invoke static invoke tests/type_propagation/block_test.toit // [[block]] -> {String_|SmallInteger_}
  11[041] - pop 1
@@ -113,7 +113,7 @@ test_nesting tests/type_propagation/block_test.toit
  14[053] - invoke static id tests/type_propagation/block_test.toit // [{String_|Null_|SmallInteger_}] -> {String_|Null_|SmallInteger_}
  17[041] - pop 1
  18[022] - load null
- 19[029] - load [block] in test_nesting tests/type_propagation/block_test.toit
+ 19[029] - load method [block] in test_nesting tests/type_propagation/block_test.toit
  24[038] - load block 0
  26[053] - invoke static invoke tests/type_propagation/block_test.toit // [[block]] -> {Null_|True_|float}
  29[041] - pop 1
@@ -141,7 +141,7 @@ test_nesting tests/type_propagation/block_test.toit
 
 [block] in test_nesting tests/type_propagation/block_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in test_nesting tests/type_propagation/block_test.toit
+  0[029] - load method [block] in [block] in test_nesting tests/type_propagation/block_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/block_test.toit // [[block]] -> {True_|float}
  10[041] - pop 1
@@ -173,7 +173,7 @@ test_nesting tests/type_propagation/block_test.toit
 
 test_catch tests/type_propagation/block_test.toit
   0[022] - load null
-  1[029] - load [block] in test_catch tests/type_propagation/block_test.toit
+  1[029] - load method [block] in test_catch tests/type_propagation/block_test.toit
   6[094] - link try 0
   8[038] - load block 4
  10[055] - invoke block S1 // [[block]] -> {False_}
@@ -182,7 +182,7 @@ test_catch tests/type_propagation/block_test.toit
  15[096] - unwind
  16[041] - pop 1
  17[022] - load null
- 18[029] - load [block] in test_catch tests/type_propagation/block_test.toit
+ 18[029] - load method [block] in test_catch tests/type_propagation/block_test.toit
  23[038] - load block 0
  25[022] - load null
  26[022] - load null
@@ -192,7 +192,7 @@ test_catch tests/type_propagation/block_test.toit
  33[053] - invoke static id tests/type_propagation/block_test.toit // [{Null_|SmallInteger_}] -> {Null_|SmallInteger_}
  36[041] - pop 1
  37[022] - load null
- 38[029] - load [block] in test_catch tests/type_propagation/block_test.toit
+ 38[029] - load method [block] in test_catch tests/type_propagation/block_test.toit
  43[038] - load block 0
  45[022] - load null
  46[022] - load null
@@ -232,7 +232,7 @@ test_catch tests/type_propagation/block_test.toit
  15[088] - return S1 1
 
 test_too_few_arguments tests/type_propagation/block_test.toit
-  0[029] - load [block] in test_too_few_arguments tests/type_propagation/block_test.toit
+  0[029] - load method [block] in test_too_few_arguments tests/type_propagation/block_test.toit
   5[038] - load block 0
   7[022] - load null
   8[022] - load null
@@ -241,7 +241,7 @@ test_too_few_arguments tests/type_propagation/block_test.toit
 
 [block] in test_too_few_arguments tests/type_propagation/block_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in test_too_few_arguments tests/type_propagation/block_test.toit
+  0[029] - load method [block] in [block] in test_too_few_arguments tests/type_propagation/block_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/block_test.toit // [[block]] -> {}
  10[040] - pop 2
@@ -252,7 +252,7 @@ test_too_few_arguments tests/type_propagation/block_test.toit
 test_modify_outer tests/type_propagation/block_test.toit
   0[026] - load smi 42
   2[014] - load local 0
-  3[029] - load [block] in test_modify_outer tests/type_propagation/block_test.toit
+  3[029] - load method [block] in test_modify_outer tests/type_propagation/block_test.toit
   8[026] - load smi 2
  10[038] - load block 1
  12[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {Null_}
@@ -277,7 +277,7 @@ test_modify_outer tests/type_propagation/block_test.toit
 test_modify_outer_nested tests/type_propagation/block_test.toit
   0[026] - load smi 42
   2[014] - load local 0
-  3[029] - load [block] in test_modify_outer_nested tests/type_propagation/block_test.toit
+  3[029] - load method [block] in test_modify_outer_nested tests/type_propagation/block_test.toit
   8[026] - load smi 2
  10[038] - load block 1
  12[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {Null_}
@@ -290,7 +290,7 @@ test_modify_outer_nested tests/type_propagation/block_test.toit
 
 [block] in test_modify_outer_nested tests/type_propagation/block_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in test_modify_outer_nested tests/type_propagation/block_test.toit
+  0[029] - load method [block] in [block] in test_modify_outer_nested tests/type_propagation/block_test.toit
   5[026] - load smi 3
   7[038] - load block 1
   9[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {Null_}
@@ -318,35 +318,35 @@ test_modify_outer_nested tests/type_propagation/block_test.toit
  18[088] - return S1 1
 
 test_recursion tests/type_propagation/block_test.toit
-  0[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+  0[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
   5[038] - load block 0
   7[053] - invoke static recursive_null tests/type_propagation/block_test.toit // [[block]] -> {Null_|SmallInteger_}
  10[040] - pop 2
- 12[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+ 12[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
  17[038] - load block 0
  19[053] - invoke static recursive_null tests/type_propagation/block_test.toit // [[block]] -> {Null_|False_}
  22[040] - pop 2
- 24[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+ 24[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
  29[038] - load block 0
  31[053] - invoke static recursive_call tests/type_propagation/block_test.toit // [[block]] -> {SmallInteger_}
  34[040] - pop 2
- 36[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+ 36[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
  41[038] - load block 0
  43[053] - invoke static recursive_call tests/type_propagation/block_test.toit // [[block]] -> {True_}
  46[040] - pop 2
- 48[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+ 48[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
  53[038] - load block 0
  55[053] - invoke static recursive_a_null tests/type_propagation/block_test.toit // [[block]] -> {Null_|SmallInteger_}
  58[040] - pop 2
- 60[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+ 60[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
  65[038] - load block 0
  67[053] - invoke static recursive_a_null tests/type_propagation/block_test.toit // [[block]] -> {String_|Null_}
  70[040] - pop 2
- 72[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+ 72[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
  77[038] - load block 0
  79[053] - invoke static recursive_a_call tests/type_propagation/block_test.toit // [[block]] -> {SmallInteger_}
  82[040] - pop 2
- 84[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+ 84[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
  89[038] - load block 0
  91[053] - invoke static recursive_a_call tests/type_propagation/block_test.toit // [[block]] -> {String_}
  94[089] - return null S2 0
@@ -392,15 +392,15 @@ test_recursion tests/type_propagation/block_test.toit
   2[088] - return S1 1
 
 test_dead tests/type_propagation/block_test.toit
-  0[029] - load [block] in test_dead tests/type_propagation/block_test.toit
+  0[029] - load method [block] in test_dead tests/type_propagation/block_test.toit
   5[038] - load block 0
   7[053] - invoke static ignore tests/type_propagation/block_test.toit // [[block]] -> {Null_}
  10[040] - pop 2
- 12[029] - load [block] in test_dead tests/type_propagation/block_test.toit
+ 12[029] - load method [block] in test_dead tests/type_propagation/block_test.toit
  17[038] - load block 0
  19[053] - invoke static ignore tests/type_propagation/block_test.toit // [[block]] -> {Null_}
  22[040] - pop 2
- 24[029] - load [block] in test_dead tests/type_propagation/block_test.toit
+ 24[029] - load method [block] in test_dead tests/type_propagation/block_test.toit
  29[038] - load block 0
  31[053] - invoke static ignore tests/type_propagation/block_test.toit // [[block]] -> {Null_}
  34[089] - return null S2 0
@@ -409,7 +409,7 @@ recursive_null tests/type_propagation/block_test.toit
  - argument 0: [block]
   0[053] - invoke static pick tests/type_propagation/block_test.toit // {True_|False_}
   3[082] - branch if false T21
-  6[029] - load [block] in recursive_null tests/type_propagation/block_test.toit
+  6[029] - load method [block] in recursive_null tests/type_propagation/block_test.toit
  11[038] - load block 0
  13[053] - invoke static recursive_null tests/type_propagation/block_test.toit // [[block]] -> {Null_}
  16[004] - store local, pop S1
@@ -438,7 +438,7 @@ recursive_a_null tests/type_propagation/block_test.toit
  - argument 0: [block]
   0[053] - invoke static pick tests/type_propagation/block_test.toit // {True_|False_}
   3[082] - branch if false T21
-  6[029] - load [block] in recursive_a_null tests/type_propagation/block_test.toit
+  6[029] - load method [block] in recursive_a_null tests/type_propagation/block_test.toit
  11[038] - load block 0
  13[053] - invoke static recursive_b_null tests/type_propagation/block_test.toit // [[block]] -> {Null_}
  16[004] - store local, pop S1
@@ -449,7 +449,7 @@ recursive_a_null tests/type_propagation/block_test.toit
 
 recursive_b_null tests/type_propagation/block_test.toit
  - argument 0: [block]
-  0[029] - load [block] in recursive_b_null tests/type_propagation/block_test.toit
+  0[029] - load method [block] in recursive_b_null tests/type_propagation/block_test.toit
   5[038] - load block 0
   7[053] - invoke static recursive_a_null tests/type_propagation/block_test.toit // [[block]] -> {Null_}
  10[004] - store local, pop S1

--- a/tests/type_propagation/gold/block_test.gold-O2
+++ b/tests/type_propagation/gold/block_test.gold-O2
@@ -20,7 +20,7 @@ main tests/type_propagation/block_test.toit
 
 test_simple tests/type_propagation/block_test.toit
   0[023] - load smi 0
-  1[029] - load [block] in test_simple tests/type_propagation/block_test.toit
+  1[029] - load method [block] in test_simple tests/type_propagation/block_test.toit
   6[025] - load smi 1
   7[038] - load block 1
   9[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {Null_}
@@ -40,21 +40,21 @@ test_simple tests/type_propagation/block_test.toit
   8[088] - return S1 1
 
 test_invokes tests/type_propagation/block_test.toit
-  0[029] - load [block] in test_invokes tests/type_propagation/block_test.toit
+  0[029] - load method [block] in test_invokes tests/type_propagation/block_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/block_test.toit // [[block]] -> {SmallInteger_}
  10[040] - pop 2
- 12[029] - load [block] in test_invokes tests/type_propagation/block_test.toit
+ 12[029] - load method [block] in test_invokes tests/type_propagation/block_test.toit
  17[020] - load literal horse
  19[038] - load block 1
  21[053] - invoke static invoke tests/type_propagation/block_test.toit // [{String_}, [block]] -> {String_}
  24[040] - pop 2
- 26[029] - load [block] in test_invokes tests/type_propagation/block_test.toit
+ 26[029] - load method [block] in test_invokes tests/type_propagation/block_test.toit
  31[026] - load smi 87
  33[038] - load block 1
  35[053] - invoke static invoke tests/type_propagation/block_test.toit // [{SmallInteger_}, [block]] -> {SmallInteger_}
  38[040] - pop 2
- 40[029] - load [block] in test_invokes tests/type_propagation/block_test.toit
+ 40[029] - load method [block] in test_invokes tests/type_propagation/block_test.toit
  45[020] - load literal true
  47[038] - load block 1
  49[053] - invoke static invoke tests/type_propagation/block_test.toit // [{True_}, [block]] -> {True_}
@@ -80,7 +80,7 @@ test_invokes tests/type_propagation/block_test.toit
 [block] in test_invokes tests/type_propagation/block_test.toit
  - argument 0: [block]
  - argument 1: {SmallInteger_}
-  0[029] - load [block] in [block] in test_invokes tests/type_propagation/block_test.toit
+  0[029] - load method [block] in [block] in test_invokes tests/type_propagation/block_test.toit
   5[017] - load local 3
   6[038] - load block 1
   8[053] - invoke static invoke tests/type_propagation/block_test.toit // [{SmallInteger_}, [block]] -> {SmallInteger_}
@@ -96,7 +96,7 @@ test_invokes tests/type_propagation/block_test.toit
 [block] in test_invokes tests/type_propagation/block_test.toit
  - argument 0: [block]
  - argument 1: {True_}
-  0[029] - load [block] in [block] in test_invokes tests/type_propagation/block_test.toit
+  0[029] - load method [block] in [block] in test_invokes tests/type_propagation/block_test.toit
   5[017] - load local 3
   6[038] - load block 1
   8[053] - invoke static invoke tests/type_propagation/block_test.toit // [{True_}, [block]] -> {True_}
@@ -105,7 +105,7 @@ test_invokes tests/type_propagation/block_test.toit
 
 test_nesting tests/type_propagation/block_test.toit
   0[022] - load null
-  1[029] - load [block] in test_nesting tests/type_propagation/block_test.toit
+  1[029] - load method [block] in test_nesting tests/type_propagation/block_test.toit
   6[038] - load block 0
   8[053] - invoke static invoke tests/type_propagation/block_test.toit // [[block]] -> {String_|SmallInteger_}
  11[041] - pop 1
@@ -113,7 +113,7 @@ test_nesting tests/type_propagation/block_test.toit
  14[053] - invoke static id tests/type_propagation/block_test.toit // [{String_|Null_|SmallInteger_}] -> {String_|Null_|SmallInteger_}
  17[041] - pop 1
  18[022] - load null
- 19[029] - load [block] in test_nesting tests/type_propagation/block_test.toit
+ 19[029] - load method [block] in test_nesting tests/type_propagation/block_test.toit
  24[038] - load block 0
  26[053] - invoke static invoke tests/type_propagation/block_test.toit // [[block]] -> {Null_|True_|float}
  29[041] - pop 1
@@ -141,7 +141,7 @@ test_nesting tests/type_propagation/block_test.toit
 
 [block] in test_nesting tests/type_propagation/block_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in test_nesting tests/type_propagation/block_test.toit
+  0[029] - load method [block] in [block] in test_nesting tests/type_propagation/block_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/block_test.toit // [[block]] -> {True_|float}
  10[041] - pop 1
@@ -173,7 +173,7 @@ test_nesting tests/type_propagation/block_test.toit
 
 test_catch tests/type_propagation/block_test.toit
   0[022] - load null
-  1[029] - load [block] in test_catch tests/type_propagation/block_test.toit
+  1[029] - load method [block] in test_catch tests/type_propagation/block_test.toit
   6[094] - link try 0
   8[038] - load block 4
  10[055] - invoke block S1 // [[block]] -> {False_}
@@ -182,7 +182,7 @@ test_catch tests/type_propagation/block_test.toit
  15[096] - unwind
  16[041] - pop 1
  17[022] - load null
- 18[029] - load [block] in test_catch tests/type_propagation/block_test.toit
+ 18[029] - load method [block] in test_catch tests/type_propagation/block_test.toit
  23[038] - load block 0
  25[022] - load null
  26[022] - load null
@@ -192,7 +192,7 @@ test_catch tests/type_propagation/block_test.toit
  33[053] - invoke static id tests/type_propagation/block_test.toit // [{Null_|SmallInteger_}] -> {Null_|SmallInteger_}
  36[041] - pop 1
  37[022] - load null
- 38[029] - load [block] in test_catch tests/type_propagation/block_test.toit
+ 38[029] - load method [block] in test_catch tests/type_propagation/block_test.toit
  43[038] - load block 0
  45[022] - load null
  46[022] - load null
@@ -232,7 +232,7 @@ test_catch tests/type_propagation/block_test.toit
  15[088] - return S1 1
 
 test_too_few_arguments tests/type_propagation/block_test.toit
-  0[029] - load [block] in test_too_few_arguments tests/type_propagation/block_test.toit
+  0[029] - load method [block] in test_too_few_arguments tests/type_propagation/block_test.toit
   5[038] - load block 0
   7[022] - load null
   8[022] - load null
@@ -241,7 +241,7 @@ test_too_few_arguments tests/type_propagation/block_test.toit
 
 [block] in test_too_few_arguments tests/type_propagation/block_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in test_too_few_arguments tests/type_propagation/block_test.toit
+  0[029] - load method [block] in [block] in test_too_few_arguments tests/type_propagation/block_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/block_test.toit // [[block]] -> {}
  10[004] - store local, pop S1
@@ -250,7 +250,7 @@ test_too_few_arguments tests/type_propagation/block_test.toit
 test_modify_outer tests/type_propagation/block_test.toit
   0[026] - load smi 42
   2[014] - load local 0
-  3[029] - load [block] in test_modify_outer tests/type_propagation/block_test.toit
+  3[029] - load method [block] in test_modify_outer tests/type_propagation/block_test.toit
   8[026] - load smi 2
  10[038] - load block 1
  12[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {Null_}
@@ -275,7 +275,7 @@ test_modify_outer tests/type_propagation/block_test.toit
 test_modify_outer_nested tests/type_propagation/block_test.toit
   0[026] - load smi 42
   2[014] - load local 0
-  3[029] - load [block] in test_modify_outer_nested tests/type_propagation/block_test.toit
+  3[029] - load method [block] in test_modify_outer_nested tests/type_propagation/block_test.toit
   8[026] - load smi 2
  10[038] - load block 1
  12[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {Null_}
@@ -288,7 +288,7 @@ test_modify_outer_nested tests/type_propagation/block_test.toit
 
 [block] in test_modify_outer_nested tests/type_propagation/block_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in test_modify_outer_nested tests/type_propagation/block_test.toit
+  0[029] - load method [block] in [block] in test_modify_outer_nested tests/type_propagation/block_test.toit
   5[026] - load smi 3
   7[038] - load block 1
   9[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {Null_}
@@ -316,35 +316,35 @@ test_modify_outer_nested tests/type_propagation/block_test.toit
  18[088] - return S1 1
 
 test_recursion tests/type_propagation/block_test.toit
-  0[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+  0[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
   5[038] - load block 0
   7[053] - invoke static recursive_null tests/type_propagation/block_test.toit // [[block]] -> {Null_|SmallInteger_}
  10[040] - pop 2
- 12[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+ 12[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
  17[038] - load block 0
  19[053] - invoke static recursive_null tests/type_propagation/block_test.toit // [[block]] -> {Null_|False_}
  22[040] - pop 2
- 24[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+ 24[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
  29[038] - load block 0
  31[053] - invoke static recursive_call tests/type_propagation/block_test.toit // [[block]] -> {SmallInteger_}
  34[040] - pop 2
- 36[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+ 36[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
  41[038] - load block 0
  43[053] - invoke static recursive_call tests/type_propagation/block_test.toit // [[block]] -> {True_}
  46[040] - pop 2
- 48[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+ 48[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
  53[038] - load block 0
  55[053] - invoke static recursive_a_null tests/type_propagation/block_test.toit // [[block]] -> {Null_|SmallInteger_}
  58[040] - pop 2
- 60[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+ 60[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
  65[038] - load block 0
  67[053] - invoke static recursive_a_null tests/type_propagation/block_test.toit // [[block]] -> {String_|Null_}
  70[040] - pop 2
- 72[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+ 72[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
  77[038] - load block 0
  79[053] - invoke static recursive_a_call tests/type_propagation/block_test.toit // [[block]] -> {SmallInteger_}
  82[040] - pop 2
- 84[029] - load [block] in test_recursion tests/type_propagation/block_test.toit
+ 84[029] - load method [block] in test_recursion tests/type_propagation/block_test.toit
  89[038] - load block 0
  91[053] - invoke static recursive_a_call tests/type_propagation/block_test.toit // [[block]] -> {String_}
  94[089] - return null S2 0
@@ -390,15 +390,15 @@ test_recursion tests/type_propagation/block_test.toit
   2[088] - return S1 1
 
 test_dead tests/type_propagation/block_test.toit
-  0[029] - load [block] in test_dead tests/type_propagation/block_test.toit
+  0[029] - load method [block] in test_dead tests/type_propagation/block_test.toit
   5[038] - load block 0
   7[053] - invoke static ignore tests/type_propagation/block_test.toit // [[block]] -> {Null_}
  10[040] - pop 2
- 12[029] - load [block] in test_dead tests/type_propagation/block_test.toit
+ 12[029] - load method [block] in test_dead tests/type_propagation/block_test.toit
  17[038] - load block 0
  19[053] - invoke static ignore tests/type_propagation/block_test.toit // [[block]] -> {Null_}
  22[040] - pop 2
- 24[029] - load [block] in test_dead tests/type_propagation/block_test.toit
+ 24[029] - load method [block] in test_dead tests/type_propagation/block_test.toit
  29[038] - load block 0
  31[053] - invoke static ignore tests/type_propagation/block_test.toit // [[block]] -> {Null_}
  34[089] - return null S2 0
@@ -407,7 +407,7 @@ recursive_null tests/type_propagation/block_test.toit
  - argument 0: [block]
   0[053] - invoke static pick tests/type_propagation/block_test.toit // {True_|False_}
   3[082] - branch if false T21
-  6[029] - load [block] in recursive_null tests/type_propagation/block_test.toit
+  6[029] - load method [block] in recursive_null tests/type_propagation/block_test.toit
  11[038] - load block 0
  13[053] - invoke static recursive_null tests/type_propagation/block_test.toit // [[block]] -> {Null_}
  16[004] - store local, pop S1
@@ -436,7 +436,7 @@ recursive_a_null tests/type_propagation/block_test.toit
  - argument 0: [block]
   0[053] - invoke static pick tests/type_propagation/block_test.toit // {True_|False_}
   3[082] - branch if false T21
-  6[029] - load [block] in recursive_a_null tests/type_propagation/block_test.toit
+  6[029] - load method [block] in recursive_a_null tests/type_propagation/block_test.toit
  11[038] - load block 0
  13[053] - invoke static recursive_b_null tests/type_propagation/block_test.toit // [[block]] -> {Null_}
  16[004] - store local, pop S1
@@ -447,7 +447,7 @@ recursive_a_null tests/type_propagation/block_test.toit
 
 recursive_b_null tests/type_propagation/block_test.toit
  - argument 0: [block]
-  0[029] - load [block] in recursive_b_null tests/type_propagation/block_test.toit
+  0[029] - load method [block] in recursive_b_null tests/type_propagation/block_test.toit
   5[038] - load block 0
   7[053] - invoke static recursive_a_null tests/type_propagation/block_test.toit // [[block]] -> {Null_}
  10[004] - store local, pop S1

--- a/tests/type_propagation/gold/deltablue_test.gold
+++ b/tests/type_propagation/gold/deltablue_test.gold
@@ -1,5 +1,5 @@
 main tests/type_propagation/deltablue_test.toit
-  0[029] - load [block] in main tests/type_propagation/deltablue_test.toit
+  0[029] - load method [block] in main tests/type_propagation/deltablue_test.toit
   5[026] - load smi 10
   7[038] - load block 1
   9[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {Null_}
@@ -40,42 +40,42 @@ Strength.next_weaker tests/type_propagation/deltablue_test.toit
   2[023] - load smi 0
   3[062] - invoke eq // [{Null_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
   4[082] - branch if false T14
-  7[033] - load global var lazy G6 // {Strength}
+  7[032] - load global var lazy G6 // {Strength}
   9[048] - as class Strength(47 - 48) // {True_}
  11[088] - return S1 1
  14[009] - load field local 2 // [{Strength}] -> {Null_|SmallInteger_}
  16[025] - load smi 1
  17[062] - invoke eq // [{Null_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
  18[082] - branch if false T28
- 21[033] - load global var lazy G5 // {Strength}
+ 21[032] - load global var lazy G5 // {Strength}
  23[048] - as class Strength(47 - 48) // {True_}
  25[088] - return S1 1
  28[009] - load field local 2 // [{Strength}] -> {Null_|SmallInteger_}
  30[026] - load smi 2
  32[062] - invoke eq // [{Null_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
  33[082] - branch if false T43
- 36[033] - load global var lazy G4 // {Strength}
+ 36[032] - load global var lazy G4 // {Strength}
  38[048] - as class Strength(47 - 48) // {True_}
  40[088] - return S1 1
  43[009] - load field local 2 // [{Strength}] -> {Null_|SmallInteger_}
  45[026] - load smi 3
  47[062] - invoke eq // [{Null_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
  48[082] - branch if false T58
- 51[033] - load global var lazy G3 // {Strength}
+ 51[032] - load global var lazy G3 // {Strength}
  53[048] - as class Strength(47 - 48) // {True_}
  55[088] - return S1 1
  58[009] - load field local 2 // [{Strength}] -> {Null_|SmallInteger_}
  60[026] - load smi 4
  62[062] - invoke eq // [{Null_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
  63[082] - branch if false T73
- 66[033] - load global var lazy G2 // {Strength}
+ 66[032] - load global var lazy G2 // {Strength}
  68[048] - as class Strength(47 - 48) // {True_}
  70[088] - return S1 1
  73[009] - load field local 2 // [{Strength}] -> {Null_|SmallInteger_}
  75[026] - load smi 5
  77[062] - invoke eq // [{Null_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
  78[082] - branch if false T88
- 81[033] - load global var lazy G1 // {Strength}
+ 81[032] - load global var lazy G1 // {Strength}
  83[048] - as class Strength(47 - 48) // {True_}
  85[088] - return S1 1
  88[053] - invoke static unreachable <sdk>/core/exceptions.toit // {}
@@ -203,7 +203,7 @@ Constraint.satisfy tests/type_propagation/deltablue_test.toit
  10[060] - invoke virtual get is_satisfied // [{EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {Null_|True_|False_}
  13[081] - branch if true T36
  16[009] - load field local 3 // [{EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {Null_|Strength}
- 18[033] - load global var lazy G0 // {Strength}
+ 18[032] - load global var lazy G0 // {Strength}
  20[062] - invoke eq // [{Null_|Strength}, {Strength}] -> {True_|False_}
  21[082] - branch if false T30
  24[020] - load literal Could not satisfy a required constraint!
@@ -811,7 +811,7 @@ Variable tests/type_propagation/deltablue_test.toit
  13[023] - load smi 0
  14[013] - store field, pop 3
  16[018] - load local 4
- 17[033] - load global var lazy G6 // {Strength}
+ 17[032] - load global var lazy G6 // {Strength}
  19[013] - store field, pop 4
  21[018] - load local 4
  22[020] - load literal true
@@ -878,7 +878,7 @@ Variable.remove_constraint tests/type_propagation/deltablue_test.toit
  - argument 1: {EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}
   0[052] - load local, as class, pop 2 - EqualityConstraint(43 - 47) // {True_}
   2[009] - load field local 99 // [{Variable}] -> {Null_|List_}
-  4[029] - load [block] in Variable.remove_constraint tests/type_propagation/deltablue_test.toit
+  4[029] - load method [block] in Variable.remove_constraint tests/type_propagation/deltablue_test.toit
   9[015] - load local 1
  10[038] - load block 1
  12[020] - load literal true
@@ -945,8 +945,8 @@ Planner.incremental_remove tests/type_propagation/deltablue_test.toit
  18[002] - pop, load local S4
  20[015] - load local 1
  21[053] - invoke static Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit // [{Planner}, {Null_|Variable}] -> {List_}
- 24[033] - load global var lazy G0 // {Strength}
- 26[029] - load [block] in Planner.incremental_remove tests/type_propagation/deltablue_test.toit
+ 24[032] - load global var lazy G0 // {Strength}
+ 26[029] - load method [block] in Planner.incremental_remove tests/type_propagation/deltablue_test.toit
  31[016] - load local 2
  32[038] - load block 1
  34[058] - invoke virtual do // [{List_}, [block]] -> {Null_}
@@ -955,7 +955,7 @@ Planner.incremental_remove tests/type_propagation/deltablue_test.toit
  41[058] - invoke virtual next_weaker // [{Strength}] -> {Strength}
  45[004] - store local, pop S1
  47[014] - load local 0
- 48[033] - load global var lazy G6 // {Strength}
+ 48[032] - load global var lazy G6 // {Strength}
  50[062] - invoke eq // [{Strength}, {Strength}] -> {True_|False_}
  51[082] - branch if false T57
  54[080] - branch T62
@@ -1040,7 +1040,7 @@ Planner.extract_plan_from_constraints tests/type_propagation/deltablue_test.toit
   7[014] - load local 0
   8[004] - store local, pop S1
  10[053] - invoke static create_list_literal_from_array_ <sdk>/core/collections.toit // [{LargeArray_|SmallArray_}] -> {List_}
- 13[029] - load [block] in Planner.extract_plan_from_constraints tests/type_propagation/deltablue_test.toit
+ 13[029] - load method [block] in Planner.extract_plan_from_constraints tests/type_propagation/deltablue_test.toit
  18[018] - load local 4
  19[038] - load block 1
  21[058] - invoke virtual do // [{List_}, [block]] -> {Null_}
@@ -1114,7 +1114,7 @@ Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit
   3[022] - load null
   4[013] - store field, pop 2
   6[016] - load local 2
-  7[033] - load global var lazy G6 // {Strength}
+  7[032] - load global var lazy G6 // {Strength}
   9[013] - store field, pop 4
  11[016] - load local 2
  12[020] - load literal true
@@ -1133,7 +1133,7 @@ Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit
  38[081] - branch if true T89
  41[014] - load local 0
  42[058] - invoke virtual remove_last // [{List_}] -> {*}
- 46[029] - load [block] in Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit
+ 46[029] - load method [block] in Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit
  51[015] - load local 1
  52[060] - invoke virtual get constraints // [{*}] -> {Null_|List_}
  55[038] - load block 1
@@ -1141,7 +1141,7 @@ Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit
  61[041] - pop 1
  62[002] - pop, load local S0
  64[060] - invoke virtual get determined_by // [{*}] -> {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}
- 67[029] - load [block] in Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit
+ 67[029] - load method [block] in Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit
  72[016] - load local 2
  73[060] - invoke virtual get constraints // [{*}] -> {Null_|List_}
  76[038] - load block 1
@@ -1192,7 +1192,7 @@ Planner.add_constraints_consuming_to tests/type_propagation/deltablue_test.toit
   0[052] - load local, as class, pop 3 - Variable(42 - 43) // {True_|False_}
   2[052] - load local, as class, pop 2 - List_(36 - 40) // {True_}
   4[009] - load field local 35 // [{Variable}] -> {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}
-  6[029] - load [block] in Planner.add_constraints_consuming_to tests/type_propagation/deltablue_test.toit
+  6[029] - load method [block] in Planner.add_constraints_consuming_to tests/type_propagation/deltablue_test.toit
  11[009] - load field local 101 // [{Variable}] -> {Null_|List_}
  13[038] - load block 1
  15[058] - invoke virtual do // [{Null_|List_}, [block]] -> {Null_}
@@ -1240,7 +1240,7 @@ Plan.add_constraint tests/type_propagation/deltablue_test.toit
 
 Plan.execute tests/type_propagation/deltablue_test.toit
  - argument 0: {Plan}
-  0[029] - load [block] in Plan.execute tests/type_propagation/deltablue_test.toit
+  0[029] - load method [block] in Plan.execute tests/type_propagation/deltablue_test.toit
   5[009] - load field local 3 // [{Plan}] -> {Null_|List_}
   7[038] - load block 1
   9[058] - invoke virtual do // [{Null_|List_}, [block]] -> {Null_}
@@ -1278,7 +1278,7 @@ chain_test tests/type_propagation/deltablue_test.toit
  35[018] - load local 4
  36[082] - branch if false T50
  39[042] - allocate instance EqualityConstraint
- 41[033] - load global var lazy G0 // {Strength}
+ 41[032] - load global var lazy G0 // {Strength}
  43[000] - load local S6
  45[017] - load local 3
  46[053] - invoke static EqualityConstraint tests/type_propagation/deltablue_test.toit // [{EqualityConstraint}, {Strength}, {Null_|Variable}, {Variable}] -> {EqualityConstraint}
@@ -1307,12 +1307,12 @@ chain_test tests/type_propagation/deltablue_test.toit
  80[083] - branch back T14
  85[041] - pop 1
  86[042] - allocate instance StayConstraint
- 88[033] - load global var lazy G3 // {Strength}
+ 88[032] - load global var lazy G3 // {Strength}
  90[016] - load local 2
  91[053] - invoke static StayConstraint tests/type_propagation/deltablue_test.toit // [{StayConstraint}, {Strength}, {Null_|Variable}] -> {StayConstraint}
  94[041] - pop 1
  95[042] - allocate instance EditConstraint
- 97[033] - load global var lazy G2 // {Strength}
+ 97[032] - load global var lazy G2 // {Strength}
  99[017] - load local 3
 100[053] - invoke static EditConstraint tests/type_propagation/deltablue_test.toit // [{EditConstraint}, {Strength}, {Null_|Variable}] -> {EditConstraint}
 103[030] - load global var G7 // {Null_|Planner}
@@ -1422,12 +1422,12 @@ projection_test tests/type_propagation/deltablue_test.toit
  84[053] - invoke static List.add <sdk>/core/collections.toit // [{List_}, {Variable}] -> {Null_}
  87[041] - pop 1
  88[042] - allocate instance StayConstraint
- 90[033] - load global var lazy G4 // {Strength}
+ 90[032] - load global var lazy G4 // {Strength}
  92[019] - load local 5
  93[053] - invoke static StayConstraint tests/type_propagation/deltablue_test.toit // [{StayConstraint}, {Strength}, {Variable}] -> {StayConstraint}
  96[041] - pop 1
  97[042] - allocate instance ScaleConstraint
- 99[033] - load global var lazy G0 // {Strength}
+ 99[032] - load global var lazy G0 // {Strength}
 101[019] - load local 5
 102[019] - load local 5
 103[000] - load local S9
@@ -1535,7 +1535,7 @@ change tests/type_propagation/deltablue_test.toit
   0[052] - load local, as class, pop 3 - Variable(42 - 43) // {True_|False_}
   2[052] - load local, as class, pop 2 - LargeInteger_(22 - 24) // {True_}
   4[042] - allocate instance EditConstraint
-  6[033] - load global var lazy G2 // {Strength}
+  6[032] - load global var lazy G2 // {Strength}
   8[019] - load local 5
   9[053] - invoke static EditConstraint tests/type_propagation/deltablue_test.toit // [{EditConstraint}, {Strength}, {Variable}] -> {EditConstraint}
  12[030] - load global var G7 // {Null_|Planner}
@@ -1543,7 +1543,7 @@ change tests/type_propagation/deltablue_test.toit
  15[053] - invoke static create_array_ <sdk>/core/collections.toit // [{EditConstraint}] -> {LargeArray_|SmallArray_}
  18[053] - invoke static create_list_literal_from_array_ <sdk>/core/collections.toit // [{LargeArray_|SmallArray_}] -> {List_}
  21[058] - invoke virtual extract_plan_from_constraints // [{Null_|Planner}, {List_}] -> {Plan}
- 25[029] - load [block] in change tests/type_propagation/deltablue_test.toit
+ 25[029] - load method [block] in change tests/type_propagation/deltablue_test.toit
  30[026] - load smi 10
  32[038] - load block 1
  34[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {Null_}

--- a/tests/type_propagation/gold/deltablue_test.gold-O2
+++ b/tests/type_propagation/gold/deltablue_test.gold-O2
@@ -1,5 +1,5 @@
 main tests/type_propagation/deltablue_test.toit
-  0[029] - load [block] in main tests/type_propagation/deltablue_test.toit
+  0[029] - load method [block] in main tests/type_propagation/deltablue_test.toit
   5[026] - load smi 10
   7[038] - load block 1
   9[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {Null_}
@@ -38,37 +38,37 @@ Strength.next_weaker tests/type_propagation/deltablue_test.toit
   2[023] - load smi 0
   3[062] - invoke eq // [{Null_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
   4[082] - branch if false T12
-  7[033] - load global var lazy G6 // {Strength}
+  7[032] - load global var lazy G6 // {Strength}
   9[088] - return S1 1
  12[009] - load field local 2 // [{Strength}] -> {Null_|SmallInteger_}
  14[025] - load smi 1
  15[062] - invoke eq // [{Null_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
  16[082] - branch if false T24
- 19[033] - load global var lazy G5 // {Strength}
+ 19[032] - load global var lazy G5 // {Strength}
  21[088] - return S1 1
  24[009] - load field local 2 // [{Strength}] -> {Null_|SmallInteger_}
  26[026] - load smi 2
  28[062] - invoke eq // [{Null_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
  29[082] - branch if false T37
- 32[033] - load global var lazy G4 // {Strength}
+ 32[032] - load global var lazy G4 // {Strength}
  34[088] - return S1 1
  37[009] - load field local 2 // [{Strength}] -> {Null_|SmallInteger_}
  39[026] - load smi 3
  41[062] - invoke eq // [{Null_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
  42[082] - branch if false T50
- 45[033] - load global var lazy G3 // {Strength}
+ 45[032] - load global var lazy G3 // {Strength}
  47[088] - return S1 1
  50[009] - load field local 2 // [{Strength}] -> {Null_|SmallInteger_}
  52[026] - load smi 4
  54[062] - invoke eq // [{Null_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
  55[082] - branch if false T63
- 58[033] - load global var lazy G2 // {Strength}
+ 58[032] - load global var lazy G2 // {Strength}
  60[088] - return S1 1
  63[009] - load field local 2 // [{Strength}] -> {Null_|SmallInteger_}
  65[026] - load smi 5
  67[062] - invoke eq // [{Null_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
  68[082] - branch if false T76
- 71[033] - load global var lazy G1 // {Strength}
+ 71[032] - load global var lazy G1 // {Strength}
  73[088] - return S1 1
  76[053] - invoke static unreachable <sdk>/core/exceptions.toit // {}
  79[041] - pop 1
@@ -191,7 +191,7 @@ Constraint.satisfy tests/type_propagation/deltablue_test.toit
   8[060] - invoke virtual get is_satisfied // [{EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {Null_|True_|False_}
  11[081] - branch if true T31
  14[009] - load field local 3 // [{EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {Null_|Strength}
- 16[033] - load global var lazy G0 // {Strength}
+ 16[032] - load global var lazy G0 // {Strength}
  18[062] - invoke eq // [{Null_|Strength}, {Strength}] -> {True_|False_}
  19[082] - branch if false T28
  22[020] - load literal Could not satisfy a required constraint!
@@ -754,7 +754,7 @@ Variable tests/type_propagation/deltablue_test.toit
   9[023] - load smi 0
  10[013] - store field, pop 3
  12[018] - load local 4
- 13[033] - load global var lazy G6 // {Strength}
+ 13[032] - load global var lazy G6 // {Strength}
  15[013] - store field, pop 4
  17[018] - load local 4
  18[020] - load literal true
@@ -818,7 +818,7 @@ Variable.remove_constraint tests/type_propagation/deltablue_test.toit
  - argument 0: {Variable}
  - argument 1: {EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}
   0[009] - load field local 99 // [{Variable}] -> {Null_|List_}
-  2[029] - load [block] in Variable.remove_constraint tests/type_propagation/deltablue_test.toit
+  2[029] - load method [block] in Variable.remove_constraint tests/type_propagation/deltablue_test.toit
   7[015] - load local 1
   8[038] - load block 1
  10[020] - load literal true
@@ -884,8 +884,8 @@ Planner.incremental_remove tests/type_propagation/deltablue_test.toit
  16[002] - pop, load local S4
  18[015] - load local 1
  19[053] - invoke static Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit // [{Planner}, {Null_|Variable}] -> {List_}
- 22[033] - load global var lazy G0 // {Strength}
- 24[029] - load [block] in Planner.incremental_remove tests/type_propagation/deltablue_test.toit
+ 22[032] - load global var lazy G0 // {Strength}
+ 24[029] - load method [block] in Planner.incremental_remove tests/type_propagation/deltablue_test.toit
  29[016] - load local 2
  30[038] - load block 1
  32[058] - invoke virtual do // [{List_}, [block]] -> {Null_}
@@ -894,7 +894,7 @@ Planner.incremental_remove tests/type_propagation/deltablue_test.toit
  39[058] - invoke virtual next_weaker // [{Strength}] -> {Strength}
  43[004] - store local, pop S1
  45[014] - load local 0
- 46[033] - load global var lazy G6 // {Strength}
+ 46[032] - load global var lazy G6 // {Strength}
  48[062] - invoke eq // [{Strength}, {Strength}] -> {True_|False_}
  49[082] - branch if false T55
  52[080] - branch T60
@@ -976,7 +976,7 @@ Planner.extract_plan_from_constraints tests/type_propagation/deltablue_test.toit
   5[014] - load local 0
   6[004] - store local, pop S1
   8[053] - invoke static create_list_literal_from_array_ <sdk>/core/collections.toit // [{LargeArray_|SmallArray_}] -> {List_}
- 11[029] - load [block] in Planner.extract_plan_from_constraints tests/type_propagation/deltablue_test.toit
+ 11[029] - load method [block] in Planner.extract_plan_from_constraints tests/type_propagation/deltablue_test.toit
  16[018] - load local 4
  17[038] - load block 1
  19[058] - invoke virtual do // [{List_}, [block]] -> {Null_}
@@ -1046,7 +1046,7 @@ Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit
   3[022] - load null
   4[013] - store field, pop 2
   6[016] - load local 2
-  7[033] - load global var lazy G6 // {Strength}
+  7[032] - load global var lazy G6 // {Strength}
   9[013] - store field, pop 4
  11[016] - load local 2
  12[020] - load literal true
@@ -1065,7 +1065,7 @@ Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit
  38[081] - branch if true T89
  41[014] - load local 0
  42[058] - invoke virtual remove_last // [{List_}] -> {*}
- 46[029] - load [block] in Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit
+ 46[029] - load method [block] in Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit
  51[015] - load local 1
  52[060] - invoke virtual get constraints // [{*}] -> {Null_|List_}
  55[038] - load block 1
@@ -1073,7 +1073,7 @@ Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit
  61[041] - pop 1
  62[002] - pop, load local S0
  64[060] - invoke virtual get determined_by // [{*}] -> {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}
- 67[029] - load [block] in Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit
+ 67[029] - load method [block] in Planner.remove_propagate_from tests/type_propagation/deltablue_test.toit
  72[016] - load local 2
  73[060] - invoke virtual get constraints // [{*}] -> {Null_|List_}
  76[038] - load block 1
@@ -1123,7 +1123,7 @@ Planner.add_constraints_consuming_to tests/type_propagation/deltablue_test.toit
  - argument 2: {List_}
   0[052] - load local, as class, pop 3 - Variable(37 - 38) // {True_|False_}
   2[009] - load field local 35 // [{Variable}] -> {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}
-  4[029] - load [block] in Planner.add_constraints_consuming_to tests/type_propagation/deltablue_test.toit
+  4[029] - load method [block] in Planner.add_constraints_consuming_to tests/type_propagation/deltablue_test.toit
   9[009] - load field local 101 // [{Variable}] -> {Null_|List_}
  11[038] - load block 1
  13[058] - invoke virtual do // [{Null_|List_}, [block]] -> {Null_}
@@ -1171,7 +1171,7 @@ Plan.add_constraint tests/type_propagation/deltablue_test.toit
 
 Plan.execute tests/type_propagation/deltablue_test.toit
  - argument 0: {Plan}
-  0[029] - load [block] in Plan.execute tests/type_propagation/deltablue_test.toit
+  0[029] - load method [block] in Plan.execute tests/type_propagation/deltablue_test.toit
   5[009] - load field local 3 // [{Plan}] -> {Null_|List_}
   7[038] - load block 1
   9[058] - invoke virtual do // [{Null_|List_}, [block]] -> {Null_}
@@ -1208,7 +1208,7 @@ chain_test tests/type_propagation/deltablue_test.toit
  33[018] - load local 4
  34[082] - branch if false T48
  37[042] - allocate instance EqualityConstraint
- 39[033] - load global var lazy G0 // {Strength}
+ 39[032] - load global var lazy G0 // {Strength}
  41[000] - load local S6
  43[017] - load local 3
  44[053] - invoke static EqualityConstraint tests/type_propagation/deltablue_test.toit // [{EqualityConstraint}, {Strength}, {Null_|Variable}, {Variable}] -> {EqualityConstraint}
@@ -1237,12 +1237,12 @@ chain_test tests/type_propagation/deltablue_test.toit
  78[083] - branch back T12
  83[041] - pop 1
  84[042] - allocate instance StayConstraint
- 86[033] - load global var lazy G3 // {Strength}
+ 86[032] - load global var lazy G3 // {Strength}
  88[016] - load local 2
  89[053] - invoke static StayConstraint tests/type_propagation/deltablue_test.toit // [{StayConstraint}, {Strength}, {Null_|Variable}] -> {StayConstraint}
  92[041] - pop 1
  93[042] - allocate instance EditConstraint
- 95[033] - load global var lazy G2 // {Strength}
+ 95[032] - load global var lazy G2 // {Strength}
  97[017] - load local 3
  98[053] - invoke static EditConstraint tests/type_propagation/deltablue_test.toit // [{EditConstraint}, {Strength}, {Null_|Variable}] -> {EditConstraint}
 101[030] - load global var G7 // {Null_|Planner}
@@ -1351,12 +1351,12 @@ projection_test tests/type_propagation/deltablue_test.toit
  82[053] - invoke static List.add <sdk>/core/collections.toit // [{List_}, {Variable}] -> {Null_}
  85[041] - pop 1
  86[042] - allocate instance StayConstraint
- 88[033] - load global var lazy G4 // {Strength}
+ 88[032] - load global var lazy G4 // {Strength}
  90[019] - load local 5
  91[053] - invoke static StayConstraint tests/type_propagation/deltablue_test.toit // [{StayConstraint}, {Strength}, {Variable}] -> {StayConstraint}
  94[041] - pop 1
  95[042] - allocate instance ScaleConstraint
- 97[033] - load global var lazy G0 // {Strength}
+ 97[032] - load global var lazy G0 // {Strength}
  99[019] - load local 5
 100[019] - load local 5
 101[000] - load local S9
@@ -1463,7 +1463,7 @@ change tests/type_propagation/deltablue_test.toit
  - argument 1: {SmallInteger_}
   0[052] - load local, as class, pop 3 - Variable(37 - 38) // {True_|False_}
   2[042] - allocate instance EditConstraint
-  4[033] - load global var lazy G2 // {Strength}
+  4[032] - load global var lazy G2 // {Strength}
   6[019] - load local 5
   7[053] - invoke static EditConstraint tests/type_propagation/deltablue_test.toit // [{EditConstraint}, {Strength}, {Variable}] -> {EditConstraint}
  10[030] - load global var G7 // {Null_|Planner}
@@ -1471,7 +1471,7 @@ change tests/type_propagation/deltablue_test.toit
  13[053] - invoke static create_array_ <sdk>/core/collections.toit // [{EditConstraint}] -> {LargeArray_|SmallArray_}
  16[053] - invoke static create_list_literal_from_array_ <sdk>/core/collections.toit // [{LargeArray_|SmallArray_}] -> {List_}
  19[058] - invoke virtual extract_plan_from_constraints // [{Null_|Planner}, {List_}] -> {Plan}
- 23[029] - load [block] in change tests/type_propagation/deltablue_test.toit
+ 23[029] - load method [block] in change tests/type_propagation/deltablue_test.toit
  28[026] - load smi 10
  30[038] - load block 1
  32[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {Null_}

--- a/tests/type_propagation/gold/finally_test.gold
+++ b/tests/type_propagation/gold/finally_test.gold
@@ -12,7 +12,7 @@ test_is_exception tests/type_propagation/finally_test.toit
   0[053] - invoke static return_is_exception tests/type_propagation/finally_test.toit // {True_|False_}
   3[041] - pop 1
   4[022] - load null
-  5[029] - load [block] in test_is_exception tests/type_propagation/finally_test.toit
+  5[029] - load method [block] in test_is_exception tests/type_propagation/finally_test.toit
  10[094] - link try 0
  12[038] - load block 4
  14[055] - invoke block S1 // [[block]] -> {Null_}
@@ -39,7 +39,7 @@ test_is_exception tests/type_propagation/finally_test.toit
   1[088] - return S1 1
 
 return_is_exception tests/type_propagation/finally_test.toit
-  0[029] - load [block] in return_is_exception tests/type_propagation/finally_test.toit
+  0[029] - load method [block] in return_is_exception tests/type_propagation/finally_test.toit
   5[094] - link try 0
   7[038] - load block 4
   9[055] - invoke block S1 // [[block]] -> {Null_}
@@ -66,7 +66,7 @@ test_exception tests/type_propagation/finally_test.toit
   0[053] - invoke static return_exception tests/type_propagation/finally_test.toit // {Null_|Exception_}
   3[041] - pop 1
   4[022] - load null
-  5[029] - load [block] in test_exception tests/type_propagation/finally_test.toit
+  5[029] - load method [block] in test_exception tests/type_propagation/finally_test.toit
  10[094] - link try 0
  12[038] - load block 4
  14[055] - invoke block S1 // [[block]] -> {Null_}
@@ -93,7 +93,7 @@ test_exception tests/type_propagation/finally_test.toit
   1[088] - return S1 1
 
 return_exception tests/type_propagation/finally_test.toit
-  0[029] - load [block] in return_exception tests/type_propagation/finally_test.toit
+  0[029] - load method [block] in return_exception tests/type_propagation/finally_test.toit
   5[094] - link try 0
   7[038] - load block 4
   9[055] - invoke block S1 // [[block]] -> {Null_}
@@ -121,7 +121,7 @@ test_catchy tests/type_propagation/finally_test.toit
   3[089] - return null S1 0
 
 catchy tests/type_propagation/finally_test.toit
-  0[029] - load [block] in catchy tests/type_propagation/finally_test.toit
+  0[029] - load method [block] in catchy tests/type_propagation/finally_test.toit
   5[094] - link try 0
   7[038] - load block 4
   9[055] - invoke block S1 // [[block]] -> {}
@@ -148,7 +148,7 @@ catchy tests/type_propagation/finally_test.toit
 
 test_nlb_out_of_try tests/type_propagation/finally_test.toit
   0[026] - load smi 4
-  2[029] - load [block] in test_nlb_out_of_try tests/type_propagation/finally_test.toit
+  2[029] - load method [block] in test_nlb_out_of_try tests/type_propagation/finally_test.toit
   7[094] - link try 0
   9[038] - load block 4
  11[055] - invoke block S1 // [[block]] -> {Null_}
@@ -162,7 +162,7 @@ test_nlb_out_of_try tests/type_propagation/finally_test.toit
 
 [block] in test_nlb_out_of_try tests/type_propagation/finally_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in test_nlb_out_of_try tests/type_propagation/finally_test.toit
+  0[029] - load method [block] in [block] in test_nlb_out_of_try tests/type_propagation/finally_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/finally_test.toit // [[block]] -> {}
  10[040] - pop 2
@@ -173,7 +173,7 @@ test_nlb_out_of_try tests/type_propagation/finally_test.toit
  22[041] - pop 1
  23[053] - invoke static pick tests/type_propagation/finally_test.toit // {True_|False_}
  26[082] - branch if false T41
- 29[029] - load [block] in [block] in test_nlb_out_of_try tests/type_propagation/finally_test.toit
+ 29[029] - load method [block] in [block] in test_nlb_out_of_try tests/type_propagation/finally_test.toit
  34[038] - load block 0
  36[053] - invoke static invoke tests/type_propagation/finally_test.toit // [[block]] -> {}
  39[040] - pop 2

--- a/tests/type_propagation/gold/finally_test.gold-O2
+++ b/tests/type_propagation/gold/finally_test.gold-O2
@@ -12,7 +12,7 @@ test_is_exception tests/type_propagation/finally_test.toit
   0[053] - invoke static return_is_exception tests/type_propagation/finally_test.toit // {True_|False_}
   3[041] - pop 1
   4[022] - load null
-  5[029] - load [block] in test_is_exception tests/type_propagation/finally_test.toit
+  5[029] - load method [block] in test_is_exception tests/type_propagation/finally_test.toit
  10[094] - link try 0
  12[038] - load block 4
  14[055] - invoke block S1 // [[block]] -> {Null_}
@@ -39,7 +39,7 @@ test_is_exception tests/type_propagation/finally_test.toit
   1[088] - return S1 1
 
 return_is_exception tests/type_propagation/finally_test.toit
-  0[029] - load [block] in return_is_exception tests/type_propagation/finally_test.toit
+  0[029] - load method [block] in return_is_exception tests/type_propagation/finally_test.toit
   5[094] - link try 0
   7[038] - load block 4
   9[055] - invoke block S1 // [[block]] -> {Null_}
@@ -66,7 +66,7 @@ test_exception tests/type_propagation/finally_test.toit
   0[053] - invoke static return_exception tests/type_propagation/finally_test.toit // {Null_|Exception_}
   3[041] - pop 1
   4[022] - load null
-  5[029] - load [block] in test_exception tests/type_propagation/finally_test.toit
+  5[029] - load method [block] in test_exception tests/type_propagation/finally_test.toit
  10[094] - link try 0
  12[038] - load block 4
  14[055] - invoke block S1 // [[block]] -> {Null_}
@@ -93,7 +93,7 @@ test_exception tests/type_propagation/finally_test.toit
   1[088] - return S1 1
 
 return_exception tests/type_propagation/finally_test.toit
-  0[029] - load [block] in return_exception tests/type_propagation/finally_test.toit
+  0[029] - load method [block] in return_exception tests/type_propagation/finally_test.toit
   5[094] - link try 0
   7[038] - load block 4
   9[055] - invoke block S1 // [[block]] -> {Null_}
@@ -121,7 +121,7 @@ test_catchy tests/type_propagation/finally_test.toit
   3[089] - return null S1 0
 
 catchy tests/type_propagation/finally_test.toit
-  0[029] - load [block] in catchy tests/type_propagation/finally_test.toit
+  0[029] - load method [block] in catchy tests/type_propagation/finally_test.toit
   5[094] - link try 0
   7[038] - load block 4
   9[055] - invoke block S1 // [[block]] -> {}
@@ -148,7 +148,7 @@ catchy tests/type_propagation/finally_test.toit
 
 test_nlb_out_of_try tests/type_propagation/finally_test.toit
   0[026] - load smi 4
-  2[029] - load [block] in test_nlb_out_of_try tests/type_propagation/finally_test.toit
+  2[029] - load method [block] in test_nlb_out_of_try tests/type_propagation/finally_test.toit
   7[094] - link try 0
   9[038] - load block 4
  11[055] - invoke block S1 // [[block]] -> {Null_}
@@ -162,7 +162,7 @@ test_nlb_out_of_try tests/type_propagation/finally_test.toit
 
 [block] in test_nlb_out_of_try tests/type_propagation/finally_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in test_nlb_out_of_try tests/type_propagation/finally_test.toit
+  0[029] - load method [block] in [block] in test_nlb_out_of_try tests/type_propagation/finally_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/finally_test.toit // [[block]] -> {}
  10[040] - pop 2
@@ -173,7 +173,7 @@ test_nlb_out_of_try tests/type_propagation/finally_test.toit
  22[041] - pop 1
  23[053] - invoke static pick tests/type_propagation/finally_test.toit // {True_|False_}
  26[082] - branch if false T41
- 29[029] - load [block] in [block] in test_nlb_out_of_try tests/type_propagation/finally_test.toit
+ 29[029] - load method [block] in [block] in test_nlb_out_of_try tests/type_propagation/finally_test.toit
  34[038] - load block 0
  36[053] - invoke static invoke tests/type_propagation/finally_test.toit // [[block]] -> {}
  39[040] - pop 2

--- a/tests/type_propagation/gold/global_test.gold
+++ b/tests/type_propagation/gold/global_test.gold
@@ -15,19 +15,19 @@ Z tests/type_propagation/global_test.toit
   3[088] - return S1 0
 
 test_simple tests/type_propagation/global_test.toit
-  0[033] - load global var lazy G0 // {SmallInteger_}
+  0[032] - load global var lazy G0 // {SmallInteger_}
   2[053] - invoke static id tests/type_propagation/global_test.toit // [{SmallInteger_}] -> {SmallInteger_}
   5[041] - pop 1
-  6[033] - load global var lazy G1 // {String_|SmallInteger_}
+  6[032] - load global var lazy G1 // {String_|SmallInteger_}
   8[053] - invoke static id tests/type_propagation/global_test.toit // [{String_|SmallInteger_}] -> {String_|SmallInteger_}
  11[041] - pop 1
  12[020] - load literal hest
  14[035] - store global var G1
  16[041] - pop 1
- 17[033] - load global var lazy G1 // {String_|SmallInteger_}
+ 17[032] - load global var lazy G1 // {String_|SmallInteger_}
  19[053] - invoke static id tests/type_propagation/global_test.toit // [{String_|SmallInteger_}] -> {String_|SmallInteger_}
  22[041] - pop 1
- 23[033] - load global var lazy G2 // {SmallInteger_}
+ 23[032] - load global var lazy G2 // {SmallInteger_}
  25[053] - invoke static id tests/type_propagation/global_test.toit // [{SmallInteger_}] -> {SmallInteger_}
  28[089] - return null S1 0
 

--- a/tests/type_propagation/gold/global_test.gold-O2
+++ b/tests/type_propagation/gold/global_test.gold-O2
@@ -15,19 +15,19 @@ Z tests/type_propagation/global_test.toit
   3[088] - return S1 0
 
 test_simple tests/type_propagation/global_test.toit
-  0[033] - load global var lazy G0 // {SmallInteger_}
+  0[032] - load global var lazy G0 // {SmallInteger_}
   2[053] - invoke static id tests/type_propagation/global_test.toit // [{SmallInteger_}] -> {SmallInteger_}
   5[041] - pop 1
-  6[033] - load global var lazy G1 // {String_|SmallInteger_}
+  6[032] - load global var lazy G1 // {String_|SmallInteger_}
   8[053] - invoke static id tests/type_propagation/global_test.toit // [{String_|SmallInteger_}] -> {String_|SmallInteger_}
  11[041] - pop 1
  12[020] - load literal hest
  14[035] - store global var G1
  16[041] - pop 1
- 17[033] - load global var lazy G1 // {String_|SmallInteger_}
+ 17[032] - load global var lazy G1 // {String_|SmallInteger_}
  19[053] - invoke static id tests/type_propagation/global_test.toit // [{String_|SmallInteger_}] -> {String_|SmallInteger_}
  22[041] - pop 1
- 23[033] - load global var lazy G2 // {SmallInteger_}
+ 23[032] - load global var lazy G2 // {SmallInteger_}
  25[053] - invoke static id tests/type_propagation/global_test.toit // [{SmallInteger_}] -> {SmallInteger_}
  28[089] - return null S1 0
 

--- a/tests/type_propagation/gold/lambda_test.gold
+++ b/tests/type_propagation/gold/lambda_test.gold
@@ -5,7 +5,7 @@ main tests/type_propagation/lambda_test.toit
   7[089] - return null S1 0
 
 test_simple tests/type_propagation/lambda_test.toit
-  0[029] - load [lambda] in test_simple tests/type_propagation/lambda_test.toit
+  0[029] - load method [lambda] in test_simple tests/type_propagation/lambda_test.toit
   5[023] - load smi 0
   6[022] - load null
   7[053] - invoke static Array_ <sdk>/core/collections.toit // [{SmallInteger_}, {Null_}] -> {LargeArray_|SmallArray_}
@@ -22,7 +22,7 @@ test_simple tests/type_propagation/lambda_test.toit
   2[088] - return S1 0
 
 test_arguments tests/type_propagation/lambda_test.toit
-  0[029] - load [lambda] in test_arguments tests/type_propagation/lambda_test.toit
+  0[029] - load method [lambda] in test_arguments tests/type_propagation/lambda_test.toit
   5[023] - load smi 0
   6[022] - load null
   7[053] - invoke static Array_ <sdk>/core/collections.toit // [{SmallInteger_}, {Null_}] -> {LargeArray_|SmallArray_}
@@ -33,7 +33,7 @@ test_arguments tests/type_propagation/lambda_test.toit
  17[026] - load smi 42
  19[053] - invoke static Lambda.call <sdk>/core/objects.toit // [{Lambda}, {SmallInteger_}] -> {*}
  22[041] - pop 1
- 23[029] - load [lambda] in test_arguments tests/type_propagation/lambda_test.toit
+ 23[029] - load method [lambda] in test_arguments tests/type_propagation/lambda_test.toit
  28[023] - load smi 0
  29[022] - load null
  30[053] - invoke static Array_ <sdk>/core/collections.toit // [{SmallInteger_}, {Null_}] -> {LargeArray_|SmallArray_}

--- a/tests/type_propagation/gold/lambda_test.gold-O2
+++ b/tests/type_propagation/gold/lambda_test.gold-O2
@@ -5,7 +5,7 @@ main tests/type_propagation/lambda_test.toit
   7[089] - return null S1 0
 
 test_simple tests/type_propagation/lambda_test.toit
-  0[029] - load [lambda] in test_simple tests/type_propagation/lambda_test.toit
+  0[029] - load method [lambda] in test_simple tests/type_propagation/lambda_test.toit
   5[023] - load smi 0
   6[022] - load null
   7[053] - invoke static Array_ <sdk>/core/collections.toit // [{SmallInteger_}, {Null_}] -> {LargeArray_|SmallArray_}
@@ -22,7 +22,7 @@ test_simple tests/type_propagation/lambda_test.toit
   2[088] - return S1 0
 
 test_arguments tests/type_propagation/lambda_test.toit
-  0[029] - load [lambda] in test_arguments tests/type_propagation/lambda_test.toit
+  0[029] - load method [lambda] in test_arguments tests/type_propagation/lambda_test.toit
   5[023] - load smi 0
   6[022] - load null
   7[053] - invoke static Array_ <sdk>/core/collections.toit // [{SmallInteger_}, {Null_}] -> {LargeArray_|SmallArray_}
@@ -33,7 +33,7 @@ test_arguments tests/type_propagation/lambda_test.toit
  17[026] - load smi 42
  19[053] - invoke static Lambda.call <sdk>/core/objects.toit // [{Lambda}, {SmallInteger_}] -> {*}
  22[041] - pop 1
- 23[029] - load [lambda] in test_arguments tests/type_propagation/lambda_test.toit
+ 23[029] - load method [lambda] in test_arguments tests/type_propagation/lambda_test.toit
  28[023] - load smi 0
  29[022] - load null
  30[053] - invoke static Array_ <sdk>/core/collections.toit // [{SmallInteger_}, {Null_}] -> {LargeArray_|SmallArray_}

--- a/tests/type_propagation/gold/nlr_test.gold
+++ b/tests/type_propagation/gold/nlr_test.gold
@@ -17,7 +17,7 @@ test_try tests/type_propagation/nlr_test.toit
   7[089] - return null S1 0
 
 always_return tests/type_propagation/nlr_test.toit
-  0[029] - load [block] in always_return tests/type_propagation/nlr_test.toit
+  0[029] - load method [block] in always_return tests/type_propagation/nlr_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/nlr_test.toit // [[block]] -> {}
  10[040] - pop 2
@@ -32,7 +32,7 @@ always_return tests/type_propagation/nlr_test.toit
   5[088] - return S1 1
 
 maybe_return tests/type_propagation/nlr_test.toit
-  0[029] - load [block] in maybe_return tests/type_propagation/nlr_test.toit
+  0[029] - load method [block] in maybe_return tests/type_propagation/nlr_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/nlr_test.toit // [[block]] -> {Null_}
  10[040] - pop 2
@@ -52,7 +52,7 @@ maybe_return tests/type_propagation/nlr_test.toit
 
 stop_unwinding tests/type_propagation/nlr_test.toit
   0[026] - load smi 42
-  2[029] - load [block] in stop_unwinding tests/type_propagation/nlr_test.toit
+  2[029] - load method [block] in stop_unwinding tests/type_propagation/nlr_test.toit
   7[094] - link try 0
   9[038] - load block 4
  11[055] - invoke block S1 // [[block]] -> {}
@@ -72,7 +72,7 @@ stop_unwinding tests/type_propagation/nlr_test.toit
   6[020] - load literal 3.2999999999999998224
   8[006] - store outer S1
  10[041] - pop 1
- 11[029] - load [block] in [block] in stop_unwinding tests/type_propagation/nlr_test.toit
+ 11[029] - load method [block] in [block] in stop_unwinding tests/type_propagation/nlr_test.toit
  16[038] - load block 0
  18[053] - invoke static invoke tests/type_propagation/nlr_test.toit // [[block]] -> {}
  21[041] - pop 1
@@ -91,7 +91,7 @@ stop_unwinding tests/type_propagation/nlr_test.toit
 
 stop_unwinding_alternative tests/type_propagation/nlr_test.toit
   0[026] - load smi 42
-  2[029] - load [block] in stop_unwinding_alternative tests/type_propagation/nlr_test.toit
+  2[029] - load method [block] in stop_unwinding_alternative tests/type_propagation/nlr_test.toit
   7[094] - link try 0
   9[038] - load block 4
  11[055] - invoke block S1 // [[block]] -> {True_}
@@ -108,7 +108,7 @@ stop_unwinding_alternative tests/type_propagation/nlr_test.toit
   1[020] - load literal 3.2999999999999998224
   3[006] - store outer S1
   5[041] - pop 1
-  6[029] - load [block] in [block] in stop_unwinding_alternative tests/type_propagation/nlr_test.toit
+  6[029] - load method [block] in [block] in stop_unwinding_alternative tests/type_propagation/nlr_test.toit
  11[038] - load block 0
  13[053] - invoke static invoke tests/type_propagation/nlr_test.toit // [[block]] -> {Null_}
  16[041] - pop 1

--- a/tests/type_propagation/gold/nlr_test.gold-O2
+++ b/tests/type_propagation/gold/nlr_test.gold-O2
@@ -17,7 +17,7 @@ test_try tests/type_propagation/nlr_test.toit
   7[089] - return null S1 0
 
 always_return tests/type_propagation/nlr_test.toit
-  0[029] - load [block] in always_return tests/type_propagation/nlr_test.toit
+  0[029] - load method [block] in always_return tests/type_propagation/nlr_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/nlr_test.toit // [[block]] -> {}
  10[041] - pop 1
@@ -30,7 +30,7 @@ always_return tests/type_propagation/nlr_test.toit
   5[088] - return S1 1
 
 maybe_return tests/type_propagation/nlr_test.toit
-  0[029] - load [block] in maybe_return tests/type_propagation/nlr_test.toit
+  0[029] - load method [block] in maybe_return tests/type_propagation/nlr_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/nlr_test.toit // [[block]] -> {Null_}
  10[040] - pop 2
@@ -50,7 +50,7 @@ maybe_return tests/type_propagation/nlr_test.toit
 
 stop_unwinding tests/type_propagation/nlr_test.toit
   0[026] - load smi 42
-  2[029] - load [block] in stop_unwinding tests/type_propagation/nlr_test.toit
+  2[029] - load method [block] in stop_unwinding tests/type_propagation/nlr_test.toit
   7[094] - link try 0
   9[038] - load block 4
  11[055] - invoke block S1 // [[block]] -> {}
@@ -70,7 +70,7 @@ stop_unwinding tests/type_propagation/nlr_test.toit
   6[020] - load literal 3.2999999999999998224
   8[006] - store outer S1
  10[041] - pop 1
- 11[029] - load [block] in [block] in stop_unwinding tests/type_propagation/nlr_test.toit
+ 11[029] - load method [block] in [block] in stop_unwinding tests/type_propagation/nlr_test.toit
  16[038] - load block 0
  18[053] - invoke static invoke tests/type_propagation/nlr_test.toit // [[block]] -> {}
  21[004] - store local, pop S1
@@ -86,7 +86,7 @@ stop_unwinding tests/type_propagation/nlr_test.toit
 
 stop_unwinding_alternative tests/type_propagation/nlr_test.toit
   0[026] - load smi 42
-  2[029] - load [block] in stop_unwinding_alternative tests/type_propagation/nlr_test.toit
+  2[029] - load method [block] in stop_unwinding_alternative tests/type_propagation/nlr_test.toit
   7[094] - link try 0
   9[038] - load block 4
  11[055] - invoke block S1 // [[block]] -> {True_}
@@ -103,7 +103,7 @@ stop_unwinding_alternative tests/type_propagation/nlr_test.toit
   1[020] - load literal 3.2999999999999998224
   3[006] - store outer S1
   5[041] - pop 1
-  6[029] - load [block] in [block] in stop_unwinding_alternative tests/type_propagation/nlr_test.toit
+  6[029] - load method [block] in [block] in stop_unwinding_alternative tests/type_propagation/nlr_test.toit
  11[038] - load block 0
  13[053] - invoke static invoke tests/type_propagation/nlr_test.toit // [[block]] -> {Null_}
  16[041] - pop 1

--- a/tests/type_propagation/gold/non_local_branch_test.gold
+++ b/tests/type_propagation/gold/non_local_branch_test.gold
@@ -8,7 +8,7 @@ main tests/type_propagation/non_local_branch_test.toit
 
 test_break tests/type_propagation/non_local_branch_test.toit
   0[026] - load smi 42
-  2[029] - load [block] in test_break tests/type_propagation/non_local_branch_test.toit
+  2[029] - load method [block] in test_break tests/type_propagation/non_local_branch_test.toit
   7[038] - load block 0
   9[053] - invoke static invoke tests/type_propagation/non_local_branch_test.toit // [[block]] -> {}
  12[040] - pop 2
@@ -28,7 +28,7 @@ test_break tests/type_propagation/non_local_branch_test.toit
 
 test_continue tests/type_propagation/non_local_branch_test.toit
   0[026] - load smi 42
-  2[029] - load [block] in test_continue tests/type_propagation/non_local_branch_test.toit
+  2[029] - load method [block] in test_continue tests/type_propagation/non_local_branch_test.toit
   7[038] - load block 0
   9[053] - invoke static invoke tests/type_propagation/non_local_branch_test.toit // [[block]] -> {}
  12[040] - pop 2
@@ -55,14 +55,14 @@ test_continue tests/type_propagation/non_local_branch_test.toit
  32[088] - return S1 1
 
 test_nested tests/type_propagation/non_local_branch_test.toit
-  0[029] - load [block] in test_nested tests/type_propagation/non_local_branch_test.toit
+  0[029] - load method [block] in test_nested tests/type_propagation/non_local_branch_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/non_local_branch_test.toit // [[block]] -> {Null_}
  10[089] - return null S2 0
 
 [block] in test_nested tests/type_propagation/non_local_branch_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in test_nested tests/type_propagation/non_local_branch_test.toit
+  0[029] - load method [block] in [block] in test_nested tests/type_propagation/non_local_branch_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/non_local_branch_test.toit // [[block]] -> {}
  10[040] - pop 2

--- a/tests/type_propagation/gold/non_local_branch_test.gold-O2
+++ b/tests/type_propagation/gold/non_local_branch_test.gold-O2
@@ -8,7 +8,7 @@ main tests/type_propagation/non_local_branch_test.toit
 
 test_break tests/type_propagation/non_local_branch_test.toit
   0[026] - load smi 42
-  2[029] - load [block] in test_break tests/type_propagation/non_local_branch_test.toit
+  2[029] - load method [block] in test_break tests/type_propagation/non_local_branch_test.toit
   7[038] - load block 0
   9[053] - invoke static invoke tests/type_propagation/non_local_branch_test.toit // [[block]] -> {}
  12[040] - pop 2
@@ -28,7 +28,7 @@ test_break tests/type_propagation/non_local_branch_test.toit
 
 test_continue tests/type_propagation/non_local_branch_test.toit
   0[026] - load smi 42
-  2[029] - load [block] in test_continue tests/type_propagation/non_local_branch_test.toit
+  2[029] - load method [block] in test_continue tests/type_propagation/non_local_branch_test.toit
   7[038] - load block 0
   9[053] - invoke static invoke tests/type_propagation/non_local_branch_test.toit // [[block]] -> {}
  12[040] - pop 2
@@ -55,14 +55,14 @@ test_continue tests/type_propagation/non_local_branch_test.toit
  32[088] - return S1 1
 
 test_nested tests/type_propagation/non_local_branch_test.toit
-  0[029] - load [block] in test_nested tests/type_propagation/non_local_branch_test.toit
+  0[029] - load method [block] in test_nested tests/type_propagation/non_local_branch_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/non_local_branch_test.toit // [[block]] -> {Null_}
  10[089] - return null S2 0
 
 [block] in test_nested tests/type_propagation/non_local_branch_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in test_nested tests/type_propagation/non_local_branch_test.toit
+  0[029] - load method [block] in [block] in test_nested tests/type_propagation/non_local_branch_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/non_local_branch_test.toit // [[block]] -> {}
  10[040] - pop 2

--- a/tests/type_propagation/gold/non_local_return_test.gold
+++ b/tests/type_propagation/gold/non_local_return_test.gold
@@ -5,7 +5,7 @@ main tests/type_propagation/non_local_return_test.toit
   7[089] - return null S1 0
 
 test_simple tests/type_propagation/non_local_return_test.toit
-  0[029] - load [block] in test_simple tests/type_propagation/non_local_return_test.toit
+  0[029] - load method [block] in test_simple tests/type_propagation/non_local_return_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/non_local_return_test.toit // [[block]] -> {}
  10[040] - pop 2
@@ -14,7 +14,7 @@ test_simple tests/type_propagation/non_local_return_test.toit
 
 [block] in test_simple tests/type_propagation/non_local_return_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in test_simple tests/type_propagation/non_local_return_test.toit
+  0[029] - load method [block] in [block] in test_simple tests/type_propagation/non_local_return_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/non_local_return_test.toit // [[block]] -> {}
  10[004] - store local, pop S1
@@ -22,7 +22,7 @@ test_simple tests/type_propagation/non_local_return_test.toit
 
 [block] in [block] in test_simple tests/type_propagation/non_local_return_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in [block] in test_simple tests/type_propagation/non_local_return_test.toit
+  0[029] - load method [block] in [block] in [block] in test_simple tests/type_propagation/non_local_return_test.toit
   5[026] - load smi 3
   7[038] - load block 1
   9[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {}
@@ -39,14 +39,14 @@ test_simple tests/type_propagation/non_local_return_test.toit
   9[088] - return S1 1
 
 test_continue tests/type_propagation/non_local_return_test.toit
-  0[029] - load [block] in test_continue tests/type_propagation/non_local_return_test.toit
+  0[029] - load method [block] in test_continue tests/type_propagation/non_local_return_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/non_local_return_test.toit // [[block]] -> {String_}
  10[089] - return null S2 0
 
 [block] in test_continue tests/type_propagation/non_local_return_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in test_continue tests/type_propagation/non_local_return_test.toit
+  0[029] - load method [block] in [block] in test_continue tests/type_propagation/non_local_return_test.toit
   5[026] - load smi 3
   7[038] - load block 1
   9[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {}

--- a/tests/type_propagation/gold/non_local_return_test.gold-O2
+++ b/tests/type_propagation/gold/non_local_return_test.gold-O2
@@ -5,14 +5,14 @@ main tests/type_propagation/non_local_return_test.toit
   7[089] - return null S1 0
 
 test_simple tests/type_propagation/non_local_return_test.toit
-  0[029] - load [block] in test_simple tests/type_propagation/non_local_return_test.toit
+  0[029] - load method [block] in test_simple tests/type_propagation/non_local_return_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/non_local_return_test.toit // [[block]] -> {}
  10[041] - pop 1
 
 [block] in test_simple tests/type_propagation/non_local_return_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in test_simple tests/type_propagation/non_local_return_test.toit
+  0[029] - load method [block] in [block] in test_simple tests/type_propagation/non_local_return_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/non_local_return_test.toit // [[block]] -> {}
  10[004] - store local, pop S1
@@ -20,7 +20,7 @@ test_simple tests/type_propagation/non_local_return_test.toit
 
 [block] in [block] in test_simple tests/type_propagation/non_local_return_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in [block] in test_simple tests/type_propagation/non_local_return_test.toit
+  0[029] - load method [block] in [block] in [block] in test_simple tests/type_propagation/non_local_return_test.toit
   5[026] - load smi 3
   7[038] - load block 1
   9[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {}
@@ -37,14 +37,14 @@ test_simple tests/type_propagation/non_local_return_test.toit
   9[088] - return S1 1
 
 test_continue tests/type_propagation/non_local_return_test.toit
-  0[029] - load [block] in test_continue tests/type_propagation/non_local_return_test.toit
+  0[029] - load method [block] in test_continue tests/type_propagation/non_local_return_test.toit
   5[038] - load block 0
   7[053] - invoke static invoke tests/type_propagation/non_local_return_test.toit // [[block]] -> {String_}
  10[089] - return null S2 0
 
 [block] in test_continue tests/type_propagation/non_local_return_test.toit
  - argument 0: [block]
-  0[029] - load [block] in [block] in test_continue tests/type_propagation/non_local_return_test.toit
+  0[029] - load method [block] in [block] in test_continue tests/type_propagation/non_local_return_test.toit
   5[026] - load smi 3
   7[038] - load block 1
   9[058] - invoke virtual repeat // [{SmallInteger_}, [block]] -> {}

--- a/tests/type_propagation/gold/richards_test.gold
+++ b/tests/type_propagation/gold/richards_test.gold
@@ -89,11 +89,11 @@ run_richards tests/type_propagation/richards_test.toit
 153[002] - pop, load local S1
 155[053] - invoke static Scheduler.schedule tests/type_propagation/richards_test.toit // [{Scheduler}] -> {Null_}
 158[041] - pop 1
-159[029] - load [block] in run_richards tests/type_propagation/richards_test.toit
+159[029] - load method [block] in run_richards tests/type_propagation/richards_test.toit
 164[038] - load block 0
 166[053] - invoke static assert_ <sdk>/core/assert_.toit // [[block]] -> {Null_}
 169[040] - pop 2
-171[029] - load [block] in run_richards tests/type_propagation/richards_test.toit
+171[029] - load method [block] in run_richards tests/type_propagation/richards_test.toit
 176[038] - load block 0
 178[053] - invoke static assert_ <sdk>/core/assert_.toit // [[block]] -> {Null_}
 181[089] - return null S4 0
@@ -434,7 +434,7 @@ TaskControlBlock.mark_as_not_held tests/type_propagation/richards_test.toit
  - argument 0: {TaskControlBlock}
   0[016] - load local 2
   1[009] - load field local 83 // [{TaskControlBlock}] -> {Null_|LargeInteger_|SmallInteger_}
-  3[033] - load global var lazy G0 // {SmallInteger_}
+  3[032] - load global var lazy G0 // {SmallInteger_}
   5[069] - invoke bit and // [{Null_|LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
   6[048] - as class LargeInteger_(22 - 24) // {True_}
   8[013] - store field, pop 5

--- a/tests/type_propagation/gold/richards_test.gold-O2
+++ b/tests/type_propagation/gold/richards_test.gold-O2
@@ -89,11 +89,11 @@ run_richards tests/type_propagation/richards_test.toit
 153[002] - pop, load local S1
 155[053] - invoke static Scheduler.schedule tests/type_propagation/richards_test.toit // [{Scheduler}] -> {Null_}
 158[041] - pop 1
-159[029] - load [block] in run_richards tests/type_propagation/richards_test.toit
+159[029] - load method [block] in run_richards tests/type_propagation/richards_test.toit
 164[038] - load block 0
 166[053] - invoke static assert_ <sdk>/core/assert_.toit // [[block]] -> {Null_}
 169[040] - pop 2
-171[029] - load [block] in run_richards tests/type_propagation/richards_test.toit
+171[029] - load method [block] in run_richards tests/type_propagation/richards_test.toit
 176[038] - load block 0
 178[053] - invoke static assert_ <sdk>/core/assert_.toit // [[block]] -> {Null_}
 181[089] - return null S4 0
@@ -405,7 +405,7 @@ TaskControlBlock.mark_as_not_held tests/type_propagation/richards_test.toit
  - argument 0: {TaskControlBlock}
   0[016] - load local 2
   1[009] - load field local 83 // [{TaskControlBlock}] -> {Null_|LargeInteger_|SmallInteger_}
-  3[033] - load global var lazy G0 // {SmallInteger_}
+  3[032] - load global var lazy G0 // {SmallInteger_}
   5[069] - invoke bit and // [{Null_|LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
   6[013] - store field, pop 5
   8[089] - return null S0 1

--- a/tests/type_propagation/gold/spawn_test.gold
+++ b/tests/type_propagation/gold/spawn_test.gold
@@ -1,5 +1,5 @@
 main tests/type_propagation/spawn_test.toit
-  0[029] - load [lambda] in main tests/type_propagation/spawn_test.toit
+  0[029] - load method [lambda] in main tests/type_propagation/spawn_test.toit
   5[023] - load smi 0
   6[022] - load null
   7[053] - invoke static Array_ <sdk>/core/collections.toit // [{SmallInteger_}, {Null_}] -> {LargeArray_|SmallArray_}

--- a/tests/type_propagation/gold/spawn_test.gold-O2
+++ b/tests/type_propagation/gold/spawn_test.gold-O2
@@ -1,5 +1,5 @@
 main tests/type_propagation/spawn_test.toit
-  0[029] - load [lambda] in main tests/type_propagation/spawn_test.toit
+  0[029] - load method [lambda] in main tests/type_propagation/spawn_test.toit
   5[023] - load smi 0
   6[022] - load null
   7[053] - invoke static Array_ <sdk>/core/collections.toit // [{SmallInteger_}, {Null_}] -> {LargeArray_|SmallArray_}

--- a/tests/type_propagation/gold/try_test.gold
+++ b/tests/type_propagation/gold/try_test.gold
@@ -8,7 +8,7 @@ test_nested tests/type_propagation/try_test.toit
 
 nested tests/type_propagation/try_test.toit
   0[022] - load null
-  1[029] - load [block] in nested tests/type_propagation/try_test.toit
+  1[029] - load method [block] in nested tests/type_propagation/try_test.toit
   6[094] - link try 0
   8[038] - load block 4
  10[055] - invoke block S1 // [[block]] -> {Null_}
@@ -22,7 +22,7 @@ nested tests/type_propagation/try_test.toit
 [block] in nested tests/type_propagation/try_test.toit
  - argument 0: [block]
   0[022] - load null
-  1[029] - load [block] in [block] in nested tests/type_propagation/try_test.toit
+  1[029] - load method [block] in [block] in nested tests/type_propagation/try_test.toit
   6[094] - link try 0
   8[038] - load block 4
  10[055] - invoke block S1 // [[block]] -> {SmallInteger_}

--- a/tests/type_propagation/gold/try_test.gold-O2
+++ b/tests/type_propagation/gold/try_test.gold-O2
@@ -8,7 +8,7 @@ test_nested tests/type_propagation/try_test.toit
 
 nested tests/type_propagation/try_test.toit
   0[022] - load null
-  1[029] - load [block] in nested tests/type_propagation/try_test.toit
+  1[029] - load method [block] in nested tests/type_propagation/try_test.toit
   6[094] - link try 0
   8[038] - load block 4
  10[055] - invoke block S1 // [[block]] -> {Null_}
@@ -22,7 +22,7 @@ nested tests/type_propagation/try_test.toit
 [block] in nested tests/type_propagation/try_test.toit
  - argument 0: [block]
   0[022] - load null
-  1[029] - load [block] in [block] in nested tests/type_propagation/try_test.toit
+  1[029] - load method [block] in [block] in nested tests/type_propagation/try_test.toit
   6[094] - link try 0
   8[038] - load block 4
  10[055] - invoke block S1 // [[block]] -> {SmallInteger_}

--- a/tests/type_propagation/gold/typecheck_test.gold
+++ b/tests/type_propagation/gold/typecheck_test.gold
@@ -39,13 +39,13 @@ test_any tests/type_propagation/typecheck_test.toit
  23[089] - return null S1 0
 
 test_throws tests/type_propagation/typecheck_test.toit
-  0[029] - load [block] in test_throws tests/type_propagation/typecheck_test.toit
+  0[029] - load method [block] in test_throws tests/type_propagation/typecheck_test.toit
   5[038] - load block 0
   7[022] - load null
   8[022] - load null
   9[053] - invoke static catch <sdk>/core/exceptions.toit // [[block], {Null_}, {Null_}] -> {*}
  12[040] - pop 2
- 14[029] - load [block] in test_throws tests/type_propagation/typecheck_test.toit
+ 14[029] - load method [block] in test_throws tests/type_propagation/typecheck_test.toit
  19[038] - load block 0
  21[022] - load null
  22[022] - load null

--- a/tests/type_propagation/gold/typecheck_test.gold-O2
+++ b/tests/type_propagation/gold/typecheck_test.gold-O2
@@ -39,13 +39,13 @@ test_any tests/type_propagation/typecheck_test.toit
  23[089] - return null S1 0
 
 test_throws tests/type_propagation/typecheck_test.toit
-  0[029] - load [block] in test_throws tests/type_propagation/typecheck_test.toit
+  0[029] - load method [block] in test_throws tests/type_propagation/typecheck_test.toit
   5[038] - load block 0
   7[022] - load null
   8[022] - load null
   9[053] - invoke static catch <sdk>/core/exceptions.toit // [[block], {Null_}, {Null_}] -> {*}
  12[040] - pop 2
- 14[029] - load [block] in test_throws tests/type_propagation/typecheck_test.toit
+ 14[029] - load method [block] in test_throws tests/type_propagation/typecheck_test.toit
  19[038] - load block 0
  21[022] - load null
  22[022] - load null

--- a/tools/snapshot.toit
+++ b/tools/snapshot.toit
@@ -812,12 +812,12 @@ BYTE_CODES ::= [
   Bytecode "LOAD_SMI_U8"                2 OP_BU "load smi",
   Bytecode "LOAD_SMI_U16"               3 OP_SU "load smi",
   Bytecode "LOAD_SMI_U32"               5 OP_WU "load smi",
-  Bytecode "LOAD_METHOD"                5 OP_WU "load",  // Has specialized stringification.
+  Bytecode "LOAD_METHOD"                5 OP_WU "load method",  // Has specialized stringification.
   Bytecode "LOAD_GLOBAL_VAR"            2 OP_BG "load global var",
-  Bytecode "LOAD_GLOBAL_VAR_DYNAMIC"    1 OP "load global var dynamic",
   Bytecode "LOAD_GLOBAL_VAR_WIDE"       3 OP_SG "load global var wide",
   Bytecode "LOAD_GLOBAL_VAR_LAZY"       2 OP_BG "load global var lazy",
-  Bytecode "LOAD_GLOBAL_VAR_LAZY_WIDE"  3 OP_BG "load global var lazy wide",
+  Bytecode "LOAD_GLOBAL_VAR_LAZY_WIDE"  3 OP_SG "load global var lazy wide",
+  Bytecode "LOAD_GLOBAL_VAR_DYNAMIC"    1 OP "load global var dynamic",
   Bytecode "STORE_GLOBAL_VAR"           2 OP_BG "store global var",
   Bytecode "STORE_GLOBAL_VAR_WIDE"      3 OP_SG "store global var wide",
   Bytecode "STORE_GLOBAL_VAR_DYNAMIC"   1 OP "store global var dynamic",


### PR DESCRIPTION
The wide variant wasn't immediately following the non-wide one.