### PR TITLE
Fixing missing IRAM markers

### DIFF
--- a/src/resources/uart_esp32.cc
+++ b/src/resources/uart_esp32.cc
@@ -203,7 +203,7 @@ public:
   }
 
   void set_read_fifo_timeout(uint8 timeout) { uart_toit_hal_set_rx_timeout(hal_, timeout); }
-  void clear_rx_fifo() { uart_toit_hal_rxfifo_rst(hal_); }
+  void UART_ISR_INLINE clear_rx_fifo() { uart_toit_hal_rxfifo_rst(hal_); }
   void clear_tx_fifo() { uart_toit_hal_txfifo_rst(hal_); }
 
   void clear_interrupt_index(uart_toit_interrupt_index_t index);
@@ -445,7 +445,7 @@ void UartResource::disable_interrupt_index(uart_toit_interrupt_index_t index) {
   disable_interrupt_mask_(interrupt_mask(index));
 }
 
-void UartResource::clear_interrupt_index(uart_toit_interrupt_index_t index) {
+void UART_ISR_INLINE UartResource::clear_interrupt_index(uart_toit_interrupt_index_t index) {
   uart_toit_hal_clr_intsts_mask(hal_, interrupt_mask(index));
 }
 

--- a/src/resources/uart_esp32_hal.c
+++ b/src/resources/uart_esp32_hal.c
@@ -96,7 +96,7 @@ void uart_toit_hal_set_reset_core(uart_hal_handle_t hal, bool reset) {
 }
 #endif  // SOC_UART_REQUIRE_CORE_RESET
 
-void uart_toit_hal_rxfifo_rst(uart_hal_handle_t hal) {
+void IRAM_ATTR uart_toit_hal_rxfifo_rst(uart_hal_handle_t hal) {
   uart_hal_rxfifo_rst(HAL);
 }
 
@@ -120,7 +120,7 @@ void uart_toit_hal_get_baudrate(uart_hal_handle_t hal, uint32_t *baud_rate) {
   uart_hal_get_baudrate(HAL, baud_rate);
 }
 
-uint32_t uart_toit_hal_get_rxfifo_len(uart_hal_handle_t hal) {
+uint32_t IRAM_ATTR uart_toit_hal_get_rxfifo_len(uart_hal_handle_t hal) {
   return uart_hal_get_rxfifo_len(HAL);
 }
 


### PR DESCRIPTION
Some of the methods called from the ISR was not marked as IRAM. This causes flashing to fail while UART is being used.