### PR TITLE
Analyze each file in its project root.

### DIFF
--- a/tools/lsp/server/compiler.toit
+++ b/tools/lsp/server/compiler.toit
@@ -58,16 +58,16 @@ class Compiler:
   /**
   Builds the flags that are passed to the compiler.
   */
-  build-run-flags --project-uri/string -> List:
+  build-run-flags --project-uri/string? -> List:
     args := [
       "--lsp",
     ]
-    if project-uri:
-      project-path-local := uri-path-translator_.to-path project-uri
-      package-lock := "$project-path-local/package.lock"
-      if file.is-file package-lock:
-        project-path-compiler := uri-path-translator_.to-path project-uri --to-compiler
-        args += ["--project-root", project-path-compiler]
+    project-path-local := uri-path-translator_.to-path project-uri
+    package-lock := "$project-path-local/package.lock"
+    if file.is-file package-lock:
+      project-path-compiler := uri-path-translator_.to-path project-uri --to-compiler
+      args += ["--project-root", project-path-compiler]
+    verbose: "run-flags: $args"
     return args
 
   /**

--- a/tools/lsp/server/documents.toit
+++ b/tools/lsp/server/documents.toit
@@ -15,52 +15,157 @@
 
 import host.file
 import tar show *
-import .summary
 
+import .project-uri
+import .summary
 import .uri-path-translator
 import .utils
 
 /**
-Keeps track of unsaved files.
+Keeps track of unsaved files and their dependencies.
 */
 class Documents:
-  documents_ /Map/*<string, Document>*/ ::= {:}
+  /**
+  A map from document uri to opened document.
+  During analysis, this map must be used to find the content of a document.
+  */
+  opened-documents_ /Map/*<string, OpenedDocument>*/ ::= {:}
+
+  /**
+  A map from a document URI to its project URI.
+
+  The project URI is the root of the project where we can find the
+    package lock file and the downloaded packages.
+
+  From the user's point of view a document is only in one project. Diagnostics
+    are only shown for this project.
+
+  Internally, a document might be in more than one project, as local dependencies
+    can lead to a document being referenced from multiple projects.
+  */
+  project-uris_ /Map/*<string, string>*/ ::= {:}
+
+  /**
+  A map from project-uri to a $AnalyzedDocuments object.
+  Note that URIs might be in more than one project.
+  */
+  analyzed-documents_ /Map/*<string, AnalyzedDocuments>*/ ::= {:}
+
   translator_ /UriPathTranslator ::= ?
   error-reporter_ / Lambda ::= ?
 
-  constructor .translator_ --.error-reporter_=(:: /* do nothing */):
+  constructor .translator_ --error-reporter/Lambda=(:: /* do nothing */):
+    error-reporter_ = error-reporter
+
+  /**
+  The project-uri the given document uri belongs to.
+
+  If the document isn't known yet computes its project-uri.
+  If $recompute is true, then recomputes the project-uri even if it is already known.
+  */
+  project-uri-for --uri/string --recompute/bool=false -> string:
+    project-uri := project-uris_.get uri
+    if project-uri and not recompute: return project-uri
+    computed := compute-project-uri --uri=uri --translator=translator_
+    project-uris_[uri] = computed
+    if not project-uri: return computed
+    // Recompute the project-uri for all documents that are in the same project.
+    // A user might have added or removed a package.{yaml|lock} file.
+    project-uris_.map --in-place: | document-uri/string document-project-uri/string |
+      if document-project-uri == project-uri:
+        compute-project-uri --uri=document-uri --translator=translator_
+    return computed
+
+  /**
+  Returns the $AnalyzedDocuments object for the given $project-uri.
+
+  If the object doesn't exist yet, it is created.
+  */
+  analyzed-documents-for --project-uri/string -> AnalyzedDocuments:
+    return analyzed-documents_.get project-uri --init=: (AnalyzedDocuments translator_ --error-reporter=error-reporter_)
 
   did-open --uri/string content/string? revision/int -> none:
-    document := documents_.get uri
+    document/OpenedDocument? := opened-documents_.get uri
     if document: error-reporter_.call "Document $uri already open"
