### PR TITLE
Allow ':' of a method/declaration to be at detent level.

### DIFF
--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -948,6 +948,7 @@ Declaration* Parser::parse_declaration(bool is_abstract) {
     if (peek_token() == Token::COLON &&
         indentation_stack_.top_indentation() == current_indentation() &&
         indentation_stack_.is_outmost(IndentationStack::DECLARATION_SIGNATURE)) {
+      // Consume the detent.
       consume();
     }
   }
@@ -1591,6 +1592,7 @@ Expression* Parser::parse_if() {
     if (peek_token() == Token::ELSE &&
         indentation_stack_.top_indentation() == current_indentation() &&
         indentation_stack_.is_outmost(IndentationStack::IF_BODY)) {
+      // Consume the detent.
       consume();
     }
   }

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -937,6 +937,20 @@ Declaration* Parser::parse_declaration(bool is_abstract) {
   }
   auto parameters = return_type_parameters.second;
 
+  // Allow colons to be at the same level as the declaring method.
+  // Something like:
+  //   foo
+  //       param1
+  //       param2
+  //   :
+  //     body
+  if (current_token() == Token::DEDENT) {
+    if (peek_token() == Token::COLON &&
+        indentation_stack_.top_indentation() == current_indentation() &&
+        indentation_stack_.is_outmost(IndentationStack::DECLARATION_SIGNATURE)) {
+      consume();
+    }
+  }
   Sequence* body;
   if (current_token() == Token::COLON) {
     consume();

--- a/tests/declaration-test.toit
+++ b/tests/declaration-test.toit
@@ -1,0 +1,22 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+
+foo
+    x
+:
+  return x
+
+class A:
+  method
+      y
+  :
+    return y
+
+main:
+  // This is a syntax test, so not really testing anything complicated
+  // with respect to the dynamic execution.
+  expect-equals 499 (foo 499)
+  expect-equals 499 ((A).method 499)

--- a/tests/negative/gold/missing-name-test.gold
+++ b/tests/negative/gold/missing-name-test.gold
@@ -4,9 +4,6 @@ tests/negative/missing-name-test.toit:5:1: error: Invalid name for declaration
 tests/negative/missing-name-test.toit:6:3: warning: Unusual indentation for parameter
   unresolved
   ^~~~~~~~~~
-tests/negative/missing-name-test.toit:8:1: error: Expected name of declaration
-:
-^
 tests/negative/missing-name-test.toit:11:1: error: Invalid name for declaration
 (499 + 33 + unresolved)
 ^
@@ -19,9 +16,6 @@ tests/negative/missing-name-test.toit:14:3: error: Invalid name for declaration
 tests/negative/missing-name-test.toit:15:5: warning: Unusual indentation for parameter
     unresolved
     ^~~~~~~~~~
-tests/negative/missing-name-test.toit:17:3: error: Expected name of declaration
-  :
-  ^
 tests/negative/missing-name-test.toit:20:3: error: Invalid name for declaration
   (499 + 33 + unresolved)
   ^
@@ -40,15 +34,9 @@ tests/negative/missing-name-test.toit:24:11: error: Expected name of declaration
 tests/negative/missing-name-test.toit:26:9: error: Expected name of declaration
   static    /* comment
         ^
-tests/negative/missing-name-test.toit:5:1: error: Missing body
-4
-^
 tests/negative/missing-name-test.toit:11:1: error: Missing body
 (499 + 33 + unresolved)
 ^
-tests/negative/missing-name-test.toit:14:3: error: Missing body
-  4
-  ^
 tests/negative/missing-name-test.toit:20:3: error: Missing body
   (499 + 33 + unresolved)
   ^
@@ -64,9 +52,6 @@ tests/negative/missing-name-test.toit:24:11: error: Members can't be abstract in
 tests/negative/missing-name-test.toit:26:9: error: Missing body
   static    /* comment
         ^
-tests/negative/missing-name-test.toit:9:3: error: Unresolved identifier: 'unresolved'
-  unresolved
-  ^~~~~~~~~~
 tests/negative/missing-name-test.toit:30:3: error: Unresolved identifier: 'unresolved'
   unresolved
   ^~~~~~~~~~
@@ -77,7 +62,4 @@ tests/negative/missing-name-test.toit:31:8: error: Argument mismatch for 'A'
 Method does not take any arguments, but one was provided
   a := A unresolved
        ^
-tests/negative/missing-name-test.toit:18:5: error: Unresolved identifier: 'unresolved'
-    unresolved
-    ^~~~~~~~~~
 Compilation failed.

--- a/tests/syntax-test.toit
+++ b/tests/syntax-test.toit
@@ -151,6 +151,15 @@ global-setter= x:
 global-setter2= x -> none:
   42
 
+fun
+    --some
+    --args
+    on
+    multiple
+    lines
+:
+  print "with colon at same level as 'fun'"
+
 abstract class Type:
   foo := 499
   constructor:


### PR DESCRIPTION
This allows us to write something like:
```
foo
    foo
    bar
    --my-named-argument
    --other-argument
    [and-a-block]
:
  body
```