### PR TITLE
Use resolv.conf to find name servers on Posix

### DIFF
--- a/lib/net/modules/dns.toit
+++ b/lib/net/modules/dns.toit
@@ -93,8 +93,13 @@ etc_resolv_client_ -> DnsClient:
       resolv_conf := (read_file_content_posix_ "/etc/resolv.conf" resolv_conf_stat[ST_SIZE_]).to_string
       nameservers := []
       resolv_conf.split "\n": | line |
+        hash := line.index_of "#"
+        if hash >= 0: line = line[..hash]
+        line = line.trim
         if line.starts_with "nameserver ":
-          nameservers.add line[11..].copy
+          server := line[11..].trim.copy
+          if net.IpAddress.is_valid server --accept_ipv4=true --accept_ipv6=false:
+            nameservers.add server
       current_etc_resolv_client_ = DnsClient nameservers
   return current_etc_resolv_client_ or DEFAULT_CLIENT
 

--- a/lib/net/modules/dns.toit
+++ b/lib/net/modules/dns.toit
@@ -41,7 +41,7 @@ dns_lookup -> net.IpAddress
     if not server:
       client = default_client
     else:
-      client = ALL_CLIENTS_.get server --init=:
+      client = AUTO_CREATED_CLIENTS_.get server --init=:
         DnsClient [server]
   return client.get host --accept_ipv4=accept_ipv4 --accept_ipv6=accept_ipv6 --timeout=timeout
 
@@ -53,12 +53,12 @@ DEFAULT_CLIENT ::= DnsClient [
 ]
 
 // A map from IP addresses (in string form) to DNS clients.
-// If a DNS client has multiple servers it can query then they
-// are separated by slash (/) in the key.
-ALL_CLIENTS_ ::= {DEFAULT_CLIENT.servers_.join "/": DEFAULT_CLIENT}
+AUTO_CREATED_CLIENTS_ ::= {:}
 
 user_set_client_/DnsClient? := null
 dhcp_client_/DnsClient? := null
+
+RESOLV_CONF_ ::= "/etc/resolv.conf"
 
 /**
 On Unix systems the default client is one that keeps an eye on changes in
@@ -70,19 +70,19 @@ On all platforms you can set a custom default client with the
 */
 default_client -> DnsClient:
   if user_set_client_: return user_set_client_
-  if platform == "FreeRTOS" and dhcp_client_: return dhcp_client_
-  if platform == "Linux" or platform == "macOS": return etc_resolv_client_
+  if platform == PLATFORM_FREERTOS and dhcp_client_: return dhcp_client_
+  if platform == PLATFORM_LINUX or platform == PLATFORM_MACOS: return etc_resolv_client_
   return DEFAULT_CLIENT
 
-default_client= client/DnsClient -> none:
+default_client= client/DnsClient? -> none:
   user_set_client_ = client
 
 current_etc_resolv_client_/DnsClient? := null
 etc_resolv_update_time_/Time? := null
 
 etc_resolv_client_ -> DnsClient:
-  error := catch --trace:
-    resolv_conf_stat := stat_ "/etc/resolv.conf" true
+  catch --trace:
+    resolv_conf_stat := stat_ RESOLV_CONF_ true
     etc_stat := stat_ "/etc" true
     resolv_conf_time := Time.epoch --ns=resolv_conf_stat[ST_MTIME_]
     etc_time := Time.epoch --ns=etc_stat[ST_MTIME_]
@@ -90,14 +90,14 @@ etc_resolv_client_ -> DnsClient:
     if etc_resolv_update_time_ == null or etc_resolv_update_time_ < modification_time:
       etc_resolv_update_time_ = modification_time
       // Create a new client from resolv.conf.
-      resolv_conf := (read_file_content_posix_ "/etc/resolv.conf" resolv_conf_stat[ST_SIZE_]).to_string
+      resolv_conf := (read_file_content_posix_ RESOLV_CONF_ resolv_conf_stat[ST_SIZE_]).to_string
       nameservers := []
       resolv_conf.split "\n": | line |
         hash := line.index_of "#"
         if hash >= 0: line = line[..hash]
         line = line.trim
         if line.starts_with "nameserver ":
