### PR TITLE
Improve esp32 tests.

### DIFF
--- a/tests/esp32/README.md
+++ b/tests/esp32/README.md
@@ -20,7 +20,7 @@ On board 1 connect as follows:
 7. IO18 (or IO34) - GND with 1MOhm (or similar high number).
 5. IO18 - IO19 with 330Ohm
 8. IO26 - IO33
-9. IO15 - IO19 with 330Ohm
+9. IO21 - IO19 with 330Ohm
 
 Connect board 1 to board 2 as follows:
 1. GND - GND

--- a/tests/esp32/rmt.toit
+++ b/tests/esp32/rmt.toit
@@ -9,7 +9,7 @@ Setup:
 Connect pin 18 and 19 with a 330 Ohm resistor. The resistor isn't
   strictly necessary but can prevent accidental short circuiting.
 
-Similarly, connect pin 15 to pin 19 with a 330 Ohm resistor. We will
+Similarly, connect pin 21 to pin 19 with a 330 Ohm resistor. We will
   use that one to pull the line high.
 */
 
@@ -20,7 +20,7 @@ import expect show *
 
 RMT_PIN_1 ::= 18
 RMT_PIN_2 ::= 19
-RMT_PIN_3 ::= 15
+RMT_PIN_3 ::= 21
 
 // Because of the resistors and a weak pull-up, the reading isn't fully precise.
 // We allow 5us error.

--- a/tests/esp32/spi_keep_active.toit
+++ b/tests/esp32/spi_keep_active.toit
@@ -6,7 +6,7 @@
 Tests the '--keep_cs_active' flag of the SPI transfer.
 
 Setup:
-Connect pin 19 and 15 with a 330 Ohm resistor. The resistor isn't
+Connect pin 19 and 21 with a 330 Ohm resistor. The resistor isn't
   strictly necessary but can prevent accidental short circuiting.
 
 Make sure that pins 12, 13, and 14 are not connected to anything important. They
@@ -19,7 +19,7 @@ import gpio
 import monitor
 
 
-CS ::= 15
+CS ::= 21
 MISO ::= 12
 MOSI ::= 13
 SCK ::= 14


### PR DESCRIPTION
Pin 15 seems to have an internal pull-up resistor which made the open-drain test fail. Switching to a different pin solved this.