### PR TITLE
Don't run the automated tests on work-in-progress branches.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - "*"
       - "*/*"
+    branches-ignore:
+      - "wip/**"
+      - "wip-**"
+      - "*/wip-**"
+      - "*/wip/**"
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - "*"
-      - "*/*"
     branches-ignore:
       - "wip/**"
       - "wip-**"


### PR DESCRIPTION
Sometimes I push to github just to be able to continue work in another location. I don't necessarily want the CI tests to run, and often I know they will fail.

With this change, the CI doesn't run for git branches named:

erik/wip/foo
erik/wip-foo
wip-foo
wip/foo