### PR TITLE
Fixes for esp32c3

### DIFF
--- a/src/embedded_data.cc
+++ b/src/embedded_data.cc
@@ -57,7 +57,7 @@ List<uint8> EmbeddedDataExtension::config() const {
   uword address = reinterpret_cast<uword>(header) + used;
   uword size = *reinterpret_cast<uint32*>(address);
   uint8* data = reinterpret_cast<uint8*>(address + sizeof(uint32));
-  return List<uint8>(data, Utils::min(size, free - sizeof(uint32)));
+  return List<uint8>(data, Utils::min(size, (uword)(free - sizeof(uint32))));
 }
 
 uword EmbeddedDataExtension::offset(const Program* program) const {

--- a/src/resources/spi_flash_esp32.cc
+++ b/src/resources/spi_flash_esp32.cc
@@ -172,7 +172,7 @@ PRIMITIVE(init_nor_flash) {
     return Primitive::os_error(ret, process);
   }
 
-  size_t size;
+  uint32_t size;
   ret = esp_flash_get_size(chip, &size);
   if (ret != ESP_OK) {
     group->tear_down();

--- a/src/resources/wifi_esp32.cc
+++ b/src/resources/wifi_esp32.cc
@@ -158,7 +158,7 @@ class WifiResourceGroup : public ResourceGroup {
     wifi_pool.put(id_);
   }
 
-  uint32 on_event(Resource* resource, word data, uint32 state);
+  uint32_t on_event(Resource* resource, word data, uint32_t state) override;
 
  private:
   int id_;
@@ -320,7 +320,7 @@ void WifiResourceGroup::get_dns() {
   }
 }
 
-uint32 WifiResourceGroup::on_event(Resource* resource, word data, uint32 state) {
+uint32_t WifiResourceGroup::on_event(Resource* resource, word data, uint32_t state) {
   SystemEvent* system_event = reinterpret_cast<SystemEvent*>(data);
 
   if (system_event->base == WIFI_EVENT) {

--- a/src/top.h
+++ b/src/top.h
@@ -117,15 +117,15 @@ static const int WORD_SHIFT = 2;
 #endif
 static_assert(sizeof(uhalf_word) == sizeof(uword) / 2, "Unexpected half-word size");
 
-typedef signed char int8;
-typedef short int16;
-typedef int int32;
-typedef long long int int64;
+typedef int8_t int8;
+typedef int16_t int16;
+typedef int32_t int32;
+typedef int64_t int64;
 
-typedef unsigned char uint8;
-typedef unsigned short uint16;
-typedef unsigned int uint32;
-typedef unsigned long long int uint64;
+typedef uint8_t uint8;
+typedef uint16_t uint16;
+typedef uint32_t uint32;
+typedef uint64_t uint64;
 
 static const word KB_LOG2 = 10;
 static const int KB = 1 << KB_LOG2;


### PR DESCRIPTION
On the ESP32-C3 (risc v5 architecture) the uint32_t and uint32 were not equivalent types in the eyes of the C++ compiler and therefore some virtual functions where not dispatched correctly.

The main change is to shift all the typedef's for ints and uints in top.h to use the stdint versions int8_t, etc.

A few other places had warnings/errors and they have been addressed.