### PR TITLE
Add missing include of <ctype.h>

### DIFF
--- a/src/primitive_core.cc
+++ b/src/primitive_core.cc
@@ -41,6 +41,7 @@
 #include <signal.h>
 #include <string.h>
 #include <cinttypes>
+#include <ctype.h>
 #include <errno.h>
 #include <sys/time.h>
 


### PR DESCRIPTION
Necessary for `isspace` with certain compilers / libraries.