-    if not document: document = Document --uri=uri
-    document.content = content
-    document.content-revision = revision
-    document.is-open = true
-    documents_[uri] = document
+    if not document: document = OpenedDocument --uri=uri --content=content --revision=revision
+    opened-documents_[uri] = document
 
   did-change --uri/string new-content/string revision/int-> none:
-    document := get-existing-document --uri=uri --is-open
+    document := get-opened-document_ --uri=uri
     document.content = new-content
-    document.content-revision = revision
+    document.revision = revision
 
   did-save --uri/string -> none:
-    document := get-existing-document --uri=uri --is-open
-    document.content = null
-    // Keep the content-version number, as it could be useful for `update_document_after_analysis`.
+    opened-documents_.remove uri
 
   did-close --uri/string -> none:
-    // We keep the entry, as the LSP client might still show errors, even if the file isn't open anymore.
-    document := get-existing-document --uri=uri --is-open
-    document.content = null
-    document.is-open = false
+    opened-documents_.remove uri
 
   delete --uri/string -> none:
-    document := documents_.get uri
-    if document:
-      document.summary.dependencies.do:
-        (get-existing-document --uri=it).reverse-deps.remove uri
-    documents_.remove uri
+    opened-documents_.remove uri
+    analyzed-documents_.do: | _ documents/AnalyzedDocuments |
+      documents.delete --uri=uri
+
+  get-opened-document_ --uri/string -> OpenedDocument:
+    return opened-documents_.get uri --init=:
+      error-reporter_.call "Document $uri doesn't exist yet"
+      OpenedDocument --uri=uri --revision=-1 --content=""
+
+  get-opened --uri/string -> OpenedDocument?:
+    return opened-documents_.get uri
+  get-opened --path/string -> OpenedDocument?:
+    return get-opened --uri=(translator_.to-uri path)
+
+  do-opened [block] -> none:
+    opened-documents_.do: |uri doc| block.call doc
+
+  save-as-tar file-name:
+    writer := file.Stream file-name file.CREAT | file.WRONLY 0x1ff
+    try:
+      write-as-tar writer
+    finally:
+      writer.close
+
+  write-as-tar writer -> none:
+    tar := Tar writer
+    opened-documents_.do: |uri entry/OpenedDocument|
+      tar.add (translator_.to-path entry.uri) entry.content
+    tar.close --no-close-writer
+
+  update-document-after-analysis -> int  // Returns a bitset.
+      --project-uri/string
+      --uri/string
+      --analysis-revision/int
+      --summary/Module:
+    analyzed := analyzed-documents-for --project-uri=project-uri
+    open-document := opened-documents_.get uri
+    content-revision := open-document ? open-document.revision : -1
+    return analyzed.update-document-after-analysis
+        --uri=uri
+        --analysis-revision=analysis-revision
+        --summary=summary
+        --content-revision=content-revision
+
+/**
+Keeps track of unsaved files.
+*/
+class AnalyzedDocuments:
+  // A map from a document URI to its project URI.
+  project-uris_ /Map/*<string, string>*/ ::= {:}
+  // For each project-uri a map from a document URI to its document.
+  // Note that URIs might be in more than one project.
+  documents_ /Map/*<Map<string, AnalyzedDocument>>*/ ::= {:}
+  // For each project-uri a set of document URIs that are relevant
+  // for the project.
+  // Note that this information is redundant with the information in
+  // `documents_`, but it is more efficient to keep it here.
+  documents-in-project_ /Map/*<string, Set<string>>*/ ::= {:}
+
+  translator_ /UriPathTranslator ::= ?
+  error-reporter_ / Lambda ::= ?
+
+  constructor .translator_ --error-reporter:
+    error-reporter_ = error-reporter
 
   /**
   This bit is set, if the summary changed externally.
@@ -75,6 +180,13 @@ class Documents:
   */
   static FIRST-ANALYSIS-AFTER-CONTENT-CHANGE-BIT ::= 2
 
