### PR TITLE
Improve tree shaking and fix optimization bug

### DIFF
--- a/src/compiler/backend.cc
+++ b/src/compiler/backend.cc
@@ -280,16 +280,7 @@ void Backend::emit_method(ir::Method* method,
       dispatch_offset = table_offset;
     } else {
       ASSERT(table_offset == -1);
-      if (!typecheck_indexes->contains_key(method->holder())) {
-        // TODO(kasper): This is a slightly weird case, where we have a
-        // method that is never called but the tree shaker fails to
-        // realize this. We end up with an unused entry in the dispatch
-        // table at 'dispatch_table->slot_index_for(method)', but at
-        // least we do not generate code for this. We should be able
-        // to shake this out earlier by realizing that not all static
-        // calls lead to live methods.
-        return;
-      }
+      ASSERT(typecheck_indexes->contains_key(method->holder()));
       int index = (*typecheck_indexes)[method->holder()];
       ASSERT(index >= 0);
       // Negative indexes are for calls with static targets.

--- a/src/compiler/ir.h
+++ b/src/compiler/ir.h
@@ -316,6 +316,18 @@ class Class : public Node {
     super_ = klass;
   }
 
+  /// Returns whether the given klass is a super of this class.
+  bool is_transitive_super_of(Class* klass) {
+    auto current = klass->super();
+    while (current != null) {
+      if (current == this) {
+        return true;
+      }
+      current = current->super();
+    }
+    return false;
+  }
+
   List<Class*> interfaces() const { return interfaces_; }
   void set_interfaces(List<Class*> interfaces) {
     ASSERT(interfaces_.is_empty());

--- a/src/compiler/optimizations/utils.cc
+++ b/src/compiler/optimizations/utils.cc
@@ -26,7 +26,6 @@ namespace compiler {
 using namespace ir;
 
 bool is_This(Node* node, Class* holder, Method* method) {
-  if (holder != method->holder()) return false;
   if (holder == null) return false;
   if (!(method->is_instance() || method->is_constructor())) return false;
   if (!node->is_ReferenceLocal()) return false;

--- a/src/compiler/optimizations/virtual_call.cc
+++ b/src/compiler/optimizations/virtual_call.cc
@@ -76,28 +76,28 @@ Expression* optimize_virtual_call(CallVirtual* node,
     if (direct_method != null && direct_method->is_abstract()) {
       direct_method = null;
     }
+  }
 
-    // We need to be careful not to directly call an operator ==.
-    // If the RHS is nullable, the interpreter shortcuts the call.
-    if (direct_method != null && opcode == INVOKE_EQ) {
-      auto param = node->arguments().first();
-      Type param_type = compute_guaranteed_type(param, holder, method);
-      if (param_type.is_valid()) {
-        // Unless the param-type is nullable, we can change to a static call.
-        if (param_type.is_nullable()) direct_method = null;
-      } else if (param->is_Literal()) {
-        // Unless the literal is `null`, we can change to a static call.
-        if (param->is_LiteralNull()) direct_method = null;
-      } else {
-        // Not enough information, so abandon and assume we can't change to static call.
-        direct_method = null;
-      }
-    }
-    // Similarly, we don't want to change any of the really efficient INVOKE_X opcodes.
-    if (direct_method != null && opcode != INVOKE_VIRTUAL) {
-      // TODO(florian): we may switch to a static call if the receiver isn't an int/Array.
+  // We need to be careful not to directly call an operator ==.
+  // If the RHS is nullable, the interpreter shortcuts the call.
+  if (direct_method != null && opcode == INVOKE_EQ) {
+    auto param = node->arguments().first();
+    Type param_type = compute_guaranteed_type(param, holder, method);
+    if (param_type.is_valid()) {
+      // Unless the param-type is nullable, we can change to a static call.
+      if (param_type.is_nullable()) direct_method = null;
+    } else if (param->is_Literal()) {
+      // Unless the literal is `null`, we can change to a static call.
+      if (param->is_LiteralNull()) direct_method = null;
+    } else {
+      // Not enough information, so abandon and assume we can't change to static call.
       direct_method = null;
     }
+  }
+  // Similarly, we don't want to change any of the really efficient INVOKE_X opcodes.
+  if (direct_method != null && opcode != INVOKE_VIRTUAL) {
+    // TODO(florian): we may switch to a static call if the receiver isn't an int/Array.
+    direct_method = null;
   }
 
   if (direct_method == null) {

--- a/src/compiler/set.h
+++ b/src/compiler/set.h
@@ -101,11 +101,28 @@ template<typename T> class UnorderedSet {
   }
   bool erase(T x) { return set_.erase(x) > 0; }
 
+  template<typename F>
+  void erase_if(const F& callback) {
+    auto it = set_.begin();
+    while (it != set_.end()) {
+      if (callback(*it)) {
+        it = set_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+
   template<typename E>
   void erase_all(const List<E>& other) {
     for (auto entry : other) {
       set_.erase(entry);
     }
+  }
+
+  template<typename E>
+  void erase_all(const UnorderedSet<E>& other_set) {
+    set_.erase(other_set.set_.begin(), other_set.set_.end());
   }
 
   bool contains(T x) const { return set_.find(x) != set_.end(); }

--- a/src/compiler/set.h
+++ b/src/compiler/set.h
@@ -40,7 +40,7 @@ template<typename T> class Set {
     }
   }
 
-  void insert_all(Set<T> other_set) {
+  void insert_all(const Set<T>& other_set) {
     for (auto& x : other_set) insert(x);
   }
 
@@ -93,10 +93,10 @@ template<typename T> class UnorderedSet {
  public:
   void insert(T x) { set_.insert(x); }
   template<class InputIt> void insert(InputIt begin, InputIt end) { set_.insert(begin, end); }
-  void insert_all(UnorderedSet<T> other_set) {
+  void insert_all(const UnorderedSet<T>& other_set) {
     set_.insert(other_set.set_.begin(), other_set.set_.end());
   }
-  void insert_all(Set<T> other_set) {
+  void insert_all(const Set<T>& other_set) {
     set_.insert(other_set.begin(), other_set.end());
   }
   bool erase(T x) { return set_.erase(x) > 0; }

--- a/src/compiler/tree.cc
+++ b/src/compiler/tree.cc
@@ -22,6 +22,7 @@
 #include "token.h"
 #include "tree.h"
 #include "../flags.h"
+#include "optimizations/utils.h"
 
 namespace toit {
 namespace compiler {
@@ -30,23 +31,62 @@ using namespace ir;
 
 typedef Selector<CallShape> CallSelector;
 
-class GrowerVisitor : public TraversingVisitor {
+class GrowerVisitor : protected TraversingVisitor {
  public:
   explicit GrowerVisitor(Method* as_check_failure)
       : as_check_failure_(as_check_failure) {}
 
   Set<Class*> found_classes() const { return found_classes_; }
   Set<Method*> found_methods() const { return found_methods_; }
+  // Selectors that only are valid for the given set of methods.
+  // The optimizer changed the dynamic call to a static call, which means that
+  // it knew that the selector goes to that function. We still need to
+  // verify that the holder was instantiated.
+  Map<CallSelector, UnorderedSet<Method*>> found_filtered_selectors() const {
+    return found_filtered_selectors_;
+  }
   Set<CallSelector> found_selectors() const { return found_selectors_; }
 
+  void grow(Method* method) {
+    current_method_ = method;
+    visit(method);
+  }
+
+ protected:
   void visit_CallConstructor(CallConstructor* node) {
     found_classes_.insert(node->klass());
     found_methods_.insert(node->target()->target());
     TraversingVisitor::visit_CallConstructor(node);
   }
 
+  bool is_super_call(CallStatic* node) const {
+    auto current_holder = current_method_->holder();
+    auto target = node->target()->target();
+    if (!is_This(node->arguments()[0], current_holder, target)) return false;
+    // Make sure this is actually a super call (and not a sub call).
+    auto current_class = current_holder;
+    auto target_holder = target->holder();
+    while (current_class != null) {
+      if (current_class == target_holder) return true;
+      current_class = current_class->super();
+    }
+    return false;
+  }
+
   void visit_CallStatic(CallStatic* node) {
-    found_methods_.insert(node->target()->target());
+    auto target = node->target()->target();
+    if (target->is_instance()) {
+      if (is_super_call(node)) {
+        // For super calls we don't need to ensure that the
+        // holder class is actually instantiated and its method not shadowed..
+        found_methods_.insert(target);
+      } else {
+        CallSelector selector(target->name(), node->shape());
+        found_filtered_selectors_[selector].insert(target);
+      }
+    } else {
+      found_methods_.insert(target);
+    }
     TraversingVisitor::visit_CallStatic(node);
   }
 
@@ -78,9 +118,11 @@ class GrowerVisitor : public TraversingVisitor {
   }
 
  private:
-  ir::Method* as_check_failure_;
+  Method* current_method_;
+  Method* as_check_failure_;
   Set<Class*> found_classes_;
   Set<Method*> found_methods_;
+  Map<CallSelector, UnorderedSet<Method*>> found_filtered_selectors_;
   Set<CallSelector> found_selectors_;
 };
 
@@ -247,7 +289,7 @@ class GraphvizTreeLogger : public TreeLogger {
 
 class TreeGrower {
  public:
-  void grow(ir::Program* program);
+  void grow(Program* program);
 
   Set<Class*> grown_classes() const { return grown_classes_; }
   // Includes globals, static functions and instance functions.
@@ -274,6 +316,10 @@ void TreeGrower::grow(Program* program) {
     logger = &null_logger;
   }
 
+  // Selectors for which the dynamic call was changed to a static call to
+  // one of the methods in the set.
+  Map<CallSelector, UnorderedSet<Method*>> filtered_selectors;
+
   for (auto klass : program->tree_roots()) {
     logger->root(klass);
     grown_classes_.insert(klass);
@@ -287,25 +333,41 @@ void TreeGrower::grow(Program* program) {
   while (!method_queue.empty()) {
     Set<Class*> found_classes;
     Set<Method*> found_methods;
+    Map<CallSelector, UnorderedSet<Method*>> found_filtered_selectors;
     Set<CallSelector> found_selectors;
 
     for (auto method : method_queue) {
       if (method->is_abstract() || method->is_dead()) continue;
 
-      GrowerVisitor visitor(program->as_check_failure());
       // Skip already visited methods.
       if (grown_methods_.contains(method)) continue;
       grown_methods_.insert(method);
-      visitor.visit(method);
+      GrowerVisitor visitor(program->as_check_failure());
+      visitor.grow(method);
       logger->add(method, visitor.found_classes(), visitor.found_methods(), visitor.found_selectors());
       found_classes.insert_all(visitor.found_classes());
       found_methods.insert_all(visitor.found_methods());
+      visitor.found_filtered_selectors().for_each([&](CallSelector selector, UnorderedSet<Method*>& methods) {
+        found_filtered_selectors[selector].insert_all(methods);
+      });
       found_selectors.insert_all(visitor.found_selectors());
     }
 
     method_queue.clear();
 
     method_queue.insert(method_queue.end(), found_methods.begin(), found_methods.end());
+
+    // Thin out the filtered selectors.
+    // If a selector is unconditionally included, we don't need to do filter checks.
+    filtered_selectors.for_each([&](CallSelector selector, UnorderedSet<Method*>& methods) {
+      if (methods.empty()) return;
+      if (handled_selectors.contains(selector) || found_selectors.contains(selector)) {
+        // No need to handle this filtered selector in a special way anymore.
+        // All the methods this selector is applicable to are included anyway.
+        methods.clear();
+        return;
+      }
+    });
 
     for (auto klass : found_classes) {
       if (grown_classes_.contains(klass)) continue;
@@ -318,11 +380,40 @@ void TreeGrower::grow(Program* program) {
           method_queue.push_back(probe);
         }
       }
+      // Filtered selectors hit, if there is a class that has a method for it, and
+      // that method is in the filtered set.
+      filtered_selectors.for_each([&](CallSelector selector, UnorderedSet<Method*>& methods) {
+        if (methods.empty()) return;
+        auto probe = queryable.lookup(selector);
+        if (probe != null && methods.contains(probe)) {
+          logger->add_method_with_selector(selector, probe);
+          method_queue.push_back(probe);
+          methods.erase(probe);
+        }
+      });
     }
 
     found_selectors.erase_all(handled_selectors);
     handled_selectors.insert(found_selectors.begin(), found_selectors.end());
-    if (!found_selectors.empty()) {
+    bool has_filtered_selectors = false;
+    found_filtered_selectors.for_each([&](CallSelector selector, UnorderedSet<Method*>& methods) {
+      if (handled_selectors.contains(selector)) {
+        // All methods that fit this selector are handled anyway.
+        // No need to filter them.
+        return;
+      }
+      methods.erase_if([&](Method* method) { return grown_methods_.contains(method); });
+      if (methods.empty()) return;
+      auto probe = filtered_selectors.find(selector);
+      if (probe != filtered_selectors.end()) {
+        // Remove the methods that were already known before.
+        methods.erase_if([&](Method* old) { return probe->second.contains(old); });
+      }
+      if (methods.empty()) return;
+      has_filtered_selectors = true;
+    });
+
+    if (!found_selectors.empty() || has_filtered_selectors) {
       for (auto klass : grown_classes_) {
         auto queryable = queryables[klass];
         for (auto selector : found_selectors) {
@@ -332,7 +423,22 @@ void TreeGrower::grow(Program* program) {
             method_queue.push_back(probe);
           }
         }
+        found_filtered_selectors.for_each([&](CallSelector selector, UnorderedSet<Method*>& methods) {
+          if (methods.empty()) return;
+          auto probe = queryable.lookup(selector);
+          if (probe != null && methods.contains(probe)) {
+            logger->add_method_with_selector(selector, probe);
+            method_queue.push_back(probe);
+            methods.erase(probe);
+          }
+        });
       }
+    }
+    if (has_filtered_selectors) {
+      found_filtered_selectors.for_each([&](CallSelector selector, UnorderedSet<Method*>& methods) {
+        if (methods.empty()) return;
+        filtered_selectors[selector].insert_all(methods);
+      });
     }
   }
 
@@ -345,7 +451,7 @@ void TreeGrower::grow(Program* program) {
   // Add superclasses as grown classes.
   // We didn't add them earlier, since their methods aren't needed if they have
   // been overridden.
-  std::vector<ir::Class*> super_classes;
+  std::vector<Class*> super_classes;
   for (auto klass : grown_classes_) {
     auto current = klass->super();
     while (current != null) {
@@ -361,11 +467,11 @@ void TreeGrower::grow(Program* program) {
 class Fixup : public ReplacingVisitor {
  public:
   explicit Fixup(Set<Class*>& grown_classes,
-                 UnorderedSet<Method*>& unreachable_methods,
+                 Set<Method*>& grown_methods,
                  Type null_type,
                  Method* as_check_failure)
       : null_type_(null_type)
-      , unreachable_methods_(unreachable_methods)
+      , grown_methods_(grown_methods)
       , as_check_failure_(as_check_failure) {
     grown_classes_and_interfaces_.insert_all(grown_classes);
 
@@ -398,11 +504,11 @@ class Fixup : public ReplacingVisitor {
 
     if (node->type().is_nullable()) {
       // Simply replace the original type with `Null_`.
-      return _new ir::Typecheck(node->kind(),
-                                node->expression(),
-                                null_type_.to_nullable(),  // So the error message is more correct.
-                                node->type_name(),
-                                node->range());
+      return _new Typecheck(node->kind(),
+                            node->expression(),
+                            null_type_.to_nullable(),  // So the error message is more correct.
+                            node->type_name(),
+                            node->range());
     }
 
     // At this point we know that the expression can't satisfy the type.
@@ -418,7 +524,7 @@ class Fixup : public ReplacingVisitor {
 
     // For as-checks we create a call to `as_check_failure` with the expression as argument.
     const char* name = node->type().klass()->name().c_str();
-    ListBuilder<ir::Expression*> arguments_builder;
+    ListBuilder<Expression*> arguments_builder;
     arguments_builder.add(node->expression());
     arguments_builder.add(_new LiteralString(name, strlen(name), node->range()));
     auto arguments = arguments_builder.build();
@@ -434,7 +540,7 @@ class Fixup : public ReplacingVisitor {
     auto result = ReplacingVisitor::visit_CallStatic(node)->as_CallStatic();
     ASSERT(result == node);
     Method* method = node->target()->target();
-    if (unreachable_methods_.contains(method)) {
+    if (!grown_methods_.contains(method)) {
       // The static method or constructor is unreachable. This might be
       // because our type propagation phase has told us that the method
       // is dead, but this can also happen when we have changed a dynamic
@@ -466,14 +572,14 @@ class Fixup : public ReplacingVisitor {
     }
     // The store is dead code, as a type-check earlier would have thrown earlier.
     // Drop the store.
-    return _new Sequence(ListBuilder<ir::Expression*>::build(node->receiver(), node->value()),
+    return _new Sequence(ListBuilder<Expression*>::build(node->receiver(), node->value()),
                          node->range());
   }
 
  private:
   Type null_type_;
   Set<Class*> grown_classes_and_interfaces_;
-  UnorderedSet<Method*> unreachable_methods_;
+  Set<Method*> grown_methods_;
   Method* as_check_failure_;
 };
 
@@ -500,7 +606,7 @@ static std::vector<Method*> shake_methods(std::vector<Method*> methods,
   return remaining_methods;
 }
 
-static void shake(ir::Program* program,
+static void shake(Program* program,
                   Set<Class*> grown_classes,
                   Set<Method*> grown_methods) {
   auto null_type = Type::invalid();
@@ -512,7 +618,7 @@ static void shake(ir::Program* program,
   }
   ASSERT(null_type.is_valid());
 
-  ListBuilder<ir::Class*> remaining_classes;
+  ListBuilder<Class*> remaining_classes;
   // Keep the order of the classes.
   for (auto klass : program->classes()) {
     if (grown_classes.contains(klass)) {
@@ -526,15 +632,7 @@ static void shake(ir::Program* program,
   }
   program->replace_classes(remaining_classes.build());
 
-  // The set of grown methods might contain methods that aren't actually reachable.
-  // This can happen when the optimizer changed a dynamic call into a static call, but
-  //   the receiver-type was never instantiated.
-  // The following set contains all methods that were grown, but not added to the program.
-  UnorderedSet<ir::Method*> unreachable_methods;
-  unreachable_methods.insert_all(grown_methods);  // Starts out with all grown methods.
-
   auto remaining_methods = shake_methods(program->methods(), grown_methods);
-  unreachable_methods.erase_all(remaining_methods);
   if (Flags::report_tree_shaking) {
     printf("Kept %d out of %d global functions\n",
            remaining_methods.length(),
@@ -542,10 +640,9 @@ static void shake(ir::Program* program,
   }
   program->replace_methods(remaining_methods);
 
-  ListBuilder<ir::Global*> remaining_globals;
+  ListBuilder<Global*> remaining_globals;
   for (auto global : program->globals()) {
     if (grown_methods.contains(global)) {
-      unreachable_methods.erase(global);
       remaining_globals.add(global);
     }
   }
@@ -563,20 +660,16 @@ static void shake(ir::Program* program,
     // Note that we already shook the copies of constructors/factories/statics that had
     //   been copied into program->methods.
     auto remaining_constructors = shake_methods(klass->constructors(), grown_methods);
-    unreachable_methods.erase_all(remaining_constructors);
     klass->replace_constructors(remaining_constructors);
     auto remaining_factories = shake_methods(klass->factories(), grown_methods);
     klass->replace_factories(remaining_factories);
-    unreachable_methods.erase_all(remaining_factories);
     klass->statics()->invalidate_resolution_map();
     auto remaining_statics = shake_methods(klass->statics()->nodes(), grown_methods);
     klass->statics()->replace_nodes(remaining_statics);
-    unreachable_methods.erase_all(remaining_factories);
     auto remaining_methods = shake_methods(klass->methods(), grown_methods);
     total_methods_count += klass->methods().length();
     remaining_methods_count += remaining_methods.length();
     klass->replace_methods(remaining_methods);
-    unreachable_methods.erase_all(remaining_methods);
   }
   if (Flags::report_tree_shaking) {
     printf("Kept %d out of %d instance methods\n",
@@ -586,7 +679,7 @@ static void shake(ir::Program* program,
 
   // Fixup references to types and methods that don't exist anymore.
   Fixup visitor(grown_classes,
-                unreachable_methods,
+                grown_methods,
                 null_type,
                 program->as_check_failure());
   for (auto method : grown_methods) {
@@ -595,12 +688,12 @@ static void shake(ir::Program* program,
   }
 }
 
-void tree_shake(ir::Program* program) {
+void tree_shake(Program* program) {
   if (Flags::disable_tree_shaking) {
     // Just remove the abstract methods, so that later phases don't need to deal with non-existing bodies.
     for (auto klass : program->classes()) {
       if (!klass->is_abstract()) continue;
-      ListBuilder<ir::MethodInstance*> non_abstract_methods;
+      ListBuilder<MethodInstance*> non_abstract_methods;
       for (auto method : klass->methods()) {
         if (!method->is_abstract()) non_abstract_methods.add(method);
       }

--- a/src/compiler/tree.cc
+++ b/src/compiler/tree.cc
@@ -31,21 +31,71 @@ using namespace ir;
 
 typedef Selector<CallShape> CallSelector;
 
+/// A typed selector set is a set of selectors, where
+/// each selector only applies to specific types.
+/// In the current implementation the type is represented by the
+/// single target that the selector can reach.
+/// For example, a selector 'foo' that applies only to type `A` (or maybe
+/// its subclasses) would be represented by the method `A.foo`.
+/// This representation is not optimal, but historical. Eventually,
+/// this set should keep track of the types that are available, making
+/// it more flexible, intuitive and powerful.
+class TypedSelectorSet {
+ public:
+  void insert(const CallSelector& selector, Method* target) {
+    selectors_[selector].insert(target);
+  }
+
+  /// Adds all typed selectors of other to this set.
+  /// Ignores all methods that are in the 'ignored_methods' set.
+  /// Ignores all selectors that are in the 'ignored_selectors' set.
+  void insert_all(TypedSelectorSet& other,
+                  const Set<Method*> ignored_methods,
+                  const Set<CallSelector> ignored_selectors) {
+    other.selectors_.for_each([&](const CallSelector& selector, const UnorderedSet<Method*> methods) {
+      if (ignored_selectors.contains(selector)) return;
+      for (auto method : methods.underlying_set()) {
+        if (ignored_methods.contains(method)) continue;
+        selectors_[selector].insert(method);
+      }
+    });
+  }
+
+  void match_and_filter(const QueryableClass& queryable,
+                        const std::function<bool (const CallSelector&, Method*)>& on_match) {
+    // A typed selector hit, if there is a class that has a method for it, and
+    // that method is in the set.
+    selectors_.for_each([&](CallSelector selector, UnorderedSet<Method*>& methods) {
+      if (methods.empty()) return;
+      auto probe = queryable.lookup(selector);
+      if (probe != null && methods.contains(probe)) {
+        bool should_erase = on_match(selector, probe);
+        if (should_erase) methods.erase(probe);
+        // We would like to completely erase entries for call selectors that don't have any
+        // target, but since we are using an ordered `Map`, that functionality is
+        // currently not available.
+      }
+    });
+  }
+
+  bool empty() const {
+    // Only looks at whether there are entries in the map. Does not
+    // run through them to see if all of the sets are empty.
+    return selectors_.empty();
+  }
+ private:
+  Map<CallSelector, UnorderedSet<Method*>> selectors_;
+};
+
 class GrowerVisitor : protected TraversingVisitor {
  public:
   explicit GrowerVisitor(Method* as_check_failure)
       : as_check_failure_(as_check_failure) {}
 
-  Set<Class*> found_classes() const { return found_classes_; }
-  Set<Method*> found_methods() const { return found_methods_; }
-  // Selectors that only are valid for the given set of methods.
-  // The optimizer changed the dynamic call to a static call, which means that
-  // it knew that the selector goes to that function. We still need to
-  // verify that the holder was instantiated.
-  Map<CallSelector, UnorderedSet<Method*>> found_filtered_selectors() const {
-    return found_filtered_selectors_;
-  }
-  Set<CallSelector> found_selectors() const { return found_selectors_; }
+  const Set<Class*>& found_classes() const { return found_classes_; }
+  const Set<Method*>& found_methods() const { return found_methods_; }
+  TypedSelectorSet& found_typed_selectors() { return found_typed_selectors_; }
+  const Set<CallSelector>& found_selectors() const { return found_selectors_; }
 
   void grow(Method* method) {
     current_method_ = method;
@@ -63,14 +113,9 @@ class GrowerVisitor : protected TraversingVisitor {
     auto current_holder = current_method_->holder();
     auto target = node->target()->target();
     if (!is_This(node->arguments()[0], current_holder, target)) return false;
-    // Make sure this is actually a super call (and not a sub call).
-    auto current_class = current_holder;
     auto target_holder = target->holder();
-    while (current_class != null) {
-      if (current_class == target_holder) return true;
-      current_class = current_class->super();
-    }
-    return false;
+    // Make sure this is actually a super call (and not a sub call).
+    return target_holder->is_transitive_super_of(current_holder);
   }
 
   void visit_CallStatic(CallStatic* node) {
@@ -78,11 +123,11 @@ class GrowerVisitor : protected TraversingVisitor {
     if (target->is_instance()) {
       if (is_super_call(node)) {
         // For super calls we don't need to ensure that the
-        // holder class is actually instantiated and its method not shadowed..
+        // holder class is actually instantiated and its method isn't shadowed.
         found_methods_.insert(target);
       } else {
         CallSelector selector(target->name(), node->shape());
-        found_filtered_selectors_[selector].insert(target);
+        found_typed_selectors_.insert(selector, target);
       }
     } else {
       found_methods_.insert(target);
@@ -122,7 +167,7 @@ class GrowerVisitor : protected TraversingVisitor {
   Method* as_check_failure_;
   Set<Class*> found_classes_;
   Set<Method*> found_methods_;
-  Map<CallSelector, UnorderedSet<Method*>> found_filtered_selectors_;
+  TypedSelectorSet found_typed_selectors_;
   Set<CallSelector> found_selectors_;
 };
 
@@ -304,6 +349,7 @@ void TreeGrower::grow(Program* program) {
   auto queryables = build_queryables_from_plain_shapes(program->classes());
 
   Set<CallSelector> handled_selectors;
+  TypedSelectorSet handled_typed_selectors;
 
   std::vector<Method*> method_queue;
 
@@ -315,10 +361,6 @@ void TreeGrower::grow(Program* program) {
   } else {
     logger = &null_logger;
   }
-
-  // Selectors for which the dynamic call was changed to a static call to
-  // one of the methods in the set.
-  Map<CallSelector, UnorderedSet<Method*>> filtered_selectors;
 
   for (auto klass : program->tree_roots()) {
     logger->root(klass);
@@ -333,7 +375,7 @@ void TreeGrower::grow(Program* program) {
   while (!method_queue.empty()) {
     Set<Class*> found_classes;
     Set<Method*> found_methods;
-    Map<CallSelector, UnorderedSet<Method*>> found_filtered_selectors;
+    TypedSelectorSet found_typed_selectors;
     Set<CallSelector> found_selectors;
 
     for (auto method : method_queue) {
@@ -347,27 +389,16 @@ void TreeGrower::grow(Program* program) {
       logger->add(method, visitor.found_classes(), visitor.found_methods(), visitor.found_selectors());
       found_classes.insert_all(visitor.found_classes());
       found_methods.insert_all(visitor.found_methods());
-      visitor.found_filtered_selectors().for_each([&](CallSelector selector, UnorderedSet<Method*>& methods) {
-        found_filtered_selectors[selector].insert_all(methods);
-      });
+      // Ignore already grown methods, and selectors that cover every type.
+      found_typed_selectors.insert_all(visitor.found_typed_selectors(),
+                                       grown_methods_,
+                                       handled_selectors);
       found_selectors.insert_all(visitor.found_selectors());
     }
 
     method_queue.clear();
 
     method_queue.insert(method_queue.end(), found_methods.begin(), found_methods.end());
-
-    // Thin out the filtered selectors.
-    // If a selector is unconditionally included, we don't need to do filter checks.
-    filtered_selectors.for_each([&](CallSelector selector, UnorderedSet<Method*>& methods) {
-      if (methods.empty()) return;
-      if (handled_selectors.contains(selector) || found_selectors.contains(selector)) {
-        // No need to handle this filtered selector in a special way anymore.
-        // All the methods this selector is applicable to are included anyway.
-        methods.clear();
-        return;
-      }
-    });
 
     for (auto klass : found_classes) {
       if (grown_classes_.contains(klass)) continue;
@@ -380,40 +411,19 @@ void TreeGrower::grow(Program* program) {
           method_queue.push_back(probe);
         }
       }
-      // Filtered selectors hit, if there is a class that has a method for it, and
-      // that method is in the filtered set.
-      filtered_selectors.for_each([&](CallSelector selector, UnorderedSet<Method*>& methods) {
-        if (methods.empty()) return;
-        auto probe = queryable.lookup(selector);
-        if (probe != null && methods.contains(probe)) {
-          logger->add_method_with_selector(selector, probe);
-          method_queue.push_back(probe);
-          methods.erase(probe);
-        }
+      handled_typed_selectors.match_and_filter(queryable,
+                                               [&](const CallSelector& selector, Method* matched) {
+        logger->add_method_with_selector(selector, matched);
+        method_queue.push_back(matched);
+        // Allow the removal of the now handled method.
+        return true;
       });
     }
 
+    // No need to look for selectors we already know about.
     found_selectors.erase_all(handled_selectors);
-    handled_selectors.insert(found_selectors.begin(), found_selectors.end());
-    bool has_filtered_selectors = false;
-    found_filtered_selectors.for_each([&](CallSelector selector, UnorderedSet<Method*>& methods) {
-      if (handled_selectors.contains(selector)) {
-        // All methods that fit this selector are handled anyway.
-        // No need to filter them.
-        return;
-      }
-      methods.erase_if([&](Method* method) { return grown_methods_.contains(method); });
-      if (methods.empty()) return;
-      auto probe = filtered_selectors.find(selector);
-      if (probe != filtered_selectors.end()) {
-        // Remove the methods that were already known before.
-        methods.erase_if([&](Method* old) { return probe->second.contains(old); });
-      }
-      if (methods.empty()) return;
-      has_filtered_selectors = true;
-    });
 
-    if (!found_selectors.empty() || has_filtered_selectors) {
+    if (!found_selectors.empty() || !found_typed_selectors.empty()) {
       for (auto klass : grown_classes_) {
         auto queryable = queryables[klass];
         for (auto selector : found_selectors) {
@@ -423,23 +433,22 @@ void TreeGrower::grow(Program* program) {
             method_queue.push_back(probe);
           }
         }
-        found_filtered_selectors.for_each([&](CallSelector selector, UnorderedSet<Method*>& methods) {
-          if (methods.empty()) return;
-          auto probe = queryable.lookup(selector);
-          if (probe != null && methods.contains(probe)) {
-            logger->add_method_with_selector(selector, probe);
-            method_queue.push_back(probe);
-            methods.erase(probe);
-          }
+        found_typed_selectors.match_and_filter(queryable,
+                                               [&](const CallSelector& selector, Method* matched) {
+          logger->add_method_with_selector(selector, matched);
+          method_queue.push_back(matched);
+          // Allow the removal of the now handled method.
+          return true;
         });
       }
     }
-    if (has_filtered_selectors) {
-      found_filtered_selectors.for_each([&](CallSelector selector, UnorderedSet<Method*>& methods) {
-        if (methods.empty()) return;
-        filtered_selectors[selector].insert_all(methods);
-      });
-    }
+
+    handled_selectors.insert_all(found_selectors);
+    // Add the newly found typed selectors, but ignore them for
+    // known methods and for selectors that are already matching everything.
+    handled_typed_selectors.insert_all(found_typed_selectors,
+                                       grown_methods_,
+                                       handled_selectors);
   }
 
   logger->print();

--- a/src/compiler/tree.cc
+++ b/src/compiler/tree.cc
@@ -83,6 +83,7 @@ class TypedSelectorSet {
     // run through them to see if all of the sets are empty.
     return selectors_.empty();
   }
+
  private:
   Map<CallSelector, UnorderedSet<Method*>> selectors_;
 };

--- a/tests/equals_test.toit
+++ b/tests/equals_test.toit
@@ -15,6 +15,21 @@ class B:
   operator == other -> bool:
     throw "Unreachable since only called with null."
 
+confuse x:
+  return x
+
+class C:
+  x := 0
+
+  foo:
+    // We must keep a virtual equality call here,
+    // since the RHS might be null, and the interpreter
+    // checks for the null case first.
+    return this == (confuse null)
+
+  operator == other:
+    return other.x == 0
+
 nul: return null
 
 foo b / B:
@@ -29,3 +44,6 @@ main:
   expect_equals 1 counter
   expect (not B == null)
   foo B
+
+  c := C
+  expect (not c.foo)

--- a/tests/toitp/tree_shaken2_input.toit
+++ b/tests/toitp/tree_shaken2_input.toit
@@ -1,0 +1,38 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+
+class B:
+  foo:
+    return 42
+
+class ASuper:
+  bar:
+    if this is A:
+      (this as A).will_be_tree_shaken
+
+class A extends ASuper:
+  will_be_tree_shaken:
+    // Pulls in `B` and makes `foo` a called selector.
+    // If the tree-shaking works correctly we should neither see
+    // `B` nor `foo` in the final tree.
+    b := B
+    (confuse b).foo
+
+
+confuse x:
+  return x
+
+class C:
+  foo:
+    return 499
+
+main:
+  a_super := ASuper
+  a_super.bar
+
+  c := C
+  confuse c
+  // If the tree-shaking works, C.foo should be tree-shaken.

--- a/tests/toitp/tree_shaken2_snap_test.toit
+++ b/tests/toitp/tree_shaken2_snap_test.toit
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+import ...tools.snapshot
+
+main args:
+  snapshot_path := args[0]
+  snapshot := SnapshotBundle.from_file snapshot_path
+  program := snapshot.decode
+
+  // We must not see `B`, and `C.foo`.
+  program.do --class_infos: | klass/ClassInfo |
+    expect_not_equals "B" klass.name
+
+  program.do --method_infos: | method/MethodInfo |
+    if method.type != MethodInfo.INSTANCE_TYPE:
+      continue.do
+    class_name := program.class_name_for method.outer
+    if class_name != "C":
+      continue.do
+    expect_not_equals "foo" method.name

--- a/tests/toitp/tree_shaken2_toitp_test.toit
+++ b/tests/toitp/tree_shaken2_toitp_test.toit
@@ -1,0 +1,6 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+main args:
+  // Only a snapshot test.

--- a/tests/toitp/tree_shaken_input.toit
+++ b/tests/toitp/tree_shaken_input.toit
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+
+class B:
+  foo:
+    return 42
+
+class A:
+  will_be_tree_shaken:
+    // Pulls in `B` and makes `foo` a called selector.
+    // If the tree-shaking works correctly we should neither see
+    // `B` nor `foo` in the final tree.
+    b := B
+    (confuse b).foo
+
+create_a -> A?:
+  return null
+
+confuse x:
+  return x
+
+class C:
+  foo:
+    return 499
+
+main:
+  a := create_a
+  if a:
+    // The optimizer will change the `will_be_tree_shaken` call to
+    // a static call, since we know that the type must be `A`.
+    // During tree-growing we will encounter 'main' first, with
+    // this static call.
+    // We must wait to evaluate the call until we have seen the
+    // construction of `A`.
+    (a as A).will_be_tree_shaken
+
+  c := C
+  confuse c
+  // If the tree-shaking works, C.foo should be tree-shaken.

--- a/tests/toitp/tree_shaken_snap_test.toit
+++ b/tests/toitp/tree_shaken_snap_test.toit
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+import ...tools.snapshot
+
+main args:
+  snapshot_path := args[0]
+  snapshot := SnapshotBundle.from_file snapshot_path
+  program := snapshot.decode
+
+  // We must not see `B`, and `C.foo`.
+  program.do --class_infos: | klass/ClassInfo |
+    expect_not_equals "B" klass.name
+
+  program.do --method_infos: | method/MethodInfo |
+    if method.type != MethodInfo.INSTANCE_TYPE:
+      continue.do
+    class_name := program.class_name_for method.outer
+    if class_name != "C":
+      continue.do
+    expect_not_equals "foo" method.name

--- a/tests/toitp/tree_shaken_toitp_test.toit
+++ b/tests/toitp/tree_shaken_toitp_test.toit
@@ -1,0 +1,6 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+main args:
+  // Only a snapshot test.


### PR DESCRIPTION
The tree-grower would grow static calls even if they were to instance methods of classes that were not instantiated. These static calls were introduced by an earlier optimization. For example, if there is a static type check before that guarantees (assuming the check works) only one dynamic method can be reached.

Now the grower treats these calls as "filtered" virtual calls. That is, they are selector calls, but if they trigger they can only grow to the target method. As such, they also have to wait for classes to be instantiated before they are added to the grown method set.

Care must be taken with super calls: these are also static calls to instance methods, but we have to handle them as soon as we seen them.

This patch also fixes a bug where a call to `operator ==` was changed into a static call, even when the RHS was not guaranteed to be non-null.