### PR TITLE
Make ChaCha20/Poly1305 support optional.

### DIFF
--- a/src/siphash.cc
+++ b/src/siphash.cc
@@ -13,6 +13,8 @@
 // The license can be found in the file `LICENSE` in the top level
 // directory of this repository.
 
+#if !defined(TOIT_FREERTOS) || defined(CONFIG_TOIT_CRYPTO)
+
 #include "utils.h"
 #include "siphash.h"
 
@@ -124,3 +126,5 @@ void Siphash::process_block() {
 }
 
 }
+
+#endif


### PR DESCRIPTION
With this change you can disable these TLS encryption protocols in sdkconfig, and the VM will still compile.

Almost all web-accessible servers will work just fine with AES based encryption, so this can save some space.

For desktop/server, the correct place to make this change would be in
third_party/esp_idf/components/mbedtls/mbedtls/include/mbedtls/config.h However, space is not an issue on these platforms.