### PR TITLE
Fix Windows pipes

### DIFF
--- a/src/event_sources/epoll_linux.cc
+++ b/src/event_sources/epoll_linux.cc
@@ -151,8 +151,7 @@ void EpollEventSource::entry() {
                 if (epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, id, null) == -1) {
                   FATAL("failed to remove 0x%lx from epoll: %d", id, errno);
                 }
-                // Don't close STD pipes.
-                if (id > 2) close(id);
+                close(id);
               }
               break;
           }

--- a/src/primitive_file_win.cc
+++ b/src/primitive_file_win.cc
@@ -506,14 +506,16 @@ PRIMITIVE(mkdtemp) {
 
 PRIMITIVE(is_open_file) {
   ARGS(int, fd);
-  int result = lseek(fd, 0, SEEK_CUR);
-  if (result < 0) {
-    if (errno == ESPIPE || errno == EINVAL || errno == EBADF) {
-      return process->false_object();
-    }
-    FAIL(ERROR);
+  HANDLE handle = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
+  if (handle == INVALID_HANDLE_VALUE) WINDOWS_ERROR;
+  int type = GetFileType(handle);
+  if (type == FILE_TYPE_DISK) {
+    return process->true_object();
+  } else if (type == FILE_TYPE_PIPE || type == FILE_TYPE_CHAR) {
+    return process->false_object();
+  } else {
+    FAIL(INVALID_ARGUMENT);
   }
-  return process->true_object();
 }
 
 PRIMITIVE(realpath) {

--- a/src/resources/pipe_win.cc
+++ b/src/resources/pipe_win.cc
@@ -47,12 +47,12 @@ class PipeResourceGroup : public ResourceGroup {
 
   bool is_standard_piped(int fd) const {
     if (!(0 <= fd && fd <= 2)) return false;
-    return (standard_pipes_ & ( 1 << fd)) != 0;
+    return (standard_pipes_ & (1 << fd)) != 0;
   }
 
   void set_standard_piped(int fd) {
     if (0 <= fd && fd <= 2) {
-      standard_pipes_ |= ( 1 << fd);
+      standard_pipes_ |= (1 << fd);
     }
   }
   volatile long& pipe_serial_number() { return pipe_serial_number_; }
@@ -313,7 +313,7 @@ class CopyPipeState {
 };
 
 static DWORD copy_pipe_thread(void* data) {
-  auto state = reinterpret_cast<CopyPipeState*>(data)->copy_loop();
+  auto state = reinterpret_cast<CopyPipeState*>(data);
   DWORD result = state->copy_loop();
   delete state;
   return result;
@@ -402,7 +402,7 @@ PRIMITIVE(fd_to_pipe) {
   CopyPipeState* state = for_writing
       ? _new CopyPipeState(read, handle)
       : _new CopyPipeState(handle, write);
-  ASSERT(state);  // Can't fail on Windows.
+  ASSERT(state);  // Can't fail on host platforms.
   HANDLE thread = CreateThread(NULL, 0, copy_pipe_thread, state, 0, NULL);
   if (thread == NULL) {
     close_handle_keep_errno(event);
@@ -417,7 +417,7 @@ PRIMITIVE(fd_to_pipe) {
     pipe_resource = _new ReadPipeResource(resource_group, read, event);
   }
 
-  ASSERT(pipe_resource);  // Can't fail on Windows.
+  ASSERT(pipe_resource);  // Can't fail on host platforms.
 
   resource_group->set_standard_piped(fd);
 


### PR DESCRIPTION
Fix non-blocking on stdio on Windows.

We can't rely on the standard fds being in non-blocking mode on Windows,
so we use a dedicated thread for each of them.