### PR TITLE
Improve espnow.

### DIFF
--- a/examples/espnow.toit
+++ b/examples/espnow.toit
@@ -5,19 +5,19 @@
 import esp32.espnow
 
 PMK ::= espnow.Key.from_string "pmk1234567890123"
-service ::= espnow.Service.station --key=PMK
 
 main:
+  service := espnow.Service.station --key=PMK
   service.add_peer
       espnow.BROADCAST_ADDRESS
       --channel=1
-  task:: espnow_tx_task
-  task:: espnow_rx_task
+  task:: espnow_tx_task service
+  task:: espnow_rx_task service
 
-espnow_tx_task:
+espnow_tx_task service/espnow.Service:
   count := 0
   while true:
-    buffer := "hello $count"    
+    buffer := "hello $count"
     service.send
         buffer.to_byte_array
         --address=espnow.BROADCAST_ADDRESS
@@ -26,11 +26,11 @@ espnow_tx_task:
     count++
     sleep --ms=1000
 
-espnow_rx_task:
+espnow_rx_task service/espnow.Service:
   while true:
     datagram := service.receive
     if datagram:
-      recv_data := datagram.data.to_string
-      print "Receive datagram from \"$datagram.address\", data: \"$recv_data\""
+      received_data := datagram.data.to_string
+      print "Receive datagram from \"$datagram.address\", data: \"$received_data\""
     else:
       sleep --ms=1000

--- a/tests/esp32/adc.toit
+++ b/tests/esp32/adc.toit
@@ -8,6 +8,10 @@ Tests the ADC.
 Note that this test accesses ADC2 which is restricted and can't be used
   while WiFi is running.
 
+On Jaguar use:
+  `jag container install -D jag.disabled -D jag.timeout=1m adc adc.toit`
+
+
 Setup:
 Connect pin 12 to pin 14 with a 330 Ohm resistor.
 Connect pin 14 to pin 32 with a 330 Ohm resistor.

--- a/tests/esp32/espnow1_board1.toit
+++ b/tests/esp32/espnow1_board1.toit
@@ -1,0 +1,44 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+/**
+Tests the espnow functionality.
+
+This test must be run without WiFi. (In theory it's
+  possible to run with WiFi, but then the channel needs to be
+  set to the same channel as the WiFi network.)
+
+On Jaguar use:
+  `jag container install -D jag.disabled -D jag.timeout=1m espnow espnow1_board1.toit`
+
+Run `espnow1_board1.toit` on board1.
+Once that one is running, run `espnow1_board2.toit` on board2.
+
+*/
+
+import esp32.espnow
+import expect show *
+import .espnow1_shared
+
+main:
+  service ::= espnow.Service.station --key=PMK
+
+  service.add_peer
+      espnow.BROADCAST_ADDRESS
+      --channel=CHANNEL
+
+  print "Listening for messages."
+  with_timeout --ms=10_000:
+    received := []
+    while true:
+      datagram := service.receive
+      if datagram:
+        message := datagram.data.to_string
+        received.add message
+        if message == END_TOKEN: break
+        print message
+      else:
+        sleep --ms=10
+
+    expect_equals TEST_DATA received

--- a/tests/esp32/espnow1_board2.toit
+++ b/tests/esp32/espnow1_board2.toit
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+/**
+See 'espnow1_board1.toit'
+*/
+
+import esp32.espnow
+import .espnow1_shared
+
+main:
+  service ::= espnow.Service.station --key=PMK
+
+  service.add_peer
+      espnow.BROADCAST_ADDRESS
+      --channel=CHANNEL
+
+  TEST_DATA.do:
+    service.send
+        it.to_byte_array
+        --address=espnow.BROADCAST_ADDRESS
+    print it
+    sleep --ms=20

--- a/tests/esp32/espnow1_shared.toit
+++ b/tests/esp32/espnow1_shared.toit
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import esp32.espnow
+
+PMK ::= espnow.Key.from_string "pmk1234567890123"
+
+END_TOKEN ::= "<END>"
+
+TEST_DATA ::= [
+  "In my younger and more vulnerable years",
+  "my father gave me some advice",
+  "that I've been turning over in my mind ever since.",
+  "\"Whenever you feel like criticizing any one,\"",
+  "he told me,",
+  "\"just remember that all the people in this world",
+  "haven't had the advantages that you've had.\"",
+  "-- F. Scott Fitzgerald",
+  "The Great Gatsby",
+  END_TOKEN
+]
+
+CHANNEL ::= 1


### PR DESCRIPTION
ESP Now still needs to run without WiFi interfering, but it's now possible to run WiFi programs after the container with ESP Now has finished.