### PR TITLE
Windows: Don't use overlapped mode for subprocess pipes.

### DIFF
--- a/src/resources/pipe_win.cc
+++ b/src/resources/pipe_win.cc
@@ -339,15 +339,26 @@ PRIMITIVE(write) {
 
 PRIMITIVE(read) {
   ARGS(ReadPipeResource, read_resource);
+  fprintf(stderr, "read: entered\n");
 
-  if (read_resource->pipe_ended()) return process->null_object();
-  if (!read_resource->read_ready()) return Smi::from(-1);
+  if (read_resource->pipe_ended()) {
+    fprintf(stderr, "read: pipe ended.\n");
+    return process->null_object();
+  }
+  if (!read_resource->read_ready()) {
+    fprintf(stderr, "read: not ready - returning -1\n");
+    return Smi::from(-1);
+  }
 
   ByteArray* array = process->allocate_byte_array(READ_BUFFER_SIZE, true);
-  if (array == null) FAIL(ALLOCATION_FAILED);
+  if (array == null) {
+    fprintf(stderr, "read: allocation failed\n");
+    FAIL(ALLOCATION_FAILED);
+  }
 
   ByteArray::Bytes bytes(array);
 
+  fprintf(stderr, "read: WaitForSingleObject in read\n");
   int result = WaitForSingleObject(read_resource->handle(), 0);  // Zero timeout.
   if (result == WAIT_TIMEOUT) {
     read_resource->not_ready();

--- a/src/resources/pipe_win.cc
+++ b/src/resources/pipe_win.cc
@@ -200,12 +200,9 @@ PRIMITIVE(create_pipe) {
   security_attributes.bInheritHandle = input;
   security_attributes.lpSecurityDescriptor = NULL;
 
-  int read_overlap_flag = input ? 0 : FILE_FLAG_OVERLAPPED;
-  int write_overlap_flag = input ? FILE_FLAG_OVERLAPPED : 0;
-
   HANDLE read = CreateNamedPipe(
       pipe_name_buffer,
-      PIPE_ACCESS_INBOUND | read_overlap_flag,
+      PIPE_ACCESS_INBOUND,
       PIPE_TYPE_BYTE | PIPE_WAIT,
       1,             // Number of pipes
       8192,          // Out buffer size
@@ -227,7 +224,7 @@ PRIMITIVE(create_pipe) {
       0,                         // No sharing
       &security_attributes,
       OPEN_EXISTING,
-      FILE_ATTRIBUTE_NORMAL | write_overlap_flag,
+      FILE_ATTRIBUTE_NORMAL,
       NULL                       // Template file
   );
 
@@ -268,8 +265,7 @@ PRIMITIVE(fd_to_pipe) {
 
   if (fd < 0 || fd > 2) FAIL(INVALID_ARGUMENT);
 
-  // Check if the standard handle has already been made a pipe. The overlapped
-  // IO does not support multiple clients.
+  // Check if the standard handle has already been made a pipe.
   if (resource_group->is_standard_piped(fd)) FAIL(INVALID_ARGUMENT);
 
   HANDLE event = CreateEvent(NULL, true, false, NULL);


### PR DESCRIPTION
When creating pipes for subprocesses, do not create the end that is for the subprocess in overlapped mode. This is a non- blocking mode that confuses non-Toit subprocesses.