### PR TITLE
Improve OOM message to include UUID of processes.

### DIFF
--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -105,7 +105,7 @@ void Interpreter::prepare_task(Method entry, Instance* code) {
 Object** Interpreter::gc(Object** sp, bool malloc_failed, int attempts, bool force_cross_process) {
   ASSERT(attempts >= 1 && attempts <= 3);  // Allocation attempts.
   if (attempts == 3) {
-    OS::heap_summary_report(0, "out of memory");
+    OS::heap_summary_report(0, "out of memory", process_);
     if (VM::current()->scheduler()->is_boot_process(process_)) {
       OS::out_of_memory("Out of memory in system process");
     }

--- a/src/os.h
+++ b/src/os.h
@@ -240,7 +240,7 @@ class OS {
   // the origin of allocations on the current thread.
   static void set_heap_tag(word tag);
   static word get_heap_tag();
-  static void heap_summary_report(int max_pages, const char* marker);
+  static void heap_summary_report(int max_pages, const char* marker, Process* process);
 
   // Returns a malloced string.
   static char* getenv(const char* variable);

--- a/src/os_darwin.cc
+++ b/src/os_darwin.cc
@@ -124,7 +124,6 @@ int OS::read_entire_file(char* name, uint8** buffer) {
 
 void OS::set_heap_tag(word tag) {}
 word OS::get_heap_tag() { return 0; }
-void OS::heap_summary_report(int max_pages, const char* marker) {}
 
 }
 

--- a/src/os_esp32.cc
+++ b/src/os_esp32.cc
@@ -736,11 +736,17 @@ class HeapSummaryCollector {
 
     int size = 0;
     int count = 0;
+    uword metadata_location, metadata_size;
+    GcMetadata::get_metadata_extent(&metadata_location, &metadata_size);
     for (int i = 0; i < NUMBER_OF_MALLOC_TAGS; i++) {
       // Leave out free space and allocation types with no allocations.
       if (i == FREE_MALLOC_TAG || sizes_[i] == 0) continue;
+      auto this_size = sizes_[i];
+      if (i == TOIT_HEAP_MALLOC_TAG) {
+        this_size -= TOIT_PAGE_SIZE + metadata_size;
+      }
       printf("  │ %7d   │ %6d   │  %-50s │\n",
-          sizes_[i], counts_[i], HeapSummaryPage::name_of_type(i));
+          this_size, counts_[i], HeapSummaryPage::name_of_type(i));
       size += sizes_[i];
       // The reported overhead isn't really separate allocations, so
       // don't count them as such.
@@ -769,8 +775,6 @@ class HeapSummaryCollector {
                 uuid_buffer);
           }
         }
-        uword metadata_location, metadata_size;
-        GcMetadata::get_metadata_extent(&metadata_location, &metadata_size);
         printf("  │ %7d   │      1   │  heap metadata                                      │\n"
                "  │ %7d   │      1   │  spare new-space                                    │\n",
                static_cast<int>(metadata_size),

--- a/src/os_esp32.cc
+++ b/src/os_esp32.cc
@@ -619,7 +619,7 @@ class HeapSummaryPage {
       case EXTERNAL_BYTE_ARRAY_MALLOC_TAG: return "external byte array";
       case BIGNUM_MALLOC_TAG: return "tls/bignum";
       case EXTERNAL_STRING_MALLOC_TAG: return "external string";
-      case TOIT_HEAP_MALLOC_TAG: return "toit";
+      case TOIT_HEAP_MALLOC_TAG: return "toit processes";
       case FREE_MALLOC_TAG: return "free";
       case LWIP_MALLOC_TAG: return "lwip";
       case HEAP_OVERHEAD_MALLOC_TAG: return "heap overhead";
@@ -764,15 +764,15 @@ class HeapSummaryCollector {
             printf("  │   %7d │   %6d │    %s%4d %s │\n",
                 static_cast<int>(toit_memory_[j]),
                 static_cast<int>(toit_memory_[j] / TOIT_PAGE_SIZE),
-                is_system ? "system " : is_current ? "current" : "process",
+                is_system ? "system " : is_current ? "current" : "other  ",
                 processes_[j]->id(),
                 uuid_buffer);
           }
         }
         uword metadata_location, metadata_size;
         GcMetadata::get_metadata_extent(&metadata_location, &metadata_size);
-        printf("  │   %7d │        1 │    GC heap metadata                                 │\n"
-               "  │   %7d │        1 │    Spare new-space                                  │\n",
+        printf("  │ %7d   │      1   │  heap metadata                                      │\n"
+               "  │ %7d   │      1   │  spare new-space                                    │\n",
                static_cast<int>(metadata_size),
                TOIT_PAGE_SIZE);
       }

--- a/src/os_linux.cc
+++ b/src/os_linux.cc
@@ -143,8 +143,6 @@ word OS::get_heap_tag() { return 0; }
 
 #endif // def TOIT_CMPCTMALLOC
 
-void OS::heap_summary_report(int max_pages, const char* marker) {}
-
 }
 
 #endif // TOIT_LINUX

--- a/src/os_posix.cc
+++ b/src/os_posix.cc
@@ -18,6 +18,8 @@
 #ifdef TOIT_POSIX
 
 #include "os.h"
+#include "process.h"
+#include "program.h"
 #include "utils.h"
 #include "uuid.h"
 #include "vm.h"
@@ -277,6 +279,17 @@ bool OS::unsetenv(const char* variable) {
 
 bool OS::set_real_time(struct timespec* time) {
   FATAL("cannot set the time");
+}
+
+void OS::heap_summary_report(int max_pages, const char* marker, Process* process) {
+  const uint8* uuid = process->program()->id();
+  fprintf(stderr, "Out of memory: %08x-%04x-%04x-%04x-%04x%08x.\n",
+      static_cast<int>(Utils::read_unaligned_uint32_be(uuid)),
+      static_cast<int>(Utils::read_unaligned_uint16_be(uuid + 4)),
+      static_cast<int>(Utils::read_unaligned_uint16_be(uuid + 6)),
+      static_cast<int>(Utils::read_unaligned_uint16_be(uuid + 8)),
+      static_cast<int>(Utils::read_unaligned_uint16_be(uuid + 10)),
+      static_cast<int>(Utils::read_unaligned_uint32_be(uuid + 12)));
 }
 
 ProtectableAlignedMemory::~ProtectableAlignedMemory() {

--- a/src/os_posix.cc
+++ b/src/os_posix.cc
@@ -283,7 +283,8 @@ bool OS::set_real_time(struct timespec* time) {
 
 void OS::heap_summary_report(int max_pages, const char* marker, Process* process) {
   const uint8* uuid = process->program()->id();
-  fprintf(stderr, "Out of memory: %08x-%04x-%04x-%04x-%04x%08x.\n",
+  fprintf(stderr, "Out of memory process %d: %08x-%04x-%04x-%04x-%04x%08x.\n",
+      process->id(),
       static_cast<int>(Utils::read_unaligned_uint32_be(uuid)),
       static_cast<int>(Utils::read_unaligned_uint16_be(uuid + 4)),
       static_cast<int>(Utils::read_unaligned_uint16_be(uuid + 6)),

--- a/src/os_win.cc
+++ b/src/os_win.cc
@@ -376,7 +376,8 @@ word OS::get_heap_tag() { return 0; }
 
 void OS::heap_summary_report(int max_pages, const char* marker, Process* process) {
   const uint8* uuid = process->program()->id();
-  fprintf(stderr, "Out of memory: %08x-%04x-%04x-%04x-%04x%08x.\n",
+  fprintf(stderr, "Out of memory in process %d: %08x-%04x-%04x-%04x-%04x%08x.\n",
+      process->id(),
       static_cast<int>(Utils::read_unaligned_uint32_be(uuid)),
       static_cast<int>(Utils::read_unaligned_uint16_be(uuid + 4)),
       static_cast<int>(Utils::read_unaligned_uint16_be(uuid + 6)),

--- a/src/os_win.cc
+++ b/src/os_win.cc
@@ -18,6 +18,8 @@
 #ifdef TOIT_WINDOWS
 
 #include "os.h"
+#include "process.h"
+#include "program.h"
 #include "utils.h"
 #include "uuid.h"
 #include "memory.h"
@@ -372,7 +374,16 @@ void OS::set_heap_tag(word tag) {}
 
 word OS::get_heap_tag() { return 0; }
 
-void OS::heap_summary_report(int max_pages, const char* marker) {}
+void OS::heap_summary_report(int max_pages, const char* marker, Process* process) {
+  const uint8* uuid = process->program()->id();
+  fprintf(stderr, "Out of memory: %08x-%04x-%04x-%04x-%04x%08x.\n",
+      static_cast<int>(Utils::read_unaligned_uint32_be(uuid)),
+      static_cast<int>(Utils::read_unaligned_uint16_be(uuid + 4)),
+      static_cast<int>(Utils::read_unaligned_uint16_be(uuid + 6)),
+      static_cast<int>(Utils::read_unaligned_uint16_be(uuid + 8)),
+      static_cast<int>(Utils::read_unaligned_uint16_be(uuid + 10)),
+      static_cast<int>(Utils::read_unaligned_uint32_be(uuid + 12)));
+}
 
 } // namespace toit
 

--- a/src/primitive_core.cc
+++ b/src/primitive_core.cc
@@ -2279,7 +2279,7 @@ PRIMITIVE(dump_heap) {
 PRIMITIVE(serial_print_heap_report) {
 #ifdef TOIT_CMPCTMALLOC
   ARGS(cstring, marker, int, max_pages);
-  OS::heap_summary_report(max_pages, marker);
+  OS::heap_summary_report(max_pages, marker, process);
 #endif // def TOIT_CMPCTMALLOC
   return process->null_object();
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -216,6 +216,12 @@ class Utils {
   }
 
   template<typename T>
+  static inline uint16 read_unaligned_uint16_be(T* ptr) {
+    uint16 le = read_unaligned_uint16(ptr);
+    return (le >> 8) | (le << 8);
+  }
+
+  template<typename T>
   static inline void write_unaligned_uint16(T* ptr, uint16 value) {
     memcpy(ptr, &value, sizeof(value));
   }
@@ -224,6 +230,12 @@ class Utils {
   template<typename T>
   static inline uint32 read_unaligned_uint32_le(T* ptr) {
     return read_unaligned_uint32(ptr);
+  }
+
+  template<typename T>
+  static inline uint32 read_unaligned_uint32_be(T* ptr) {
+    uint32 le = read_unaligned_uint32(ptr);
+    return (le >> 24) | ((le >> 8) & 0xff00) | ((le << 8) & 0xff0000) | (le << 24);
   }
 
   template<typename T>


### PR DESCRIPTION
```
  ┌───────────┬──────────┬─────────────────────────────────────────────────────┐
  │   Bytes   │  Count   │  Type                                               │
  ├───────────┼──────────┼─────────────────────────────────────────────────────┤
  │       8   │      1   │  external byte array                                │
  │  114688   │     25   │  toit                                               │
  │     16384 │        4 │    process   0 931fac5e-1437-8551-7113-3c52f9c9fc95 │
  │     12288 │        3 │    process   1 19754d90-0d08-1770-7ef0-c25f0bc5f9b9 │
  │     65536 │       16 │    process   2 8be11b04-6d16-e0a3-2da0-dd6d0927e6f3 │
  │     16384 │        1 │    GC heap metadata                                 │
  │      4096 │        1 │    Spare new-space                                  │
  │    6120   │     24   │  lwip                                               │
  │    7144   │    587   │  heap overhead                                      │
  │    1928   │     28   │  event source                                       │
  │    6632   │    168   │  thread/other                                       │
  │   26400   │     21   │  thread/spawn                                       │
  │   45800   │    218   │  untagged                                           │
  │   12304   │     60   │  wifi                                               │
  └───────────┴──────────┴─────────────────────────────────────────────────────┘
  Total: 221024 bytes in 545 allocations (91%), largest free 3k, total free 21k
```