+  delete --uri/string -> none:
+    document := documents_.get uri
+    if document:
+      document.summary.dependencies.do:
+        (get-existing --uri=it).reverse-deps.remove uri
+    documents_.remove uri
+
   /**
   Updates the $summary for the given $uri.
 
@@ -84,8 +196,10 @@ class Documents:
   The caller can use these to see whether reverse-dependencies need to be analyzed, or whether
     diagnostics of this analysis need to be reported.
   */
-  update-document-after-analysis --uri/string -> int  // Returns a bitset.
+  update-document-after-analysis -> int  // Returns a bitset.
+      --uri/string
       --analysis-revision/int
+      --content-revision/int
       --summary/Module:
     document := get-dependency-document_ --uri=uri
 
@@ -101,7 +215,7 @@ class Documents:
     // Delete all obsolete reverse dependencies.
     old-deps.do: |dep-uri|
       if not new-deps.contains dep-uri:
-        dep-doc := get-existing-document --uri=dep-uri
+        dep-doc := get-existing --uri=dep-uri
         dep-doc.reverse-deps.remove uri --if-absent=:
           error-reporter_.call "Couldn't delete reverse dependency for $dep-uri (not dep of $uri anymore)"
     // Set up the new reverse dependencies.
@@ -117,59 +231,33 @@ class Documents:
     document.analysis-revision = analysis-revision
 
     result := 0
-    if old-analysis-revision < document.content-revision and
-        analysis-revision >= document.content-revision:
+    if old-analysis-revision < content-revision and
+        analysis-revision >= content-revision:
       result |= FIRST-ANALYSIS-AFTER-CONTENT-CHANGE-BIT
     if not (old-summary and old-summary.equals-external summary):
       result |= SUMMARY-CHANGED-EXTERNALLY-BIT
 
     return result
 
-  /**
-  Returns the document for $uri.
+  get-dependency-document_ --uri/string -> AnalyzedDocument:
+    return documents_.get uri --init=: AnalyzedDocument
 
-  The document must exist.
-  If $is-open, then also checks that the document is currently open.
-  */
-  get-existing-document --uri/string --is-open/bool=false -> Document:
+  get-existing --uri/string -> AnalyzedDocument:
     result := documents_.get uri --init=:
       error-reporter_.call "Document $uri doesn't exist yet"
-      Document --uri=uri --is-open=is-open
-    if is-open and not result.is-open:
-      error-reporter_.call "Document $uri isn't open as expected"
+      AnalyzedDocument
     return result
-  get-existing-document --path/string --is-open/bool=false -> Document:
-    return get-existing-document --uri=(translator_.to-uri path) --is-open=is-open
 
-  get-dependency-document_ --uri/string -> Document:
-    return documents_.get uri --init=: Document --uri=uri
+  get --uri/string -> AnalyzedDocument?: return documents_.get uri
+  get --path/string -> AnalyzedDocument?: return get --uri=(translator_.to-uri path)
 
-  save-as-tar file-name:
-    writer := file.Stream file-name file.CREAT | file.WRONLY 0x1ff
-    try:
-      write-as-tar writer
-    finally:
-      writer.close
-
-  write-as-tar writer -> none:
-    tar := Tar writer
-    documents_.do: |uri entry|
-      if entry.content: tar.add (translator_.to-path entry.uri) entry.content
-    tar.close --no-close-writer
-
-  get --uri/string -> Document?: return documents_.get uri
-  get --path/string -> Document?: return get --uri=(translator_.to-uri path)
-
-  do [block] -> none:
-    documents_.do: |uri doc| block.call doc
-
-
-class Document:
-  uri      / string ::= ?
-  is-open  / bool    := ?
-  content  / string? := ?
-  summary  / Module? := ?
-  reverse-deps / Set := ?
+/**
+A document that is opened in the editor and thus has content that isn't
+saved to disk.
+*/
+class OpenedDocument:
+  uri     / string
+  content / string := ?
 
   /**
   The revision of the $content.
@@ -178,14 +266,14 @@ class Document:
   Any analysis result that is equal or greater than the content revision provides
     up-to-date results.
   */
