### PR TITLE
Give project-uri to compiler actions.

### DIFF
--- a/tests/lsp/repro-compiler-test-slow.toit
+++ b/tests/lsp/repro-compiler-test-slow.toit
@@ -72,17 +72,17 @@ create-archive path toitc -> string:
   protocol := FileServerProtocol documents repro-filesystem uri-translator
   compiler := Compiler toitc uri-translator timeout-ms
       --protocol=protocol
-      --project-uri=uri-translator.to-uri directory.cwd
 
   compiler-input := create-compiler-input --path=untitled-path
 
   suggestions := null
-  compiler.run --compiler-input=compiler-input:
+  compiler.run --compiler-input=compiler-input
+      --project-uri=uri-translator.to-uri directory.cwd:
     check-compiler-output it
 
   write-repro
       --repro-path=path
-      --compiler-flags=compiler.build-run-flags
+      --compiler-flags=compiler.build-run-flags --project-uri=(uri-translator.to-uri directory.cwd)
       --compiler-input=compiler-input
       --info="Test"
       --protocol=protocol

--- a/tools/lsp/server/compiler.toit
+++ b/tools/lsp/server/compiler.toit
@@ -44,32 +44,29 @@ class Compiler:
   on-error_            /Lambda?     ::= ?
   timeout-ms_          /int         ::= ?
   protocol             /FileServerProtocol ::= ?
-  project-uri_         /string?     ::= ?
 
   constructor
       .compiler-path_
       .uri-path-translator_
       .timeout-ms_
       --.protocol
-      --project-uri/string?
       --on-error/Lambda?=null
       --on-crash/Lambda?=null:
     on-crash_ = on-crash
     on-error_ = on-error
-    project-uri_ = project-uri
 
   /**
   Builds the flags that are passed to the compiler.
   */
-  build-run-flags -> List:
+  build-run-flags --project-uri/string -> List:
     args := [
       "--lsp",
     ]
-    if project-uri_:
-      project-path-local := uri-path-translator_.to-path project-uri_
+    if project-uri:
+      project-path-local := uri-path-translator_.to-path project-uri
       package-lock := "$project-path-local/package.lock"
       if file.is-file package-lock:
-        project-path-compiler := uri-path-translator_.to-path project-uri_ --to-compiler
+        project-path-compiler := uri-path-translator_.to-path project-uri --to-compiler
         args += ["--project-root", project-path-compiler]
     return args
 
@@ -79,8 +76,8 @@ class Compiler:
   Returns whether the call was successful.
   If there was a crash, invokes the stored `on_crash` handler, and returns false.
   */
-  run --ignore-crashes/bool=false --compiler-input/string [read-callback] -> bool:
-    flags := build-run-flags
+  run --project-uri/string? --ignore-crashes/bool=false --compiler-input/string [read-callback] -> bool:
+    flags := build-run-flags --project-uri=project-uri
 
     cpp-pipes := pipe.fork
         true                // use_path
@@ -138,7 +135,7 @@ class Compiler:
           did-crash = true
     return not did-crash
 
-  analyze uris/List -> AnalysisResult?:
+  analyze --project-uri/string? uris/List -> AnalysisResult?:
     // Work around small stack size.
     // TODO(1268): remove work-around
     latch := monitor.Latch
@@ -153,7 +150,7 @@ class Compiler:
 
       verbose: "Calling compiler analysis with $paths"
       compiler-input := "ANALYZE\n$(paths.size)\n$(paths.join "\n")\n"
-      completed-successfully := run --compiler-input=compiler-input:
+      completed-successfully := run --project-uri=project-uri --compiler-input=compiler-input:
         |reader /BufferedReader|
 
         summary := null
@@ -242,11 +239,12 @@ class Compiler:
       latch.set (completed-successfully ? result : null)
     return latch.get
 
-  complete uri/string line-number/int column-number/int -> List/*<string>*/:
+  complete --project-uri/string? uri/string line-number/int column-number/int -> List/*<string>*/:
     path := uri-path-translator_.to-path uri --to-compiler
     // We don't care if the compiler crashed.
     // Just send whatever completions we get.
-    run --compiler-input="COMPLETE\n$path\n$line-number\n$column-number\n":
+    run --project-uri=project-uri
+        --compiler-input="COMPLETE\n$path\n$line-number\n$column-number\n":
       |reader /BufferedReader|
       suggestions := []
 
@@ -258,11 +256,12 @@ class Compiler:
       return suggestions
     unreachable
 
