### PR TITLE
Use fewer linux builders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,6 @@ jobs:
             shard: 7
           - container: ubuntu-20.04
             shard: 8
-          - container: ubuntu-20.04
-            shard: 9
-          - container: ubuntu-20.04
-            shard: 10
 
     runs-on: ${{ matrix.container }}
 
@@ -48,7 +44,7 @@ jobs:
           echo "toit_version=$TOIT_VERSION" >> $GITHUB_OUTPUT
           if [ "$RUNNER_OS" == "Linux" ]; then
             echo "artifact=toit-linux.tar.gz" >> $GITHUB_OUTPUT
-            echo "total_shards=10" >> $GITHUB_OUTPUT
+            echo "total_shards=8" >> $GITHUB_OUTPUT
           elif [ "$RUNNER_OS" == "macOS" ]; then
             echo "artifact=toit-macos.tar.gz" >> $GITHUB_OUTPUT
             echo "total_shards=5" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Some of the builders couldn't start immediately, because we sharded out the normal tests too much. By reducing it a bit, the 'cross' and 'esp32' workflows can now start at the same time as all the other builders.