-  content-revision / int := ?
+  revision / int := ?
 
-  /**
-  Whether the summary is correct. That is, whether the summary could be used instead
-    of the content to analyze other files.
-  */
-  is-summary-up-to-date -> bool:
-    return summary and analysis-revision >= content-revision
+  constructor --.uri --.content --.revision:
+
+
+class AnalyzedDocument:
+  summary  / Module? := ?
+  reverse-deps / Set := ?
 
   // The revision of the analysis that last ran on this document.
   // -1 if no analysis has been run yet.
@@ -195,9 +283,6 @@ class Document:
   // -1 if no request is pending.
   analysis-requested-by-revision / int := -1
 
-  constructor --.uri
-      --.is-open=false
-      --.content=null
-      --.content-revision=-1
+  constructor
       --.summary=null
       --.reverse-deps={}:

--- a/tools/lsp/server/file_server.toit
+++ b/tools/lsp/server/file_server.toit
@@ -118,10 +118,8 @@ class FileServerProtocol:
     is-regular := false
     is-directory := false
     content := null
-    document := documents_.get --uri=(translator_.to-uri compiler-path --from-compiler)
-    // Just having a document is not enough, as we might still have entries for
-    // deleted files.
-    if document and document.content:
+    document := documents_.get-opened --uri=(translator_.to-uri compiler-path --from-compiler)
+    if document:
       exists = true
       is-regular = true
       is-directory = false

--- a/tools/lsp/server/package.lock
+++ b/tools/lsp/server/package.lock
@@ -1,6 +1,7 @@
-sdk: ^1.6.10
+sdk: ^2.0.0-alpha.120
 prefixes:
   cli: pkg-cli
+  fs: pkg-fs
   host: pkg-host
   tar: pkg-tar
 packages:
@@ -9,11 +10,18 @@ packages:
     name: cli
     version: 1.1.1
     hash: 4cfb8204a27b6eea6c4d1339c96f6e8cb41e43db
+  pkg-fs:
+    url: github.com/toitlang/pkg-fs
+    name: fs
+    version: 1.0.0
+    hash: c816c85022a155f37a4396455da9b27595050de1
+    prefixes:
+      host: pkg-host
   pkg-host:
     url: github.com/toitlang/pkg-host
     name: host
-    version: 1.8.1
-    hash: 7f0cc4280065fb18ee09d3803f12180cec852d32
+    version: 1.11.0
+    hash: 7e7df6ac70d98a02f232185add81a06cec0d77e8
   pkg-tar:
     url: github.com/toitlang/pkg-tar
     name: tar

--- a/tools/lsp/server/package.yaml
+++ b/tools/lsp/server/package.yaml
@@ -2,6 +2,9 @@ dependencies:
   cli:
     url: github.com/toitlang/pkg-cli
     version: ^1.1.1
+  fs:
+    url: github.com/toitlang/pkg-fs
+    version: ^1.0.0
   host:
     url: github.com/toitlang/pkg-host
     version: ^1.8.1

--- a/tools/lsp/server/project-uri.toit
+++ b/tools/lsp/server/project-uri.toit
@@ -1,0 +1,48 @@
+// Copyright (C) 2023 Toitware ApS.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+import fs
+import host.file
+import system
+import .uri-path-translator
+
+/**
+Computes the project URI for a given path.
+
+The project URI is the path that contains a `package.{yaml|lock}` file.
+However, it must not be inside a '.packages' folder. In that case we assume that
+there is a `package.{yaml|lock}` file in the parent folder.
+*/
+compute-project-uri --uri/string --translator/UriPathTranslator -> string:
+  path := translator.to-path uri
+  dir := fs.dirname path
+
+  slash-dir := dir.replace --all "\\" "/"
+  segments := slash-dir.split "/"
+  dot-packages-index := segments.index-of ".packages"
+
+  if dot-packages-index != -1:
+    // We don't even check whether there is a package.yaml|lock file.
+    // we just assume that this is the project uri.
+    result-path := segments[..dot-packages-index].join "/"
+    return translator.to-uri result-path
+
+  while true:
+    if file.is-file "$dir/package.yaml" or file.is-file "$dir/package.lock":
+      return translator.to-uri dir
+    parent := fs.dirname dir
+    if parent == ".":
+      return translator.to-uri dir
+    dir = parent

