### PR TITLE
Don't allow mutations of final fields.

### DIFF
--- a/src/compiler/resolver_method.h
+++ b/src/compiler/resolver_method.h
@@ -70,6 +70,7 @@ class MethodResolver : public ast::Visitor {
       , scope_(scope)
       , resolution_mode_(STATIC)
       , super_forcing_expression_(null)
+      , block_may_mutate_final_(true)
       , current_lambda_(null)
       , loop_status_(NO_LOOP)
       , loop_block_depth_(0) {}
@@ -108,6 +109,21 @@ class MethodResolver : public ast::Visitor {
   ResolutionMode resolution_mode_;
   // The expression that forced to switch the constructor to instance mode.
   ast::Expression* super_forcing_expression_;
+  /// Whether the current block is allowed to mutate a final field, assuming
+  ///   we are in the static part of a constructor.
+  /// Specifically, we do allow:
+  ///     class A:
+  ///       field_x/int
+  ///       constructor:
+  ///         [1].do: field_x = it
+  ///
+  /// However, we don't allow:
+  ///     constructor:
+  ///        b := : field_x = 499
+  ///        x = 42
+  ///        super
+  ///        b.call
+  bool block_may_mutate_final_;
   ast::Node* current_lambda_;
   LoopStatus loop_status_;
   int loop_block_depth_;
@@ -265,6 +281,7 @@ class MethodResolver : public ast::Visitor {
                          Symbol label);
   ir::Code* _create_block(ast::Block* node,
                           bool has_implicit_it_parameter,
+                          bool may_mutate_final,
                           Symbol label);
   ir::Expression* _create_lambda(ast::Lambda* node,
                                  Symbol label);

--- a/tests/field2-test.toit
+++ b/tests/field2-test.toit
@@ -12,9 +12,6 @@ side x: side-sum += x
 call-block should-call/bool [block]:
   if should-call: block.call
 
-call-lambda should-call/bool fun/Lambda:
-  if should-call: fun.call
-
 class A:
   field / any
 
@@ -63,11 +60,9 @@ class A:
     (if true: field = arg else: field = arg) and field++
 
   constructor.return-local:
-    field = 497
+    field = 498
     call-block true:
       continue.call-block field++
-    call-lambda true::
-      continue.call-lambda field++
 
 main:
   expect-equals 42 (A 42).field

--- a/tests/negative/final-field4-test.toit
+++ b/tests/negative/final-field4-test.toit
@@ -1,0 +1,30 @@
+// Copyright (C) 2020 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+// TEST_FLAGS: --force
+
+call-lambda lambda/Lambda:
+  lambda.call 499
+
+call-block [block]:
+  block.call 499
+
+class A:
+  field/int
+  constructor:
+    field = 499
+    // We don't allow assignments to final fields in lambdas, as they
+    // can survive the static part of a constructor.
+    call-lambda:: field = it
+
+  constructor.block-ok:
+    field = 499
+    call-block: field = it
+
+  constructor.block-bad:
+    field = 499
+    block := (: field = it)
+    call-block block
+
+main:
+  a := A

--- a/tests/negative/gold/final-field4-test.gold
+++ b/tests/negative/gold/final-field4-test.gold
@@ -1,0 +1,7 @@
+tests/negative/final-field4-test.toit:18:19: error: Final field 'field' cannot be assigned
+    call-lambda:: field = it
+                  ^~~~~
+tests/negative/final-field4-test.toit:26:17: error: Final field 'field' cannot be assigned
+    block := (: field = it)
+                ^~~~~
+Compilation failed.

--- a/tests/negative/gold/uninitialized-field-test.gold
+++ b/tests/negative/gold/uninitialized-field-test.gold
@@ -1,6 +1,9 @@
 tests/negative/uninitialized-field-test.toit:69:3: error: Unresolved identifier: 'unresolved'
   unresolved
   ^~~~~~~~~~
+tests/negative/uninitialized-field-test.toit:44:7: error: Final field 'field' cannot be assigned
+      field = 42
+      ^~~~~
 tests/negative/uninitialized-field-test.toit:13:3: error: Field 'field' must be initialized in a constructor
   field / any
   ^~~~~


### PR DESCRIPTION
Once the 'super' has been called we must not allow changes to final fields.

Fixes https://github.com/toitware/toit/issues/4178