### PR TITLE
Update third-parties of compiler.

### DIFF
--- a/src/compiler/third_party/libyaml/CMakeLists.txt
+++ b/src/compiler/third_party/libyaml/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.19.0)
 project (yaml C)
 
 set (YAML_VERSION_MAJOR 0)

--- a/src/compiler/third_party/libyaml/README.toitware
+++ b/src/compiler/third_party/libyaml/README.toitware
@@ -12,6 +12,10 @@ A Yaml library for C.
 We have patched the CMakeLists.txt to avoid warnings during build.
 See 'toitware.diff' for the changes, and https://github.com/yaml/libyaml/issues/210.
 
+We have patched the CMakeLists.txt to increase the minimum CMake version, as
+newer versions of CMake warn otherwise.
+See 'toitware2.diff' for the changes.
+
 Similarly, we have changed the .gitignore file, so it doesn't exclude the
 config.h.in file in the 'cmake' directory.
 See https://github.com/yaml/libyaml/pull/232 for a pull request to the project.

--- a/src/compiler/third_party/libyaml/toitware2.diff
+++ b/src/compiler/third_party/libyaml/toitware2.diff
@@ -1,0 +1,11 @@
+diff --git a/src/compiler/third_party/libyaml/CMakeLists.txt b/src/compiler/third_party/libyaml/CMakeLists.txt
+index 964a1c59..7152b3df 100644
+--- a/src/compiler/third_party/libyaml/CMakeLists.txt
++++ b/src/compiler/third_party/libyaml/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ 
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.19.0)
+ project (yaml C)
+ 
+ set (YAML_VERSION_MAJOR 0)

--- a/src/compiler/third_party/semver/CMakeLists.txt
+++ b/src/compiler/third_party/semver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.19.0)
 
 set(SEMVER_STATIC_LIB_NAME "semver" CACHE STRING "Base name of static library output")
 


### PR DESCRIPTION
Newer CMake versions complain if the minimum is too low. Just bumping these up was enough.