-  goto-definition uri/string line-number/int column-number/int -> List/*<Location>*/:
+  goto-definition --project-uri/string? uri/string line-number/int column-number/int -> List/*<Location>*/:
     path := uri-path-translator_.to-path uri --to-compiler
     // We don't care if the compiler crashed.
     // Just send the definitions we got.
-    run --compiler-input="GOTO DEFINITION\n$path\n$line-number\n$column-number\n":
+    run --project-uri=project-uri
+        --compiler-input="GOTO DEFINITION\n$path\n$line-number\n$column-number\n":
       |reader /BufferedReader|
       definitions := []
 
@@ -277,18 +276,21 @@ class Compiler:
       return definitions
     unreachable
 
-  parse --paths/List/*<string>*/ -> bool:
+  parse --project-uri/string? --paths/List/*<string>*/ -> bool:
     // Parse all files and fill the fileserver.
-    return run --compiler-input="PARSE\n$paths.size\n$(paths.join "\n")\n":
+    return run
+        --project-uri=project-uri
+        --compiler-input="PARSE\n$paths.size\n$(paths.join "\n")\n":
       |reader /BufferedReader|
       while true:
         // Just drain the reader.
         data := reader.read
         if not data: break
 
-  snapshot-bundle uri/string -> ByteArray?:
+  snapshot-bundle --project-uri/string? uri/string -> ByteArray?:
     path := uri-path-translator_.to-path uri --to-compiler
-    run --compiler-input="SNAPSHOT BUNDLE\n$path\n":
+    run --project-uri=project-uri
+        --compiler-input="SNAPSHOT BUNDLE\n$path\n":
       |reader /BufferedReader|
       status := reader.read-line
       if status != "OK": return null
@@ -316,9 +318,10 @@ class Compiler:
     "defaultLibrary",
   ]
 
-  semantic-tokens uri/string -> List:
+  semantic-tokens --project-uri/string? uri/string -> List:
     path := uri-path-translator_.to-path uri --to-compiler
-    run --compiler-input="SEMANTIC TOKENS\n$path\n":
+    run --project-uri=project-uri
+        --compiler-input="SEMANTIC TOKENS\n$path\n":
       |reader /BufferedReader|
       element-count := int.parse reader.read-line
       result := List element-count: int.parse reader.read-line

--- a/tools/lsp/server/compiler.toit
+++ b/tools/lsp/server/compiler.toit
@@ -58,7 +58,7 @@ class Compiler:
   /**
   Builds the flags that are passed to the compiler.
   */
-  build-run-flags --project-uri/string -> List:
+  build-run-flags --project-uri/string? -> List:
     args := [
       "--lsp",
     ]

--- a/tools/lsp/server/repro.toit
+++ b/tools/lsp/server/repro.toit
@@ -146,13 +146,12 @@ create-archive project-uri/string? compiler-path/string entry-path/string out-pa
   protocol := FileServerProtocol.local compiler-path sdk-path documents translator
   compiler := Compiler compiler-path translator DEFAULT-TIMEOUT-MS
       --protocol=protocol
-      --project-uri=project-uri
   entry-uri := translator.to-uri entry-path
-  compiler.analyze [entry-uri]
+  compiler.analyze [entry-uri] --project-uri=project-uri
 
   write-repro
       --repro-path=out-path
-      --compiler-flags=compiler.build-run-flags
+      --compiler-flags=compiler.build-run-flags --project-uri=project-uri
       --compiler-input="ANALYZE\n1\n$entry-path\n"
       --info="from repro tool"
       --protocol=protocol

--- a/tools/toitlsp/lsp/compiler/compiler.go
+++ b/tools/toitlsp/lsp/compiler/compiler.go
@@ -118,7 +118,7 @@ func (c *Compiler) ctx(ctx context.Context) (context.Context, context.CancelFunc
 	return context.WithCancel(ctx)
 }
 
