### PR TITLE
Use a single macro in the ARGS line of primitives to indicate a Windows path

### DIFF
--- a/src/primitive.h
+++ b/src/primitive.h
@@ -893,6 +893,24 @@ namespace toit {
   Blob name;                                                      \
   if (!_raw_##name->byte_content(process->program(), &name, STRINGS_ONLY)) WRONG_TYPE;
 
+// Filesystem primitives should generally use this, since the chdir primitive
+// merely changes a string representing the current directory.
+#define BLOB_TO_ABSOLUTE_PATH(result, blob)                                 \
+  if (blob.length() == 0) INVALID_ARGUMENT;                                 \
+  WideCharAllocationManager allocation_##result(process);                   \
+  wchar_t* wchar_##result = allocation_##result.to_wcs(&blob);              \
+  wchar_t result[MAX_PATH];                                                 \
+  auto error_##result = get_absolute_path(process, wchar_##result, result); \
+  if (error_##result) return error_##result
+
+HeapObject* get_absolute_path(Process* process, const wchar_t* pathname, wchar_t* output, const wchar_t* used_for_relative = null);
+
+#define _A_T_WindowsPath(N, name)                                           \
+  Object* _raw_##name = __args[-(N)];                                       \
+  Blob name##_blob;                                                         \
+  if (!_raw_##name->byte_content(process->program(), &name##_blob, STRINGS_ONLY)) WRONG_TYPE; \
+  BLOB_TO_ABSOLUTE_PATH(name, name##_blob);
+
 #define _A_T_Blob(N, name)                                        \
   Object* _raw_##name = __args[-(N)];                             \
   Blob name;                                                      \

--- a/src/primitive_file_win.cc
+++ b/src/primitive_file_win.cc
@@ -107,7 +107,7 @@ const wchar_t* current_dir(Process* process) {
   return current_directory;
 }
 
-HeapObject* get_absolute_path(Process* process, const wchar_t* pathname, wchar_t* output, const wchar_t* used_for_relative = null) {
+HeapObject* get_absolute_path(Process* process, const wchar_t* pathname, wchar_t* output, const wchar_t* used_for_relative) {
   size_t pathname_length = wcslen(pathname);
 
   // Poor man's version. For better platform handling, use PathCchAppendEx.
@@ -144,18 +144,8 @@ HeapObject* get_absolute_path(Process* process, const wchar_t* pathname, wchar_t
   return null;
 }
 
-// Filesystem primitives should generally use this, since the chdir primitive
-// merely changes a string representing the current directory.
-#define BLOB_TO_ABSOLUTE_PATH(result, blob)                                 \
-  WideCharAllocationManager allocation_##result(process);                   \
-  wchar_t* wchar_##result = allocation_##result.to_wcs(&blob);              \
-  wchar_t result[MAX_PATH];                                                 \
-  auto error_##result = get_absolute_path(process, wchar_##result, result); \
-  if (error_##result) return error_##result
-
 PRIMITIVE(open) {
-  ARGS(StringOrSlice, pathname, int, flags, int, mode);
-  BLOB_TO_ABSOLUTE_PATH(path, pathname);
+  ARGS(WindowsPath, path, int, flags, int, mode);
 
   int os_flags = _O_BINARY;
   if ((flags & FILE_RDWR) == FILE_RDONLY) os_flags |= _O_RDONLY;
@@ -212,8 +202,7 @@ PRIMITIVE(opendir) {
 }
 
 PRIMITIVE(opendir2) {
-  ARGS(SimpleResourceGroup, group, StringOrSlice, pathname);
-  BLOB_TO_ABSOLUTE_PATH(path, pathname);
+  ARGS(SimpleResourceGroup, group, WindowsPath, path);
 
   ByteArray* proxy = process->object_heap()->allocate_proxy();
   if (proxy == null) ALLOCATION_FAILED;
@@ -351,8 +340,7 @@ Object* time_stamp(Process* process, time_t time) {
 // Returns null for entries that do not exist.
 // Otherwise returns an array with indices from the FILE_ST_xxx constants.
 PRIMITIVE(stat) {
-  ARGS(StringOrSlice, pathname, bool, follow_links);
-  BLOB_TO_ABSOLUTE_PATH(path, pathname);
+  ARGS(WindowsPath, path, bool, follow_links);
 
   USE(follow_links);
 
@@ -405,8 +393,7 @@ PRIMITIVE(stat) {
 }
 
 PRIMITIVE(unlink) {
-  ARGS(StringOrSlice, pathname);
-  BLOB_TO_ABSOLUTE_PATH(path, pathname);
+  ARGS(WindowsPath, path);
 
   int result = _wunlink(path);
   if (result < 0) return return_open_error(process, errno);
@@ -414,26 +401,21 @@ PRIMITIVE(unlink) {
 }
 
 PRIMITIVE(rmdir) {
-  ARGS(StringOrSlice, pathname);
-  BLOB_TO_ABSOLUTE_PATH(path, pathname);
+  ARGS(WindowsPath, path);
 
   if (RemoveDirectoryW(path) == 0) WINDOWS_ERROR;
   return process->program()->null_object();
 }
 
 PRIMITIVE(rename) {
-  ARGS(StringOrSlice, old_name_blob, StringOrSlice, new_name_blob);
-  BLOB_TO_ABSOLUTE_PATH(old_name, old_name_blob);
-  BLOB_TO_ABSOLUTE_PATH(new_name, new_name_blob);
+  ARGS(WindowsPath, old_name, WindowsPath, new_name);
   int result = _wrename(old_name, new_name);
   if (result < 0) return return_open_error(process, errno);
   return process->program()->null_object();
 }
 
 PRIMITIVE(chdir) {
-  ARGS(StringOrSlice, pathname);
-  if (pathname.length() == 0) INVALID_ARGUMENT;
-  BLOB_TO_ABSOLUTE_PATH(path, pathname);
+  ARGS(WindowsPath, path);
 
   struct stat64 statbuf{};
   int result = _wstat64(path, &statbuf);
@@ -448,8 +430,7 @@ PRIMITIVE(chdir) {
 }
 
 PRIMITIVE(mkdir) {
-  ARGS(StringOrSlice, pathname, int, mode);
-  BLOB_TO_ABSOLUTE_PATH(path, pathname);
+  ARGS(WindowsPath, path, int, mode);
 
   int result = CreateDirectoryW(path, NULL);
   if (result == 0) WINDOWS_ERROR;

--- a/src/resources/pipe_win.cc
+++ b/src/resources/pipe_win.cc
@@ -411,6 +411,7 @@ static Object* fork_helper(
     Object* err_object,
     int fd_3,
     int fd_4,
+    wchar_t* command,
     Array* arguments,
     Object* environment_object) {
   if (arguments->length() > 1000000) OUT_OF_BOUNDS;
@@ -492,7 +493,7 @@ static Object* fork_helper(
     FreeEnvironmentStringsW(reinterpret_cast<wchar_t*>(old_environment));
   }
 
-  if (!CreateProcessW(NULL,
+  if (!CreateProcessW(command,
                       command_line,
                       NULL,
                       NULL,
@@ -532,11 +533,10 @@ PRIMITIVE(fork) {
        Object, err_obj,
        int, fd_3,
        int, fd_4,
-       StringOrSlice, command,
+       WindowsPath, command,
        Array, args);
-  USE(command);  // Not used on Windows.
   return fork_helper(process, resource_group, use_path, in_obj, out_obj, err_obj,
-                     fd_3, fd_4, args, process->program()->null_object());
+                     fd_3, fd_4, command, args, process->program()->null_object());
 }
 
 PRIMITIVE(fork2) {
@@ -547,12 +547,11 @@ PRIMITIVE(fork2) {
        Object, err_obj,
        int, fd_3,
        int, fd_4,
-       StringOrSlice, command,
+       WindowsPath, command,
        Array, args,
        Object, environment_object);
-  USE(command);  // Not used on Windows.
   return fork_helper(process, resource_group, use_path, in_obj, out_obj, err_obj,
-                     fd_3, fd_4, args, environment_object);
+                     fd_3, fd_4, command, args, environment_object);
 }
 
 } // namespace toit


### PR DESCRIPTION
Instead of using argv[0] to get the executable.