### PR TITLE
Don't pre-allocate memory for TLS handshake

### DIFF
--- a/src/utils.cc
+++ b/src/utils.cc
@@ -538,8 +538,6 @@ const char* vm_git_version() { return VM_GIT_VERSION; }
 const char* vm_git_info() { return VM_GIT_INFO; }
 const char* vm_sdk_model() { return TOIT_MODEL; }
 
-void dont_optimize_away_these_allocations(void** blocks) {}
-
 const uint8 Utils::REVERSE_NIBBLE[16] = {
     0b0000,
     0b1000,

--- a/src/utils.h
+++ b/src/utils.h
@@ -416,11 +416,6 @@ bit_cast(const From& src) noexcept {
   return dst;
 }
 
-// This does nothing, but the optimizer can't see that at the use point, so it
-// forces the optimizer to preserve allocations that are immediately freed.
-extern void dont_optimize_away_these_allocations(void** blocks);
-
-
 template<typename T>
 class List {
  public:


### PR DESCRIPTION
Now that tagging_mbedtls_calloc tries to GC-then-retry failed allocations, perhaps we don't need to free up memory before doing a handshake.  Lets try this and see how it works.  It's also possible that a less
agressive version of this code would be right.