### PR TITLE
Don't sync by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,11 +138,6 @@ sync: sync-packages
 sync-packages: check-env $(BUILD)/$(HOST)/CMakeCache.txt
 	(cd $(BUILD)/$(HOST) && ninja sync_packages)
 
-.PHONY: disable-auto-sync
-disable-auto-sync:
-	$(MAKE) rebuild-cmake
-	cmake -DTOIT_PKG_AUTO_SYNC=OFF $(BUILD)/$(HOST)
-
 .PHONY: host-tools
 host-tools: check-env $(BUILD)/$(HOST)/CMakeCache.txt
 	(cd $(BUILD)/$(HOST) && ninja build_tools)

--- a/tools/toit.cmake
+++ b/tools/toit.cmake
@@ -18,7 +18,7 @@
 # In the latter case the `EXECUTING_SCRIPT` variable is defined, and we only
 # process the command that we should execute.
 
-option(TOIT_PKG_AUTO_SYNC "Automatically sync packages when building" ON)
+option(TOIT_PKG_AUTO_SYNC "Automatically sync packages when building" OFF)
 
 set(TOIT_DOWNLOAD_PACKAGE_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/toit.cmake")
 if (DEFINED EXECUTING_SCRIPT)


### PR DESCRIPTION
If developers want to sync they can just write `toit.pkg sync`.