-          server := line[11..].trim.copy
+          server := line[11..].trim
           if net.IpAddress.is_valid server --accept_ipv4=true --accept_ipv6=false:
             nameservers.add server
       current_etc_resolv_client_ = DnsClient nameservers

--- a/lib/net/modules/dns.toit
+++ b/lib/net/modules/dns.toit
@@ -66,7 +66,7 @@ On Unix systems the default client is one that keeps an eye on changes in
 On FreeRTOS systems the default client is set by DHCP.
 On Windows we currently default to using Google and Cloudflare DNS servers.
 On all platforms you can set a custom default client with the
-  $(default_client=) setter.
+  $(default_client= client) setter.
 */
 default_client -> DnsClient:
   if user_set_client_: return user_set_client_

--- a/src/compiler/propagation/type_primitive_file.cc
+++ b/src/compiler/propagation/type_primitive_file.cc
@@ -38,6 +38,7 @@ TYPE_PRIMITIVE_ANY(mkdtemp)
 TYPE_PRIMITIVE_ANY(is_open_file)
 TYPE_PRIMITIVE_ANY(realpath)
 TYPE_PRIMITIVE_ANY(cwd)
+TYPE_PRIMITIVE_ANY(read_file_content_posix)
 
 }  // namespace toit::compiler
 }  // namespace toit

--- a/src/compiler/propagation/type_primitive_file.cc
+++ b/src/compiler/propagation/type_primitive_file.cc
@@ -38,7 +38,7 @@ TYPE_PRIMITIVE_ANY(mkdtemp)
 TYPE_PRIMITIVE_ANY(is_open_file)
 TYPE_PRIMITIVE_ANY(realpath)
 TYPE_PRIMITIVE_ANY(cwd)
-TYPE_PRIMITIVE_ANY(read_file_content_posix)
+TYPE_PRIMITIVE_BYTE_ARRAY(read_file_content_posix)
 
 }  // namespace toit::compiler
 }  // namespace toit

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -610,6 +610,7 @@ namespace toit {
   PRIMITIVE(is_open_file, 1)                 \
   PRIMITIVE(realpath, 1)                     \
   PRIMITIVE(cwd, 0)                          \
+  PRIMITIVE(read_file_content_posix, 2)      \
 
 #define MODULE_PIPE(PRIMITIVE)               \
   PRIMITIVE(init, 0)                         \

--- a/src/primitive_file_win.cc
+++ b/src/primitive_file_win.cc
@@ -563,6 +563,11 @@ PRIMITIVE(cwd) {
   return result;
 }
 
+PRIMITIVE(read_file_content_posix) {
+  // This is currenly only used for resolv.conf.
+  UNIMPLEMENTED_PRIMITIVE;
+}
+
 }
 
 #endif  // TOIT_WINDOWS.

--- a/src/primitive_file_win.cc
+++ b/src/primitive_file_win.cc
@@ -564,7 +564,7 @@ PRIMITIVE(cwd) {
 }
 
 PRIMITIVE(read_file_content_posix) {
-  // This is currenly only used for resolv.conf.
+  // This is currenly only used for /etc/resolv.conf.
   UNIMPLEMENTED_PRIMITIVE;
 }
 


### PR DESCRIPTION
On Posix we keep an eye on the /etc/resolv.conf file and
reparse it when it changes to get the currrent name servers.
This is also the way golang does it, and glibc does something
similar.

The reason I made a new primitive is that otherwise we
would end up copying chunks of the file.toit into the core
(currently in pkg-host), which would bloat the VM more on
ESP32 because we can't tree shake based on platform.  Since
the file reading code is in C++ it doesn't affect the size on ESP32
as much.

If we get smarter at tree shaking in a platform-dependent
way we should probably make this more a Toit than C++
implementation and clean it up.

Still to do: Something for ESP32 that sets the default DNS
resolver from the DHCP data.