### PR TITLE
Warn if 'if' and 'else' are not at same indentation.

### DIFF
--- a/tests/health/gold/sdk/tests__indentation-test.toit.gold
+++ b/tests/health/gold/sdk/tests__indentation-test.toit.gold
@@ -1,0 +1,6 @@
+tests/indentation-test.toit:50:9: warning: Unexpected indentation: 'if' and 'else' not at same level
+        else:  // Else can be at any level. Does not require the next line to be indented more.
+        ^~~~
+tests/indentation-test.toit:57:9: warning: Unexpected indentation: 'if' and 'else' not at same level
+        else if true:
+        ^~~~

--- a/tests/negative/gold/if3-test.gold
+++ b/tests/negative/gold/if3-test.gold
@@ -1,0 +1,10 @@
+tests/negative/if3-test.toit:10:5: warning: Unexpected indentation: 'if' and 'else' not at same level
+    else:
+    ^~~~
+tests/negative/if3-test.toit:11:7: error: Unresolved identifier: 'unresolved'
+      unresolved
+      ^~~~~~~~~~
+tests/negative/if3-test.toit:18:11: error: Unresolved identifier: 'unresolved'
+          unresolved
+          ^~~~~~~~~~
+Compilation failed.

--- a/tests/negative/gold/indent3-test.gold
+++ b/tests/negative/gold/indent3-test.gold
@@ -1,3 +1,6 @@
+tests/negative/indent3-test.toit:8:8: warning: Unexpected indentation: 'if' and 'else' not at same level
+       else if true:
+       ^~~~
 tests/negative/indent3-test.toit:9:5: error: All expressions in a sequence must be indented the same way
     "bad indent"
     ^~~~~~~~~~~~

--- a/tests/negative/if3-test.toit
+++ b/tests/negative/if3-test.toit
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+toto [block]:
+
+main:
+  if true:
+      print "something"
+    else:
+      unresolved
+
+
+  toto: if true:
+        print "something"
+      // No warning here, though.
+      else:
+          unresolved


### PR DESCRIPTION
Fixes #1967.