### PR TITLE
Don't require 'all' for 'install'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ clean:
 INSTALL_SRC_ARCH := $(TARGET)
 
 .PHONY: install-sdk install
-install-sdk: all
+install-sdk:
 	install -D --target-directory="$(DESTDIR)$(prefix)"/bin "$(CURDIR)"/build/$(INSTALL_SRC_ARCH)/sdk/bin/*
 	install -D --target-directory="$(DESTDIR)$(prefix)"/tools "$(CURDIR)"/build/$(INSTALL_SRC_ARCH)/sdk/tools/*
 	install -D --target-directory="$(DESTDIR)$(prefix)"/vessels "$(CURDIR)"/build/$(INSTALL_SRC_ARCH)/sdk/vessels/*


### PR DESCRIPTION
When compiling for Archlinux we don't need the esptool. Don't create it during installation.