### PR TITLE
Reduce only-for-malloc area from 160k to 108k

### DIFF
--- a/src/third_party/dartino/gc_metadata.cc
+++ b/src/third_party/dartino/gc_metadata.cc
@@ -43,9 +43,9 @@ void GcMetadata::set_up_singleton() {
   lowest_address_ = Utils::round_down(range_address, TOIT_PAGE_SIZE);
   uword size = Utils::round_up(range.size + range_address - lowest_address_, TOIT_PAGE_SIZE);
 #ifdef TOIT_FREERTOS
-  // Assume that the first 160k of memory can be used for C allocations, so we
+  // Assume that the first 108k of memory can be used for C allocations, so we
   // remove that from the area that needs to be covered by the heap metadata.
-  // This reduces the heap metadata from 24k or 28k to 12k or 16k.
+  // This reduces the heap metadata from 24k or 28k to 16k.
   const uword ONLY_FOR_MALLOC = 108 * KB;
   const uword TWELVE_K_METADATA_LIMIT = 148 * KB;
   const uword SIXTEEN_K_METADATA_LIMIT = 200 * KB;

--- a/src/third_party/dartino/gc_metadata.cc
+++ b/src/third_party/dartino/gc_metadata.cc
@@ -46,7 +46,7 @@ void GcMetadata::set_up_singleton() {
   // Assume that the first 160k of memory can be used for C allocations, so we
   // remove that from the area that needs to be covered by the heap metadata.
   // This reduces the heap metadata from 24k or 28k to 12k or 16k.
-  const uword ONLY_FOR_MALLOC = 160 * KB;
+  const uword ONLY_FOR_MALLOC = 108 * KB;
   const uword TWELVE_K_METADATA_LIMIT = 148 * KB;
   const uword SIXTEEN_K_METADATA_LIMIT = 200 * KB;
   if (!OS::use_spiram_for_metadata() && !OS::use_spiram_for_heap()) {


### PR DESCRIPTION
For non-SPIRAM ESP32s, this increases the size of the heap metadata from 12k to 16k, but may help for systems that have large Toit heaps and low amounts of malloced memory.