-func (c *Compiler) Analyze(ctx context.Context, uris ...lsp.DocumentURI) (*AnalyzeResult, error) {
+func (c *Compiler) Analyze(ctx context.Context, projectURI lsp.DocumentURI, uris ...lsp.DocumentURI) (*AnalyzeResult, error) {
 	ctx, cancel := c.ctx(ctx)
 	defer cancel()
 
@@ -132,9 +132,11 @@ func (c *Compiler) Analyze(ctx context.Context, uris ...lsp.DocumentURI) (*Analy
 		result *AnalyzeResult
 	}
 
-	err := c.run(ctx, fmt.Sprintf("ANALYZE\n%d\n%s\n", len(paths), strings.Join(paths, "\n")), func(ctx context.Context, stdout io.Reader) {
-		res.result, res.err = c.parser.AnalyzeOutput(stdout)
-	})
+	err := c.run(ctx,
+		projectURI,
+		fmt.Sprintf("ANALYZE\n%d\n%s\n", len(paths), strings.Join(paths, "\n")), func(ctx context.Context, stdout io.Reader) {
+			res.result, res.err = c.parser.AnalyzeOutput(stdout)
+		})
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +144,7 @@ func (c *Compiler) Analyze(ctx context.Context, uris ...lsp.DocumentURI) (*Analy
 	return res.result, res.err
 }
 
-func (c *Compiler) GotoDefinition(ctx context.Context, docURI lsp.DocumentURI, position lsp.Position) ([]lsp.Location, error) {
+func (c *Compiler) GotoDefinition(ctx context.Context, projectURI lsp.DocumentURI, docURI lsp.DocumentURI, position lsp.Position) ([]lsp.Location, error) {
 	ctx, cancel := c.ctx(ctx)
 	defer cancel()
 
@@ -153,9 +155,11 @@ func (c *Compiler) GotoDefinition(ctx context.Context, docURI lsp.DocumentURI, p
 		result []lsp.Location
 	}
 
-	err := c.run(ctx, fmt.Sprintf("GOTO DEFINITION\n%s\n%d\n%d\n", path, position.Line, position.Character), func(ctx context.Context, stdout io.Reader) {
-		res.result, res.err = c.parser.GotoDefinitionOutput(stdout)
-	})
+	err := c.run(ctx,
+		projectURI,
+		fmt.Sprintf("GOTO DEFINITION\n%s\n%d\n%d\n", path, position.Line, position.Character), func(ctx context.Context, stdout io.Reader) {
+			res.result, res.err = c.parser.GotoDefinitionOutput(stdout)
+		})
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +167,7 @@ func (c *Compiler) GotoDefinition(ctx context.Context, docURI lsp.DocumentURI, p
 	return res.result, res.err
 }
 
-func (c *Compiler) Complete(ctx context.Context, docURI lsp.DocumentURI, position lsp.Position) ([]lsp.CompletionItem, error) {
+func (c *Compiler) Complete(ctx context.Context, projectURI lsp.DocumentURI, docURI lsp.DocumentURI, position lsp.Position) ([]lsp.CompletionItem, error) {
 	ctx, cancel := c.ctx(ctx)
 	defer cancel()
 
@@ -174,7 +178,7 @@ func (c *Compiler) Complete(ctx context.Context, docURI lsp.DocumentURI, positio
 		result []lsp.CompletionItem
 	}
 
-	err := c.run(ctx, fmt.Sprintf("COMPLETE\n%s\n%d\n%d\n", path, position.Line, position.Character), func(ctx context.Context, stdout io.Reader) {
+	err := c.run(ctx, projectURI, fmt.Sprintf("COMPLETE\n%s\n%d\n%d\n", path, position.Line, position.Character), func(ctx context.Context, stdout io.Reader) {
 		res.result, res.err = c.parser.CompleteOutput(stdout)
 	})
 	if err != nil {
@@ -184,7 +188,7 @@ func (c *Compiler) Complete(ctx context.Context, docURI lsp.DocumentURI, positio
 	return res.result, res.err
 }
 
-func (c *Compiler) SemanticTokens(ctx context.Context, docURI lsp.DocumentURI) (*lsp.SemanticTokens, error) {
+func (c *Compiler) SemanticTokens(ctx context.Context, projectURI lsp.DocumentURI, docURI lsp.DocumentURI) (*lsp.SemanticTokens, error) {
 	ctx, cancel := c.ctx(ctx)
 	defer cancel()
 
@@ -195,7 +199,7 @@ func (c *Compiler) SemanticTokens(ctx context.Context, docURI lsp.DocumentURI) (
 		result []uint
 	}
 
-	err := c.run(ctx, fmt.Sprintf("SEMANTIC TOKENS\n%s\n", path), func(ctx context.Context, stdout io.Reader) {
+	err := c.run(ctx, projectURI, fmt.Sprintf("SEMANTIC TOKENS\n%s\n", path), func(ctx context.Context, stdout io.Reader) {
 		res.result, res.err = c.parser.SemanticTokensOutput(stdout)
 	})
 	if err != nil {
@@ -211,7 +215,7 @@ func (c *Compiler) SemanticTokens(ctx context.Context, docURI lsp.DocumentURI) (
 	}, nil
 }
 
-func (c *Compiler) Parse(ctx context.Context, uris ...lsp.DocumentURI) error {
+func (c *Compiler) Parse(ctx context.Context, projectURI lsp.DocumentURI, uris ...lsp.DocumentURI) error {
 	ctx, cancel := c.ctx(ctx)
 	defer cancel()
 
@@ -221,9 +225,11 @@ func (c *Compiler) Parse(ctx context.Context, uris ...lsp.DocumentURI) error {
 	}
 
 	var resErr error
-	err := c.run(ctx, fmt.Sprintf("PARSE\n%d\n%s\n", len(paths), strings.Join(paths, "\n")), func(ctx context.Context, stdout io.Reader) {
-		_, resErr = ioutil.ReadAll(stdout)
-	})
+	err := c.run(ctx,
+		projectURI,
+		fmt.Sprintf("PARSE\n%d\n%s\n", len(paths), strings.Join(paths, "\n")), func(ctx context.Context, stdout io.Reader) {
+			_, resErr = ioutil.ReadAll(stdout)
+		})
 	if err != nil {
 		return err
 	}
@@ -231,7 +237,7 @@ func (c *Compiler) Parse(ctx context.Context, uris ...lsp.DocumentURI) error {
 	return resErr
 }
 
-func (c *Compiler) SnapshotBundle(ctx context.Context, docUri lsp.DocumentURI) ([]byte, error) {
+func (c *Compiler) SnapshotBundle(ctx context.Context, projectURI lsp.DocumentURI, docUri lsp.DocumentURI) ([]byte, error) {
 	ctx, cancel := c.ctx(ctx)
 	defer cancel()
 
@@ -241,9 +247,11 @@ func (c *Compiler) SnapshotBundle(ctx context.Context, docUri lsp.DocumentURI) (
 		res []byte
 		err error
 	}
-	err := c.run(ctx, fmt.Sprintf("SNAPSHOT BUNDLE\n%s\n", path), func(ctx context.Context, stdout io.Reader) {
-		res.res, res.err = c.parser.SnapshotBundleOutput(stdout)
-	})
+	err := c.run(ctx,
+		projectURI,
+		fmt.Sprintf("SNAPSHOT BUNDLE\n%s\n", path), func(ctx context.Context, stdout io.Reader) {
+			res.res, res.err = c.parser.SnapshotBundleOutput(stdout)
+		})
 	if err != nil {
 		return nil, err
 	}
@@ -302,14 +310,14 @@ func (w *logWriter) Write(b []byte) (n int, err error) {
 
 type parserFn func(context.Context, io.Reader)
 
-func (c *Compiler) run(ctx context.Context, input string, parserFunc parserFn) error {
+func (c *Compiler) run(ctx context.Context, projectURI lsp.DocumentURI, input string, parserFunc parserFn) error {
 	multi := newMultiplexConn(c.logger)
 	fileServer := NewPipeFileServer(c.fs, c.logger, c.settings.SDKPath)
 	c.fs_protocol = fileServer.Protocol()
 	go fileServer.Run(multi.CompilerToFS.r, multi.FSToCompiler.w)
 	defer fileServer.Stop()
 
-	cmd := c.cmd(ctx, input, fileServer)
+	cmd := c.cmd(ctx, projectURI, input, fileServer)
 	input = fmt.Sprintf("%s\n%s", fileServer.ConfigLine(), input)
 
 	c.logger.Debug("running compiler", zap.String("input", input), zap.Stringer("cmd", cmd))
@@ -369,10 +377,10 @@ func (c *Compiler) run(ctx context.Context, input string, parserFunc parserFn) e
 	return nil
 }
 
-func (c *Compiler) cmd(ctx context.Context, input string, fileServer FileServer) *exec.Cmd {
+func (c *Compiler) cmd(ctx context.Context, projectURI lsp.DocumentURI, input string, fileServer FileServer) *exec.Cmd {
 	args := []string{"--lsp"}
-	if c.settings.RootURI != "" {
-		project_root := uri.URIToPath(c.settings.RootURI)
+	if projectURI != "" {
+		project_root := uri.URIToPath(projectURI)
 		lock_file := filepath.Join(project_root, "package.lock")
 		if stat, err := os.Stat(lock_file); err == nil && !stat.IsDir() {
 			args = append(args, "--project-root", uri.URIToCompilerPath(c.settings.RootURI))

--- a/tools/toitlsp/lsp/doc_handlers.go
+++ b/tools/toitlsp/lsp/doc_handlers.go
@@ -97,7 +97,7 @@ func (s *Server) textDocumentDefinition(ctx context.Context, conn *jsonrpc2.Conn
 	}
 	cCtx := s.GetContext(conn)
 	compiler := s.createCompiler(cCtx)
-	res, err := compiler.GotoDefinition(ctx, req.TextDocument.URI, req.Position)
+	res, err := compiler.GotoDefinition(ctx, cCtx.RootURI, req.TextDocument.URI, req.Position)
 	if err != nil {
 		return nil, s.handleCompilerError(ctx, handleCompilerErrorOptions{
 			Conn:     conn,
@@ -115,7 +115,7 @@ func (s *Server) textDocumentCompletion(ctx context.Context, conn *jsonrpc2.Conn
 	}
 	cCtx := s.GetContext(conn)
 	compiler := s.createCompiler(cCtx)
-	res, err := compiler.Complete(ctx, req.TextDocument.URI, req.Position)
+	res, err := compiler.Complete(ctx, cCtx.RootURI, req.TextDocument.URI, req.Position)
 	if err != nil {
 		return nil, s.handleCompilerError(ctx, handleCompilerErrorOptions{
 			Conn:     conn,
@@ -167,7 +167,7 @@ func (s *Server) textDocumentSemanticTokensFull(ctx context.Context, conn *jsonr
 	}
 	cCtx := s.GetContext(conn)
 	compiler := s.createCompiler(cCtx)
-	res, err := compiler.SemanticTokens(ctx, req.TextDocument.URI)
+	res, err := compiler.SemanticTokens(ctx, cCtx.RootURI, req.TextDocument.URI)
 	if err != nil {
 		return nil, s.handleCompilerError(ctx, handleCompilerErrorOptions{
 			Conn:     conn,
@@ -204,7 +204,7 @@ func (s *Server) analyzeWithRevision(ctx context.Context, conn *jsonrpc2.Conn, r
 
 	cCtx := s.GetContext(conn)
 	c := s.createCompiler(cCtx)
-	result, err := c.Analyze(ctx, uris...)
+	result, err := c.Analyze(ctx, cCtx.RootURI, uris...)
 	if err != nil {
 		err := s.handleCompilerError(ctx, handleCompilerErrorOptions{
 			Conn:     conn,

--- a/tools/toitlsp/lsp/toit_handlers.go
+++ b/tools/toitlsp/lsp/toit_handlers.go
@@ -127,7 +127,7 @@ func (s *Server) Analyze(ctx context.Context, conn *jsonrpc2.Conn, req AnalyzePa
 	cCtx := s.GetContext(conn)
 	c := s.createCompiler(cCtx)
 
-	analyzeResult, err := c.Analyze(ctx, uris...)
+	analyzeResult, err := c.Analyze(ctx, cCtx.RootURI, uris...)
 	if err != nil {
 		return false, err
 	}
@@ -199,7 +199,7 @@ func (s *Server) ToitArchiveWriter(ctx context.Context, conn *jsonrpc2.Conn, req
 
 	cCtx := s.GetContext(conn)
 	c := s.createCompiler(cCtx)
-	if err := c.Parse(ctx, uris...); err != nil {
+	if err := c.Parse(ctx, cCtx.RootURI, uris...); err != nil {
 		return s.handleCompilerError(ctx, handleCompilerErrorOptions{
 			Conn:     conn,
 			Error:    err,
@@ -248,7 +248,7 @@ func (s *Server) ToitSnapshotBundle(ctx context.Context, conn *jsonrpc2.Conn, re
 
 	cCtx := s.GetContext(conn)
 	c := s.createCompiler(cCtx)
-	b, err := c.SnapshotBundle(ctx, uri)
+	b, err := c.SnapshotBundle(ctx, cCtx.RootURI, uri)
 	if err != nil {
 		return nil, s.handleCompilerError(ctx, handleCompilerErrorOptions{
 			Conn:     conn,


### PR DESCRIPTION
Eventually we would like to pass project-uris that are depending on the URIs we are working on. This is a first step in that direction. Instead of having the project-URI in the compiler, we pass it for every action.