### PR TITLE
fix `make clean` when there are no sdkconfig files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ flash-no-env: esp32-no-env
 .PHONY:	clean
 clean:
 	rm -rf build/
-	find toolchains -name sdkconfig | xargs rm
+	find toolchains -name sdkconfig -exec rm '{}' ';'
 
 INSTALL_SRC_ARCH := $(HOST)
 


### PR DESCRIPTION
find toolchains -name sdkconfig -exec rm '{}' ';' when there are no sdkconfig files