--- a/tools/lsp/server/server.toit
+++ b/tools/lsp/server/server.toit
@@ -74,7 +74,6 @@ class LspServer:
   toit-path-override_  /string?     ::= ?
   /// The root uri of the workspace.
   /// Rarely needed, as the server generally works with absolute paths.
-  /// It's mainly used to find package.lock files.
   root-uri_ /string? := null
 
   active-requests_ := 0
@@ -206,6 +205,7 @@ class LspServer:
   did-open params/DidOpenTextDocumentParams -> none:
     document := params.text-document
     uri := translator_.canonicalize document.uri
+    project-uri := documents_.project-uri-for --uri=uri
     // We are calling `analyze` just after updating the document.
     // The next analysis-revision is thus the one where the new content has been
     //   taken into account.
@@ -227,13 +227,15 @@ class LspServer:
     // If the request doesn't specify whether it wants the sdk we include it.
     include-sdk := params.include-sdk == null ? true : params.include-sdk
     uris := non-canonicalized-uris.map: translator_.canonicalize it
+    // We assume the project-uri is from the first uri.
+    project-uri := documents_.project-uri-for --uri=uris[0]
     paths := uris.map: translator_.to-path it
     compiler := compiler_
-    compiler.parse --paths=paths --project-uri=root-uri_
+    compiler.parse --paths=paths --project-uri=project-uri
     buffer := bytes.Buffer
     write-repro
         --writer=buffer
-        --compiler-flags=compiler.build-run-flags --project-uri=root-uri_
+        --compiler-flags=compiler.build-run-flags --project-uri=project-uri
         --compiler-input=json.stringify paths
         --protocol=compiler.protocol
         --info="toit/archive"
@@ -244,8 +246,9 @@ class LspServer:
 
   snapshot-bundle params/SnapshotBundleParams -> Map?:
     uri := translator_.canonicalize params.uri
+    project-uri := documents_.project-uri-for --uri=uri
     compiler := compiler_
