### PR TITLE
UART esp32 write with a write state

### DIFF
--- a/lib/uart.toit
+++ b/lib/uart.toit
@@ -42,7 +42,6 @@ class Port implements reader.Reader:
 
   uart_ := ?
   state_/ResourceState_
-  should_ensure_write_state_/bool
 
   /** Number of encountered errors. */
   errors := 0
@@ -108,7 +107,6 @@ class Port implements reader.Reader:
       parity
       tx_flags
       mode
-    should_ensure_write_state_ = false
     state_ = ResourceState_ resource_group_ uart_
 
   /**
@@ -131,7 +129,6 @@ class Port implements reader.Reader:
        --stop_bits/StopBits=STOP_BITS_1
        --parity/int=PARITY_DISABLED:
      group := resource_group_
-     should_ensure_write_state_ = true
      uart_ = uart_create_path_ group device baud_rate data_bits stop_bits.value_ parity
      state_ = ResourceState_ group uart_
 
@@ -196,19 +193,13 @@ class Port implements reader.Reader:
   Returns the number of bytes written.
   */
   write data from=0 to=data.size --break_length=0 --wait=false -> int:
-    while true:
-      if should_ensure_write_state_: state_.wait_for_state WRITE_STATE_ | ERROR_STATE_
-      if not uart_: throw "CLOSED"
-      written := uart_write_ uart_ data from to break_length wait
-      if should_ensure_write_state_ and written == 0 and from != to:
-        // We shouldn't have tried to write.
-        state_.clear_state WRITE_STATE_
-        continue
+    size := to - from
+    while from < to:
+      from += write_no_wait_ data from to --break_length=break_length
 
-      if written >= 0: return written
-      assert: wait
-      flush
-      return -written
+    if wait: flush
+
+    return size
 
   /**
   Reads data from the port.
@@ -239,6 +230,17 @@ class Port implements reader.Reader:
       flushed := uart_wait_tx_ uart_
       if flushed: return
       sleep --ms=1
+
+  write_no_wait_ data from=0 to=data.size --break_length=0:
+    while true:
+      state_.wait_for_state WRITE_STATE_ | ERROR_STATE_
+      if not uart_: throw "CLOSED"
+      written := uart_write_ uart_ data from to break_length
+      if written < to - from:
+        // Not every thing was written, clear write flag and try again
+        state_.clear_state WRITE_STATE_
+        if written == 0: continue
+      return written
 
 /**
 Extends the functionality of the UART Port on platforms that support configurable RS232 devices. It allows setting
@@ -324,11 +326,8 @@ uart_close_ group uart:
 /**
 Writes the $data to the uart.
 Returns the amount of bytes that were written.
-
-If $wait is true, but the baud rate was too low to wait, returns a negative number, where
-  the absolute value is the amount of bytes that were written.
 */
-uart_write_ uart data from to break_length wait:
+uart_write_ uart data from to break_length:
   #primitive.uart.write
 
 uart_wait_tx_ uart:

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -417,7 +417,7 @@ namespace toit {
   PRIMITIVE(close, 2)                        \
   PRIMITIVE(get_baud_rate, 1)                \
   PRIMITIVE(set_baud_rate, 2)                \
-  PRIMITIVE(write, 6)                        \
+  PRIMITIVE(write, 5)                        \
   PRIMITIVE(read, 1)                         \
   PRIMITIVE(wait_tx, 1)                      \
   PRIMITIVE(set_control_flags, 2)           \

--- a/src/resources/uart_posix.cc
+++ b/src/resources/uart_posix.cc
@@ -356,10 +356,8 @@ PRIMITIVE(set_baud_rate) {
 }
 
 // Writes the data to the UART.
-// If wait is true, waits, unless the baud-rate is too low. If the function did
-// not wait, returns the negative value of the written bytes.
 PRIMITIVE(write) {
-  ARGS(IntResource, resource, Blob, data, int, from, int, to, int, break_length, bool, wait);
+  ARGS(IntResource, resource, Blob, data, int, from, int, to, int, break_length);
   int fd = resource->id();
 
   const uint8* tx = data.address();
@@ -375,30 +373,18 @@ PRIMITIVE(write) {
   }
 
   int baud_rate = 0;
-  if (break_length > 0 || wait) {
+  if (break_length > 0) {
     // If we have a break, or need to wait we need the current baud_rate.
     struct termios tty;
     if (tcgetattr(fd, &tty) != 0) return Primitive::os_error(errno, process);
     // We assume that the input and output speed are the same and only query the output speed.
     speed_t speed = cfgetospeed(&tty);
     baud_rate = baud_rate_to_int(speed);
-  }
-
-  if (break_length > 0) {
     // Toit (because of ESP32) defines the break-length as equal to the time it takes to write 1 bit.
     // Linux uses 'ms' instead. We need to get the baud-rate so we can convert from bit-duration to ms.
     int ms = break_length * 1000 / baud_rate;
     if (ms == 0) ms = 1;
     if (tcsendbreak(fd, ms) != 0) return Primitive::os_error(errno, process);
-  }
-
-  if (wait) {
-    if (baud_rate < 100000) {
-      return Smi::from(-written);
-    }
-    // TODO(florian): do we ever want to do a blocking wait on Linux?
-    // Wait until the data has been drained.
-    if (tcdrain(fd) != 0) return Primitive::os_error(errno, process);
   }
 
   return Smi::from(written);

--- a/src/resources/uart_win.cc
+++ b/src/resources/uart_win.cc
@@ -352,10 +352,10 @@ PRIMITIVE(set_baud_rate) {
 }
 
 // Writes the data to the UART.
-// Does not support break or wait
+// Does not support break
 PRIMITIVE(write) {
-  ARGS(UartResource, uart_resource, Blob, data, int, from, int, to, int, break_length, bool, wait);
-  if (break_length > 0 || wait) INVALID_ARGUMENT;
+  ARGS(UartResource, uart_resource, Blob, data, int, from, int, to, int, break_length);
+  if (break_length > 0) INVALID_ARGUMENT;
 
   const uint8* tx = data.address();
   if (from < 0 || from > to || to > data.length()) OUT_OF_RANGE;


### PR DESCRIPTION
Modified the write to be more toity. Using a high resolution timer to inform toit when a full write buffer could accept more data. Currently hardcoded to when 10% of the write buffer has been freed to allow for jittering