### PR TITLE
Make RootCertificate a real object.

### DIFF
--- a/lib/tls/certificate.toit
+++ b/lib/tls/certificate.toit
@@ -41,7 +41,7 @@ class RootCertificate:
   Constructs a RootCertificate from a binary DER-endoded certificate
     or an ASCII PEM-encoded certificate.
 
-  The $raw certificate, is in unparsed form, ie either in PEM (ASCII) format or
+  The $raw certificate is in unparsed form, either in PEM (ASCII) format or
     in DER format. Usually you would use a byte array constant in DER format,
     which will stay in flash on embedded platforms, using very little memory.
     More memory is used when it is added to a TLS socket.  If it is installed

--- a/lib/tls/certificate.toit
+++ b/lib/tls/certificate.toit
@@ -29,7 +29,7 @@ Trusted Root TLS Certificate used to verify a server's identity.
 It is composed of a x509 certificate and a fingerprint.
 */
 class RootCertificate:
-  fingerprint/int
+  fingerprint/int?
   parsed_/x509.Certificate? := null
   name/string? := null
   raw ::= ?
@@ -40,23 +40,40 @@ class RootCertificate:
   /**
   Constructs a RootCertificate from a binary DER-endoded certificate
     or an ASCII PEM-encoded certificate.
+
+  The $raw certificate, is in unparsed form, ie either in PEM (ASCII) format or
+    in DER format. Usually you would use a byte array constant in DER format,
+    which will stay in flash on embedded platforms, using very little memory.
+    More memory is used when it is added to a TLS socket.  If it is installed
+    in the process with $install then no extra memory is used until it is
+    needed to complete a TLS handshake.
   */
-  constructor --.name=null .raw .fingerprint:
+  constructor --.name=null --.fingerprint=null .raw:
 
   /**
   Gets a parsed form suitable for adding to a TLS socket.
   */
-  parsed -> x509.Certificate:
+  ensure_parsed_ -> x509.Certificate:
     if parsed_ == null:
       parsed_ = x509.Certificate.parse raw
     return parsed_
 
   /**
-  Installs the unparsed certificate as a trusted root, usable for all
-    TLS connections for this process.
+  Add a trusted root certificate that can be used for all TLS connections.
+
+  This method is an alternative to adding root certificates to individual TLS
+    sockets, or using the --root_certificates argument on the HTTP client.
+    If you add root certificates to a specific connection then these global
+    certificates are not consulted for that connection, not even as a fallback.
+
+  The trusted roots added with this method have a "subject" field that is used
+    to match with the "issuer" field that the server provides. Only matching
+    roots are tried when attempting to verify a server certificate. The
+    "AuthorityKeyIdentifier" and "SubjectKeyIdentifer" extensions are not
+    supported.
   */
   install -> none:
-    add_global_root_certificate raw fingerprint
+    add_global_root_certificate_ raw fingerprint
 
 /**
 Add a trusted root certificate that can be used for all TLS connections.
@@ -82,5 +99,5 @@ Certificates, the $cert argument, are added here in unparsed form, ie either in
 Returns the hash of the added certificate, which can be used to add it more
   efficiently, without parsing the certificate at startup time.
 */
-add_global_root_certificate cert hash/int?=null -> int:
+add_global_root_certificate_ cert hash/int?=null -> int:
   #primitive.tls.add_global_root_certificate

--- a/lib/tls/certificate.toit
+++ b/lib/tls/certificate.toit
@@ -3,6 +3,7 @@
 // found in the lib/LICENSE file.
 
 import net.x509 as x509
+import tls
 
 /**
 TLS Certificate used as identity in a TLS session.
@@ -21,6 +22,41 @@ class Certificate:
   An optional password can be given, to unlock the private key if needed.
   */
   constructor .certificate .private_key --.password="":
+
+/**
+Trusted Root TLS Certificate used to verify a server's identity.
+
+It is composed of a x509 certificate and a fingerprint.
+*/
+class RootCertificate:
+  fingerprint/int
+  parsed_/x509.Certificate? := null
+  name/string? := null
+  raw ::= ?
+
+  stringify -> string:
+    return name or "Root certificate w/ fingerprint $fingerprint"
+
+  /**
+  Constructs a RootCertificate from a binary DER-endoded certificate
+    or an ASCII PEM-encoded certificate.
+  */
+  constructor --.name=null .raw .fingerprint:
+
+  /**
+  Gets a parsed form suitable for adding to a TLS socket.
+  */
+  parsed -> x509.Certificate:
+    if parsed_ == null:
+      parsed_ = x509.Certificate.parse raw
+    return parsed_
+
+  /**
+  Installs the unparsed certificate as a trusted root, usable for all
+    TLS connections for this process.
+  */
+  install -> none:
+    add_global_root_certificate raw fingerprint
 
 /**
 Add a trusted root certificate that can be used for all TLS connections.

--- a/lib/tls/certificate.toit
+++ b/lib/tls/certificate.toit
@@ -49,6 +49,7 @@ class RootCertificate:
     needed to complete a TLS handshake.
   */
   constructor --.name=null --.fingerprint=null .raw:
+    if raw is not ByteArray and raw is not string: throw "WRONG_OBJECT_TYPE"
 
   /**
   Gets a parsed form suitable for adding to a TLS socket.

--- a/lib/tls/session.toit
+++ b/lib/tls/session.toit
@@ -291,7 +291,7 @@ class Session:
         tls_add_root_certificate_ tls_ root_certificate.res_
       else:
         root := root_certificate as tls.RootCertificate
-        tls_add_root_certificate_ tls_ root.parsed.res_
+        tls_add_root_certificate_ tls_ root.ensure_parsed_.res_
     if certificate:
       tls_add_certificate_ tls_ certificate.certificate.res_ certificate.private_key certificate.password
     tls_init_socket_ tls_ null

--- a/lib/tls/session.toit
+++ b/lib/tls/session.toit
@@ -11,6 +11,7 @@ import crypto.sha show Sha256 Sha384
 import encoding.tison
 import monitor
 import net.x509 as x509
+import tls
 import reader
 import writer
 
@@ -285,7 +286,12 @@ class Session:
       handshake_in_progress_ = null
 
   handshake_ tls_state/monitor.ResourceState_ --session_state/ByteArray?=null -> none:
-    root_certificates.do: tls_add_root_certificate_ tls_ it.res_
+    root_certificates.do: | root_certificate |
+      if root_certificate is x509.Certificate:
+        tls_add_root_certificate_ tls_ root_certificate.res_
+      else:
+        root := root_certificate as tls.RootCertificate
+        tls_add_root_certificate_ tls_ root.parsed.res_
     if certificate:
       tls_add_certificate_ tls_ certificate.certificate.res_ certificate.private_key certificate.password
     tls_init_socket_ tls_ null

--- a/tests/tls_global_cert_test_slow.toit
+++ b/tests/tls_global_cert_test_slow.toit
@@ -158,35 +158,36 @@ connect_to_site host port expected_certificate_name:
 
 add_global_certs -> none:
   // Test binary (DER) roots.
-  tls.add_global_root_certificate DIGICERT_GLOBAL_ROOT_G2_BYTES 0x025449c2
-  tls.add_global_root_certificate DIGICERT_GLOBAL_ROOT_CA_BYTES
-  tls.add_global_root_certificate GLOBALSIGN_ROOT_CA_BYTES  // Needed for pravda.ru.
-  tls.add_global_root_certificate GLOBALSIGN_ROOT_CA_R3_BYTES  // Needed for lund.se.
-  tls.add_global_root_certificate COMODO_RSA_CERTIFICATION_AUTHORITY_BYTES  // Needed for elpriser.nu.
-  tls.add_global_root_certificate BALTIMORE_CYBERTRUST_ROOT_BYTES  // Needed for coinbase.com.
+  tls.add_global_root_certificate_ DIGICERT_GLOBAL_ROOT_G2_BYTES 0x025449c2
+  tls.add_global_root_certificate_ DIGICERT_GLOBAL_ROOT_CA_BYTES
+  // Test roots that are RootCertificate objects.
+  GLOBALSIGN_ROOT_CA_BYTES.install  // Needed for pravda.ru.
+  GLOBALSIGN_ROOT_CA_R3_BYTES.install  // Needed for lund.se.
+  COMODO_RSA_CERTIFICATION_AUTHORITY_BYTES.install  // Needed for elpriser.nu.
+  BALTIMORE_CYBERTRUST_ROOT_BYTES.install  // Needed for coinbase.com.
   // Test a binary root that is a modified copy-on-write byte array.
   USERTRUST_ECC_CERTIFICATION_AUTHORITY_BYTES[42] ^= 42
   USERTRUST_ECC_CERTIFICATION_AUTHORITY_BYTES[42] ^= 42
-  tls.add_global_root_certificate USERTRUST_ECC_CERTIFICATION_AUTHORITY_BYTES  // Needed for helsinki.fi.
+  tls.add_global_root_certificate_ USERTRUST_ECC_CERTIFICATION_AUTHORITY_BYTES  // Needed for helsinki.fi.
   // Test ASCII (PEM) roots.
-  tls.add_global_root_certificate USERTRUST_RSA_CERTIFICATE_TEXT 0x0c49cbaf  // Needed for dmi.dk.
-  tls.add_global_root_certificate ISRG_ROOT_X1_TEXT  // Needed by dkhostmaster.dk and digimedia.com.
+  tls.add_global_root_certificate_ USERTRUST_RSA_CERTIFICATE_TEXT 0x0c49cbaf  // Needed for dmi.dk.
+  tls.add_global_root_certificate_ ISRG_ROOT_X1_TEXT  // Needed by dkhostmaster.dk and digimedia.com.
   // Test that the cert can be a slice.
-  tls.add_global_root_certificate DIGICERT_ROOT_TEXT[..DIGICERT_ROOT_TEXT.size - 9]
+  tls.add_global_root_certificate_ DIGICERT_ROOT_TEXT[..DIGICERT_ROOT_TEXT.size - 9]
 
   // Test that we get a sensible error when trying to add a parsed root
   // certificate.
   parsed := net.Certificate.parse USERTRUST_RSA_CERTIFICATE_TEXT
-  expect_error "WRONG_OBJECT_TYPE": tls.add_global_root_certificate parsed
+  expect_error "WRONG_OBJECT_TYPE": tls.add_global_root_certificate_ parsed
 
   // Test that unparseable cert gives an immediate error.
   expect_error "OID is not found":
     DIGICERT_GLOBAL_ROOT_CA_BYTES[42] ^= 42
-    tls.add_global_root_certificate DIGICERT_GLOBAL_ROOT_CA_BYTES
+    tls.add_global_root_certificate_ DIGICERT_GLOBAL_ROOT_CA_BYTES
 
   // Test that it's not too costly to add the same cert multiple times.
   1_000_000.repeat:
-    tls.add_global_root_certificate DIGICERT_GLOBAL_ROOT_G2_BYTES 0x025449c2
+    tls.add_global_root_certificate_ DIGICERT_GLOBAL_ROOT_G2_BYTES 0x025449c2
 
 // Ebay.de sometimes uses this trusted root certificate.
 // Serial number 01:FD:6D:30:FC:A3:CA:51:A8:1B:BC:64:0E:35:03:2D
@@ -418,7 +419,7 @@ DIGICERT_ASSURED_ID_ROOT_G3_BYTES ::= #[
     '!','f',199,'/',234,150,'c','j','e','E',146,149,1,180,
 ]
 
-GLOBALSIGN_ROOT_CA_BYTES ::= #[
+GLOBALSIGN_ROOT_CA_BYTES ::= tls.RootCertificate #[
     '0',0x82,3,'u','0',0x82,2,']',160,3,2,1,2,2,11,4,0,0,0,0,1,21,'K','Z',195,
     0x94,'0',13,6,9,'*',134,'H',134,247,13,1,1,5,5,0,'0','W','1',11,'0',9,6,3,
     'U',4,6,19,2,'B','E','1',25,'0',23,6,3,'U',4,10,19,16,'G','l','o','b','a',
@@ -465,7 +466,7 @@ GLOBALSIGN_ROOT_CA_BYTES ::= #[
     201,222,12,136,10,29,214,'f','U',226,252,'H',201,')','&','i',224,
 ]
 
-COMODO_RSA_CERTIFICATION_AUTHORITY_BYTES ::= #[
+COMODO_RSA_CERTIFICATION_AUTHORITY_BYTES ::= tls.RootCertificate #[
     '0',0x82,5,216,'0',130,3,192,160,3,2,1,2,2,16,'L',170,249,202,219,'c','o',
     224,31,247,'N',216,'[',3,134,157,'0',13,6,9,'*',134,'H',134,247,13,1,1,12,
     0x5,0,'0',129,133,'1',11,'0',9,6,3,'U',4,6,19,2,'G','B','1',27,'0',25,6,3,
@@ -545,7 +546,7 @@ COMODO_RSA_CERTIFICATION_AUTHORITY_BYTES ::= #[
     173,187,27,'_','t',
 ]
 
-BALTIMORE_CYBERTRUST_ROOT_BYTES ::= #[
+BALTIMORE_CYBERTRUST_ROOT_BYTES ::= tls.RootCertificate #[
     '0',0x82,3,'w','0',130,2,'_',160,3,2,1,2,2,4,2,0,0,185,'0',13,6,9,'*',134,
     'H',0x86,0xf7,0xd,1,1,5,5,0,'0','Z','1',11,'0',9,6,3,'U',4,6,19,2,'I','E',
     '1',0x12,'0',16,6,3,'U',4,10,19,9,'B','a','l','t','i','m','o','r','e','1',
@@ -629,7 +630,7 @@ USERTRUST_ECC_CERTIFICATION_AUTHORITY_BYTES ::= #[
     'M',201,'a',218,209,']','W','j',24,
 ]
 
-GLOBALSIGN_ROOT_CA_R3_BYTES ::= #[
+GLOBALSIGN_ROOT_CA_R3_BYTES ::= tls.RootCertificate #[
     '0',0x82,0x3,'_','0',130,2,'G',160,3,2,1,2,2,11,4,0,0,0,0,1,'!','X','S',8,
     162,'0',13,6,9,'*',134,'H',134,247,13,1,1,11,5,0,'0','L','1',' ','0',30,6,
     3,'U',4,0xb,19,23,'G','l','o','b','a','l','S','i','g','n',' ','R','o','o',

--- a/tests/tls_test_slow.toit
+++ b/tests/tls_test_slow.toit
@@ -248,4 +248,4 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
 
 // The ecc256 and ecc384 sites have started using this root.
 /// ISRG Root X1.
-ISRG_ROOT_X1 ::= net.Certificate.parse ISRG_ROOT_X1_TEXT_
+ISRG_ROOT_X1 ::= tls.RootCertificate ISRG_ROOT_X1_TEXT_


### PR DESCRIPTION
This is a response to the comment on https://github.com/toitware/toit-cert-roots/pull/18

It makes an incompatible change that makes a public method private, but nobody has started using the global trusted roots yet afaik.

An upcoming change to toit-cert-roots will make use of this new type.