-    bundle := compiler.snapshot-bundle --project-uri=root-uri_ uri
+    bundle := compiler.snapshot-bundle --project-uri=project-uri uri
     // Encode the byte-array as base64.
     if not bundle: return null
     return {
@@ -276,24 +279,29 @@ class LspServer:
 
   completion params/CompletionParams -> List/*<CompletionItem>*/:
     uri := translator_.canonicalize params.text-document.uri
-    return compiler_.complete --project-uri=root-uri_ uri params.position.line params.position.character
+    project-uri := documents_.project-uri-for --uri=uri
+    return compiler_.complete --project-uri=project-uri uri params.position.line params.position.character
 
   // TODO(florian): The specification supports a list of locations, or Locationlinks..
   // For now just returns one location.
   goto-definition params/TextDocumentPositionParams -> List/*<Location>*/:
     uri := translator_.canonicalize params.text-document.uri
-    return compiler_.goto-definition --project-uri=root-uri_ uri params.position.line params.position.character
+    project-uri := documents_.project-uri-for --uri=uri
+    return compiler_.goto-definition --project-uri=project-uri uri params.position.line params.position.character
 
   document-symbol params/DocumentSymbolParams -> List/*<DocumentSymbol>*/:
     uri := translator_.canonicalize params.text-document.uri
-    document := documents_.get --uri=uri
+    project-uri := documents_.project-uri-for --uri=uri
+    analyzed-documents := documents_.analyzed-documents-for --project-uri=project-uri
+    document := analyzed-documents.get --uri=uri
     if not (document and document.summary):
-      analyze [uri]
-      document = documents_.get-existing-document --uri=uri
+      analyze --project-uri=project-uri [uri] next-analysis-revision_++
+      document = analyzed-documents.get-existing --uri=uri
       if not document.summary: return []
+    opened-document := documents_.get-opened --uri=uri
     content := ""
-    if document.content:
-      content = document.content
+    if opened-document:
+      content = opened-document.content
     else:
       path := translator_.to-path uri
       if file.is-file path:
@@ -303,7 +311,8 @@ class LspServer:
 
   semantic-tokens params/SemanticTokensParams -> SemanticTokens:
     uri := translator_.canonicalize params.text-document.uri
-    tokens := compiler_.semantic-tokens --project-uri=root-uri_ uri
+    project-uri := documents_.project-uri-for --uri=uri
+    tokens := compiler_.semantic-tokens --project-uri=project-uri uri
     return SemanticTokens --data=tokens
 
   shutdown:
@@ -329,12 +338,26 @@ class LspServer:
     if uris.is-empty: return
 
     revision = revision or next-analysis-revision_++
-    assert: uris.every: | uri |
-      (documents_.get-existing-document --uri=uri).analysis-revision < revision
 
-    verbose: "Analyzing: $uris  ($revision)"
+    project-uris := {:}
+    uris.do: |uri|
+      project-uri := documents_.project-uri-for --uri=uri
+      list := project-uris.get project-uri --init=:[]
+      list.add uri
 
-    analysis-result := compiler_.analyze --project-uri=root-uri_ uris
+    project-uris.do: |project-uri uris|
+      analyze uris --project-uri=project-uri revision
+
+  analyze uris/List --project-uri/string? revision/int -> none:
+    analyzed-documents := documents_.analyzed-documents-for --project-uri=project-uri
+
+    assert:
+      uris.every: | uri |
+        (analyzed-documents.get-existing --uri=uri).analysis-revision < revision
+
+    verbose: "Analyzing: $uris  ($revision) in $project-uri"
+
+    analysis-result := compiler_.analyze --project-uri=project-uri uris
     if not analysis-result:
       verbose: "Analysis failed (no analysis result). ($revision)"
       return  // Analysis didn't succeed. Don't bother with the result.
@@ -352,9 +375,9 @@ class LspServer:
         entry-path := translator_.to-path uri
         probably-entry-problem := diagnostics-per-uri.is-empty and
             diagnostics-without-position.any: it.contains entry-path
-        document := documents_.get --uri=uri
+        document := documents_.get-opened --uri=uri
         if probably-entry-problem and document:
-          if document.is-open:
+          if document:
             // This should not happen.
             // TODO(florian): report to client and log (potentially creating repro).
           else:
@@ -373,18 +396,24 @@ class LspServer:
     // Always report diagnostics for the given uris, unless there is a more recent
     // analysis already, or if the document has been updated in the meantime.
     uris.do: | uri |
-      doc := documents_.get-existing-document --uri=uri
-      if not doc.analysis-revision >= revision and not doc.content-revision > revision:
+      doc := analyzed-documents.get-existing --uri=uri
+      opened-doc := documents_.get-opened --uri=uri
+      content-revision := opened-doc ? opened-doc.revision : -1
+      if not doc.analysis-revision >= revision and not content-revision > revision:
         report-diagnostics-documents.add uri
 
     summaries.do: |summary-uri summary|
       assert: summary != null
-      update-result := documents_.update-document-after-analysis --uri=summary-uri
+      opened := documents_.get-opened --uri=summary-uri
+      content-revision := opened ? opened.revision : -1
+      update-result := analyzed-documents.update-document-after-analysis
+          --uri=summary-uri
           --analysis-revision=revision
+          --content-revision=content-revision
           --summary=summary
-      has-changed-summary := (update-result & Documents.SUMMARY-CHANGED-EXTERNALLY-BIT) != 0
+      has-changed-summary := (update-result & AnalyzedDocuments.SUMMARY-CHANGED-EXTERNALLY-BIT) != 0
       first-analysis-after-content-change :=
-          (update-result & Documents.FIRST-ANALYSIS-AFTER-CONTENT-CHANGE-BIT) != 0
+          (update-result & AnalyzedDocuments.FIRST-ANALYSIS-AFTER-CONTENT-CHANGE-BIT) != 0
 
       // If the summary has changed, it either means that:
       //  - this was one of the $uris that was analyzed
@@ -396,14 +425,14 @@ class LspServer:
         changed-summary-documents.add summary-uri
       if has-changed-summary or first-analysis-after-content-change:
         report-diagnostics-documents.add summary-uri
-      dep-document := documents_.get-existing-document --uri=summary-uri
+      dep-document := analyzed-documents.get-existing --uri=summary-uri
       request-revision := dep-document.analysis-requested-by-revision
       if request-revision != -1 and request-revision < revision:
         report-diagnostics-documents.add summary-uri
 
     // All reverse dependencies of changed documents need to have their diagnostics printed.
     changed-summary-documents.do:
-      document := documents_.get-existing-document --uri=it
+      document := analyzed-documents.get-existing --uri=it
 
       // Local lambda that transitively adds reverse dependencies.
       // We add all transitive dependencies, as it's hard to track implicit exports.
@@ -416,14 +445,14 @@ class LspServer:
       add-rev-deps = :: |rev-dep-uri|
         if not report-diagnostics-documents.contains rev-dep-uri:
           report-diagnostics-documents.add rev-dep-uri
-          rev-document := documents_.get-existing-document --uri=rev-dep-uri
+          rev-document := analyzed-documents.get-existing --uri=rev-dep-uri
           rev-document.reverse-deps.do: add-rev-deps.call it
 
       document.reverse-deps.do: add-rev-deps.call it
 
     // Send the diagnostics we have to the client.
     report-diagnostics-documents.do: |uri|
-      document := documents_.get-existing-document --uri=uri
+      document := analyzed-documents.get-existing --uri=uri
       request-revision := document.analysis-requested-by-revision
       was-analyzed := summaries.contains uri
       if was-analyzed:
@@ -437,13 +466,15 @@ class LspServer:
 
     // Local lambda that returns whether a document needs analysis.
     needs-analysis := : |uri|
-      document := documents_.get-existing-document --uri=uri
+      document := analyzed-documents.get-existing --uri=uri
       up-to-date := document.analysis-revision >= revision
-      will-be-analyzed := document.content-revision and document.content-revision > revision
+      opened := documents_.get-opened --uri=uri
+      content-revision := opened ? opened.revision : -1
+      will-be-analyzed := content-revision > revision
       not up-to-date and not will-be-analyzed
 
     // See which documents need to be analyzed as a result of changes.
-    documents-needing-analysis := report-diagnostics-documents.filter --in-place: // Reuse the set
+    documents-needing-analysis := report-diagnostics-documents.filter --in-place: // Reuse the set.
       needs-analysis.call it
 
     if not documents-needing-analysis.is-empty:

--- a/tools/lsp/server/uri_path_translator.toit
+++ b/tools/lsp/server/uri_path_translator.toit
@@ -13,6 +13,7 @@
 // The license can be found in the file `LICENSE` in the top level
 // directory of this repository.
 
+import fs
 import system
 import system show platform
 
@@ -118,7 +119,7 @@ class UriPathTranslator:
     return compiler-path
 
   local-path-to-compiler-path local-path/string -> string:
-    assert: is-absolute_ local-path
+    assert: fs.is-absolute local-path
     if platform == system.PLATFORM-WINDOWS:
       return "/$local-path"
     return local-path
@@ -129,10 +130,3 @@ class UriPathTranslator:
   Specifically deals with different ways of percent-encoding.
   */
   canonicalize uri/string -> string: return to-uri (to-path uri)
-
-  is-absolute_ path/string -> bool:
-    if path.starts-with "/": return true
-    if platform == system.PLATFORM-WINDOWS:
-      if path.starts-with "\\\\": return true
-      if path.size >= 2 and path[1] == ':': return true
-    return false


### PR DESCRIPTION
Instead of having one shared project root, find the project root for each file before running the analysis on it.

Still missing:
- we shouldn't report diagnostics for files that are in different project roots. Otherwise, we could end up with files that have a warning when they are not opened, and then one when they aren't (depending on the project root that is used to analyze them).
- if a summary has changed, then all projects that contain that file should be analyzed again.