### PR TITLE
Add ethernet service

### DIFF
--- a/lib/esp32/net/ethernet.toit
+++ b/lib/esp32/net/ethernet.toit
@@ -113,7 +113,7 @@ class EthernetServiceProvider extends ServiceProvider implements ServiceHandler:
     unreachable
 
   connect client/int -> List:
-    module ::= (state_.up: EthernetModule_ this create_resource_group_) as EthernetModule_
+    state_.up: EthernetModule_ this create_resource_group_
     try:
       resource := NetworkResource this client state_ --notifiable
       return [

--- a/lib/esp32/net/ethernet.toit
+++ b/lib/esp32/net/ethernet.toit
@@ -35,12 +35,56 @@ ETHERNET_CONNECTED_    ::= 1 << 0
 ETHERNET_DHCP_SUCCESS_ ::= 1 << 1
 ETHERNET_DISCONNECTED_ ::= 1 << 2
 
+/**
+Service provider for networking via the Ethernet peripheral.
+
+# Olimex Gateway
+The Olimex gateway needs an SDK config change:
+
+``` diff
+diff --git b/toolchains/esp32/sdkconfig a/toolchains/esp32/sdkconfig
+index df798c8..fef8c8a 100644
+--- b/toolchains/esp32/sdkconfig
++++ a/toolchains/esp32/sdkconfig
+@@ -492,9 +492,10 @@ CONFIG_ETH_ENABLED=y
+ CONFIG_ETH_USE_ESP32_EMAC=y
+ CONFIG_ETH_PHY_INTERFACE_RMII=y
+ # CONFIG_ETH_PHY_INTERFACE_MII is not set
+-CONFIG_ETH_RMII_CLK_INPUT=y
+-# CONFIG_ETH_RMII_CLK_OUTPUT is not set
+-CONFIG_ETH_RMII_CLK_IN_GPIO=0
++# CONFIG_ETH_RMII_CLK_INPUT is not set
++CONFIG_ETH_RMII_CLK_OUTPUT=y
++# CONFIG_ETH_RMII_CLK_OUTPUT_GPIO0 is not set
++CONFIG_ETH_RMII_CLK_OUT_GPIO=17
+ CONFIG_ETH_DMA_BUFFER_SIZE=512
+ CONFIG_ETH_DMA_RX_BUFFER_NUM=10
+ CONFIG_ETH_DMA_TX_BUFFER_NUM=10
+```
+
+After that, the ethernet service provider can be installed with:
+```
+  provider := EthernetServiceProvider
+      --phy_chip=ethernet.PHY_CHIP_LAN8720
+      --phy_address=0
+      --mac_chip=ethernet.MAC_CHIP_ESP32
+      --mac_mdc=gpio.Pin 23
+      --mac_mdio=gpio.Pin 18
+      --mac_spi_device=null
+      --mac_interrupt=null
+  provider.install
+```
+*/
 class EthernetServiceProvider extends ServiceProvider
     implements ServiceHandler:
 
   state_/NetworkState ::= NetworkState
   create_resource_group_/Lambda
 
+  /**
+  The $mac_chip must be one of $MAC_CHIP_ESP32 or $MAC_CHIP_W5500.
+  The $phy_chip must be one of $PHY_CHIP_NONE, $PHY_CHIP_IP101 or $PHY_CHIP_LAN8720.
+  */
   constructor
       --phy_chip/int
       --phy_address/int=-1

--- a/lib/esp32/net/ethernet.toit
+++ b/lib/esp32/net/ethernet.toit
@@ -28,22 +28,6 @@ PHY_CHIP_IP101    ::= 1
 PHY_CHIP_LAN8720  ::= 2
 PHY_CHIP_DP83848  ::= 3
 
-CONFIG_PHY_CHIP    /string ::= "ethernet.phy.chip"
-CONFIG_PHY_ADDRESS /string ::= "ethernet.phy.address"
-CONFIG_PHY_RESET   /string ::= "ethernet.phy.reset"
-
-CONFIG_MAC_CHIP      /string ::= "ethernet.mac.chip"
-CONFIG_MAC_MDC       /string ::= "ethernet.mac.mdc"
-CONFIG_MAC_MDIO      /string ::= "ethernet.mac.mdio"
-CONFIG_MAC_INTERRUPT /string ::= "ethernet.mac.interrupt"
-
-CONFIG_MAC_SPI_CS           /string ::= "ethernet.mac.spi.cs"
-CONFIG_MAC_SPI_DC           /string ::= "ethernet.mac.spi.dc"
-CONFIG_MAC_SPI_FREQUENCY    /string ::= "ethernet.mac.spi.frequency"
-CONFIG_MAC_SPI_MODE         /string ::= "ethernet.mac.spi.mode"
-CONFIG_MAC_SPI_ADDRESS_BITS /string ::= "ethernet.mac.spi.address.bits"
-CONFIG_MAC_SPI_COMMAND_BITS /string ::= "ethernet.mac.spi.command.bits"
-
 ETHERNET_CONNECT_TIMEOUT_  ::= Duration --s=10
 ETHERNET_DHCP_TIMEOUT_     ::= Duration --s=16
 
@@ -53,33 +37,48 @@ ETHERNET_DISCONNECTED_ ::= 1 << 2
 
 class EthernetServiceProvider extends ServiceProvider
     implements ServiceHandler:
-  state_/NetworkState ::= NetworkState
 
-  constructor:
+  state_/NetworkState ::= NetworkState
+  create_resource_group_/Lambda
+
+  constructor
+      --phy_chip/int
+      --phy_address/int=-1
+      --phy_reset/gpio.Pin?=null
+      --mac_chip/int
+      --mac_mdc/gpio.Pin?
+      --mac_mdio/gpio.Pin?
+      --mac_spi_device/spi.Device?
+      --mac_interrupt/gpio.Pin?:
+    if mac_chip == MAC_CHIP_ESP32 or mac_chip == MAC_CHIP_OPENETH:
+      create_resource_group_ = :: ethernet_init_esp32_
+          mac_chip
+          phy_chip
+          phy_address
+          phy_reset ? phy_reset.num : -1
+          mac_mdc ? mac_mdc.num : -1
+          mac_mdio ? mac_mdio.num : -1
+    else if phy_chip != PHY_CHIP_NONE:
+      throw "unexpected PHY chip selection"
+    else:
+      create_resource_group_ = :: ethernet_init_spi_
+          mac_chip
+          (mac_spi_device as spi.Device_).device_
+          mac_interrupt.num
     super "system/ethernet/esp32" --major=0 --minor=1
         --tags=[NetworkService.TAG_ETHERNET]
     provides EthernetService.SELECTOR --handler=this
 
   handle index/int arguments/any --gid/int --client/int -> any:
     if index == EthernetService.CONNECT_INDEX:
-      return connect client arguments
+      return connect client
     if index == NetworkService.ADDRESS_INDEX:
       network := (resource client arguments) as NetworkResource
       return address network
     unreachable
 
-  connect client/int config/Map -> List:
-    // TODO(kasper): Parse the configuration.
-    phy_chip/int := config[ethernet.CONFIG_PHY_CHIP]
-    phy_addr/int? := config.get ethernet.CONFIG_PHY_ADDRESS
-    phy_reset/gpio.Pin? := null
-    mac_chip/int := config[ethernet.CONFIG_MAC_CHIP]
-    mac_mdc/gpio.Pin? := null
-    mac_mdio/gpio.Pin? := null
-    mac_spi/spi.Device? := null
-    mac_interrupt/gpio.Pin? := null
-
-    module ::= (state_.up: EthernetModule this) as EthernetModule
+  connect client/int -> List:
+    module ::= (state_.up: EthernetModule this create_resource_group_) as EthernetModule
     try:
       // TODO(kasper): We should verify that the configuration
       // of the ethernet module we got matches the one we requested.
@@ -110,29 +109,8 @@ class EthernetModule implements NetworkModule:
   resource_group_ := ?
   address_/net.IpAddress? := null
 
-  constructor .service
-      --phy_chip/int
-      --phy_addr/int=-1
-      --phy_reset/gpio.Pin?=null
-      --mac_chip/int
-      --mac_mdc/gpio.Pin?
-      --mac_mdio/gpio.Pin?
-      --mac_spi_device/spi.Device?
-      --mac_int/gpio.Pin?:
-    if mac_chip == MAC_CHIP_ESP32 or mac_chip == MAC_CHIP_OPENETH:
-      resource_group_ = ethernet_init_esp32_
-        mac_chip
-        phy_chip
-        phy_addr
-        (phy_reset ? phy_reset.num : -1)
-        (mac_mdc ? mac_mdc.num : -1)
-        (mac_mdio ? mac_mdio.num : -1)
-    else:
-      if phy_chip != PHY_CHIP_NONE: throw "unexpected PHY chip selection"
-      resource_group_ = ethernet_init_spi_
-        mac_chip
-        (mac_spi_device as spi.Device_).device_
-        mac_int.num
+  constructor .service create_resource_group/Lambda:
+    resource_group_ = create_resource_group.call
 
   address -> net.IpAddress:
     return address_
@@ -142,9 +120,7 @@ class EthernetModule implements NetworkModule:
     with_timeout ETHERNET_DHCP_TIMEOUT_: wait_for_dhcp_ip_address_
 
   disconnect -> none:
-    if not resource_group_:
-      return
-
+    if not resource_group_: return
     logger_.debug "closing"
     ethernet_close_ resource_group_
     resource_group_ = null

--- a/lib/net/ethernet.toit
+++ b/lib/net/ethernet.toit
@@ -8,8 +8,7 @@ import system.api.ethernet show EthernetServiceClient
 service_/EthernetServiceClient? := null
 service_initialized_/bool := false
 
-open config/Map -> net.Client
-    --name/string?=null:
+open --name/string?=null -> net.Client:
   if not service_initialized_:
     // We typically run the ethernet service in a non-system
     // container with --trigger=boot, so we need to give it
@@ -23,4 +22,4 @@ open config/Map -> net.Client
         --if_absent=: null
   service := service_
   if not service: throw "ethernet unavailable"
-  return net.Client service --name=name (service.connect config)
+  return net.Client service --name=name service.connect

--- a/lib/net/ethernet.toit
+++ b/lib/net/ethernet.toit
@@ -1,0 +1,26 @@
+// Copyright (C) 2023 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the lib/LICENSE file.
+
+import net
+import system.api.ethernet show EthernetServiceClient
+
+service_/EthernetServiceClient? := null
+service_initialized_/bool := false
+
+open config/Map -> net.Client
+    --name/string?=null:
+  if not service_initialized_:
+    // We typically run the ethernet service in a non-system
+    // container with --trigger=boot, so we need to give it
+    // time to start so it can be discovered. We should really
+    // generalize this handling for net.open and wifi.open too,
+    // so we get a shared pattern for dealing with discovering
+    // such network services at start up.
+    service_initialized_ = true
+    service_ = (EthernetServiceClient).open
+        --timeout=(Duration --s=5)
+        --if_absent=: null
+  service := service_
+  if not service: throw "ethernet unavailable"
+  return net.Client service --name=name (service.connect config)

--- a/lib/system/api/ethernet.toit
+++ b/lib/system/api/ethernet.toit
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the lib/LICENSE file.
+
+import system.api.network show NetworkService NetworkServiceClient
+import system.services show ServiceSelector
+
+interface EthernetService extends NetworkService:
+  static SELECTOR ::= ServiceSelector
+      --uuid="7752a0f4-572b-407f-933c-c8a9e4573d29"
+      --major=0
+      --minor=1
+
+  connect config/Map -> List
+  static CONNECT_INDEX /int ::= 1000
+
+class EthernetServiceClient extends NetworkServiceClient implements EthernetService:
+  static SELECTOR ::= EthernetService.SELECTOR
+  constructor selector/ServiceSelector=SELECTOR:
+    assert: selector.matches SELECTOR
+    super selector
+
+  connect config/Map -> List:
+    return invoke_ EthernetService.CONNECT_INDEX config

--- a/lib/system/api/ethernet.toit
+++ b/lib/system/api/ethernet.toit
@@ -11,7 +11,7 @@ interface EthernetService extends NetworkService:
       --major=0
       --minor=1
 
-  connect config/Map -> List
+  connect -> List
   static CONNECT_INDEX /int ::= 1000
 
 class EthernetServiceClient extends NetworkServiceClient implements EthernetService:
@@ -20,5 +20,5 @@ class EthernetServiceClient extends NetworkServiceClient implements EthernetServ
     assert: selector.matches SELECTOR
     super selector
 
-  connect config/Map -> List:
-    return invoke_ EthernetService.CONNECT_INDEX config
+  connect -> List:
+    return invoke_ EthernetService.CONNECT_INDEX null


### PR DESCRIPTION
Users of the ethernet can use:

```
import net.ethernet
main:
  network := ethernet.open
  ...
  network.close
```

but someone has to provide the ethernet driver as a service by importing `esp32.net.ethernet` and installing a configured `EthernetServiceProvider` instance.