### PR TITLE
Fix failure to recognize an allocation failure.

### DIFF
--- a/src/objects.h
+++ b/src/objects.h
@@ -83,10 +83,10 @@ class Object {
   bool byte_content(Program* program, Blob* blob, BlobKind strings_only);
 
   // Primitive support that sets content and length iff receiver is a ByteArray.
-  // Returns whether the content and length are set.
-  // The content can be set to `null` in which case the 'error' indicates the
-  // reason. Most likely the function tried to allocate a ByteArray (for making a
-  // CowByteArray mutable), but failed due to out-of-memory.
+  // Returns whether the content and length are set.  If it returns false, the
+  // 'error' indicates the reason.  Most likely this is either a type error or
+  // the function tried to allocate a ByteArray (for making a CowByteArray
+  // mutable), but failed due to out-of-memory.
   bool mutable_byte_content(Process* process, uint8** content, int* length, Error** error);
 
   // Same as above, but with a blob.

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -947,8 +947,7 @@ Object* get_absolute_path(Process* process, const wchar_t* pathname, wchar_t* ou
   Object* _raw_##name = __args[-(N)];                                        \
   MutableBlob name;                                                          \
   Error* _mutable_blob_error_##name;                                         \
-  if (!_raw_##name->mutable_byte_content(process, &name, &_mutable_blob_error_##name)) FAIL(WRONG_OBJECT_TYPE); \
-  if (name.address() == null) return _mutable_blob_error_##name;
+  if (!_raw_##name->mutable_byte_content(process, &name, &_mutable_blob_error_##name)) return _mutable_blob_error_##name;
 
 #define MAKE_UNPACKING_MACRO(Type, N, name)                      \
   __ARG__(N, name##_proxy, ByteArray, is_byte_array)             \


### PR DESCRIPTION
When we were converting a COW byte array to a writable byte array in a primitive we didn't notice a heap full error correctly.