### PR TITLE
Analyze each URI in its own project.

### DIFF
--- a/tools/toitlsp/cmd/toitdoc.go
+++ b/tools/toitlsp/cmd/toitdoc.go
@@ -266,7 +266,22 @@ func extractSummaries(ctx context.Context, options extractSummariesOptions) (map
 		return nil, subErr
 	}
 
-	return server.GetContext(conn).Documents.Summaries(), nil
+	mergedSummaries := map[doclsp.DocumentURI]*toit.Module{}
+	documents := server.GetContext(conn).Documents
+	allProjectURIs := documents.AllProjectURIs()
+	for _, projectUri := range allProjectURIs {
+		analyzedDocuments := server.GetContext(conn).Documents.AnalyzedDocumentsFor(projectUri)
+		for uri, summary := range analyzedDocuments.Summaries() {
+			docProjectUri, err := documents.ProjectURIFor(uri, false)
+			if err != nil {
+				return nil, err
+			}
+			if docProjectUri == projectUri {
+				mergedSummaries[uri] = summary
+			}
+		}
+	}
+	return mergedSummaries, nil
 }
 
 func pathToURI(path string) doclsp.DocumentURI {

--- a/tools/toitlsp/lsp/compiler/compiler.go
+++ b/tools/toitlsp/lsp/compiler/compiler.go
@@ -379,12 +379,10 @@ func (c *Compiler) run(ctx context.Context, projectURI lsp.DocumentURI, input st
 
 func (c *Compiler) cmd(ctx context.Context, projectURI lsp.DocumentURI, input string, fileServer FileServer) *exec.Cmd {
 	args := []string{"--lsp"}
-	if projectURI != "" {
-		project_root := uri.URIToPath(projectURI)
-		lock_file := filepath.Join(project_root, "package.lock")
-		if stat, err := os.Stat(lock_file); err == nil && !stat.IsDir() {
-			args = append(args, "--project-root", uri.URIToCompilerPath(c.settings.RootURI))
-		}
+	project_root := uri.URIToPath(projectURI)
+	lock_file := filepath.Join(project_root, "package.lock")
+	if stat, err := os.Stat(lock_file); err == nil && !stat.IsDir() {
+		args = append(args, "--project-root", uri.URIToCompilerPath(c.settings.RootURI))
 	}
 	cmd := exec.CommandContext(ctx, c.settings.CompilerPath, args...)
 	for !fileServer.IsReady() {

--- a/tools/toitlsp/lsp/compiler/compiler.go
+++ b/tools/toitlsp/lsp/compiler/compiler.go
@@ -21,9 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -379,11 +377,7 @@ func (c *Compiler) run(ctx context.Context, projectURI lsp.DocumentURI, input st
 
 func (c *Compiler) cmd(ctx context.Context, projectURI lsp.DocumentURI, input string, fileServer FileServer) *exec.Cmd {
 	args := []string{"--lsp"}
-	project_root := uri.URIToPath(projectURI)
-	lock_file := filepath.Join(project_root, "package.lock")
-	if stat, err := os.Stat(lock_file); err == nil && !stat.IsDir() {
-		args = append(args, "--project-root", uri.URIToCompilerPath(c.settings.RootURI))
-	}
+	args = append(args, "--project-root", uri.URIToCompilerPath(projectURI))
 	cmd := exec.CommandContext(ctx, c.settings.CompilerPath, args...)
 	for !fileServer.IsReady() {
 		runtime.Gosched()

--- a/tools/toitlsp/lsp/doc_handlers.go
+++ b/tools/toitlsp/lsp/doc_handlers.go
@@ -96,8 +96,12 @@ func (s *Server) textDocumentDefinition(ctx context.Context, conn *jsonrpc2.Conn
 		return nil, err
 	}
 	cCtx := s.GetContext(conn)
+	projectURI, err := cCtx.Documents.ProjectURIFor(req.TextDocument.URI, true)
+	if err != nil {
+		return nil, err
+	}
 	compiler := s.createCompiler(cCtx)
-	res, err := compiler.GotoDefinition(ctx, cCtx.RootURI, req.TextDocument.URI, req.Position)
+	res, err := compiler.GotoDefinition(ctx, projectURI, req.TextDocument.URI, req.Position)
 	if err != nil {
 		return nil, s.handleCompilerError(ctx, handleCompilerErrorOptions{
 			Conn:     conn,
@@ -114,8 +118,12 @@ func (s *Server) textDocumentCompletion(ctx context.Context, conn *jsonrpc2.Conn
 		return nil, err
 	}
 	cCtx := s.GetContext(conn)
+	projectURI, err := cCtx.Documents.ProjectURIFor(req.TextDocument.URI, true)
+	if err != nil {
+		return nil, err
+	}
 	compiler := s.createCompiler(cCtx)
-	res, err := compiler.Complete(ctx, cCtx.RootURI, req.TextDocument.URI, req.Position)
+	res, err := compiler.Complete(ctx, projectURI, req.TextDocument.URI, req.Position)
 	if err != nil {
 		return nil, s.handleCompilerError(ctx, handleCompilerErrorOptions{
 			Conn:     conn,
@@ -172,8 +180,12 @@ func (s *Server) textDocumentSemanticTokensFull(ctx context.Context, conn *jsonr
 		return nil, err
 	}
 	cCtx := s.GetContext(conn)
+	projectURI, err := cCtx.Documents.ProjectURIFor(req.TextDocument.URI, true)
+	if err != nil {
+		return nil, err
+	}
 	compiler := s.createCompiler(cCtx)
-	res, err := compiler.SemanticTokens(ctx, cCtx.RootURI, req.TextDocument.URI)
+	res, err := compiler.SemanticTokens(ctx, projectURI, req.TextDocument.URI)
 	if err != nil {
 		return nil, s.handleCompilerError(ctx, handleCompilerErrorOptions{
 			Conn:     conn,
@@ -479,6 +491,5 @@ func (s *Server) createCompiler(cCtx ConnContext) *compiler.Compiler {
 		SDKPath:      cCtx.Settings.SDKPath,
 		CompilerPath: cCtx.Settings.ToitcPath,
 		Timeout:      cCtx.Settings.Timeout,
-		RootURI:      cCtx.RootURI,
 	})
 }

--- a/tools/toitlsp/lsp/doc_handlers.go
+++ b/tools/toitlsp/lsp/doc_handlers.go
@@ -272,15 +272,17 @@ func (s *Server) analyzeWithProjectURIAndRevision(ctx context.Context, conn *jso
 		for _, uri := range uris {
 			entryPath := util.UriToRealPath(golsp.DocumentURI(uri))
 			probablyEntryProblem := len(result.Diagnostics) == 0 && stringsContainsAny(result.DiagnosticsWithoutPosition, entryPath)
-			_, ok := cCtx.Documents.GetOpenedDocument(uri)
-			if probablyEntryProblem && ok {
-				// This should not happen.
-				// TODO(floitsch): report to client and log (potentially creating repro).
-				s.logger.Info("LSP server error. Document not opened.", zap.String("URI", string(uri)))
-			}
-			// In any case: delete the entry, if there is one.
-			if err := cCtx.Documents.Delete(uri); err != nil {
-				return err
+			if probablyEntryProblem {
+				_, ok := cCtx.Documents.GetOpenedDocument(uri)
+				if ok {
+					// This should not happen.
+					// TODO(floitsch): report to client and log (potentially creating repro).
+					s.logger.Info("LSP server error. Document not opened.", zap.String("URI", string(uri)))
+				}
+				// In any case: delete the entry, if there is one.
+				if err := cCtx.Documents.Delete(uri); err != nil {
+					return err
+				}
 			}
 		}
 		// Don't use the analysis result.

--- a/tools/toitlsp/lsp/doc_handlers.go
+++ b/tools/toitlsp/lsp/doc_handlers.go
@@ -39,7 +39,7 @@ const (
 func (s *Server) TextDocumentDidOpen(ctx context.Context, conn *jsonrpc2.Conn, req lsp.DidOpenTextDocumentParams) error {
 	req.TextDocument.URI = uri.Canonicalize(req.TextDocument.URI)
 	cCtx := s.GetContext(conn)
-	if err := cCtx.Documents.Add(req.TextDocument.URI, &req.TextDocument.Text, cCtx.NextAnalysisRevision); err != nil {
+	if err := cCtx.Documents.Open(req.TextDocument.URI, req.TextDocument.Text, cCtx.NextAnalysisRevision); err != nil {
 		return err
 	}
 
@@ -132,19 +132,25 @@ func (s *Server) textDocumentSymbol(ctx context.Context, conn *jsonrpc2.Conn, re
 		return nil, err
 	}
 	cCtx := s.GetContext(conn)
-	doc, ok := cCtx.Documents.Get(req.TextDocument.URI)
+	projectURI, err := cCtx.Documents.ProjectURIFor(req.TextDocument.URI, true)
+	if err != nil {
+		return nil, err
+	}
+	analyzedDocuments := cCtx.Documents.AnalyzedDocumentsFor(projectURI)
+	doc, ok := analyzedDocuments.Get(req.TextDocument.URI)
 	if !ok || doc.Summary == nil {
 		if err := s.analyze(ctx, conn, req.TextDocument.URI); err != nil {
 			return nil, err
 		}
-		doc = cCtx.Documents.GetExisting(req.TextDocument.URI)
+		doc = analyzedDocuments.GetExisting(req.TextDocument.URI)
 		if doc.Summary == nil {
 			return nil, nil
 		}
 	}
-	var content string
-	if doc.Content != nil {
-		content = *doc.Content
+	content := ""
+	openedDoc, ok := cCtx.Documents.GetOpenedDocument(req.TextDocument.URI)
+	if ok && openedDoc.Content != nil {
+		content = *openedDoc.Content
 	} else {
 		path := uri.URIToPath(req.TextDocument.URI)
 		f, err := s.localFileSystem.Read(path)
@@ -178,11 +184,8 @@ func (s *Server) textDocumentSemanticTokensFull(ctx context.Context, conn *jsonr
 	return res, nil
 }
 
-/**
-  Analyzes the given $uris and sends diagnostics to the client.
-
-  Transitively analyzes all newly discovered files.
-*/
+// Analyzes the given $uris and sends diagnostics to the client.
+// Transitively analyzes all newly discovered files.
 func (s *Server) analyze(ctx context.Context, conn *jsonrpc2.Conn, uris ...lsp.DocumentURI) error {
 	if err := s.WaitUntilReady(ctx, conn); err != nil {
 		return err
@@ -196,6 +199,29 @@ func (s *Server) analyze(ctx context.Context, conn *jsonrpc2.Conn, uris ...lsp.D
 }
 
 func (s *Server) analyzeWithRevision(ctx context.Context, conn *jsonrpc2.Conn, revision int, uris ...lsp.DocumentURI) error {
+	if len(uris) == 0 {
+		return nil
+	}
+
+	// Map from project URI to a list of documents that need to be analyzed.
+	projectURIs := map[lsp.DocumentURI][]lsp.DocumentURI{}
+	for _, docUri := range uris {
+		projectURI, err := s.GetContext(conn).Documents.ProjectURIFor(docUri, true)
+		if err != nil {
+			return err
+		}
+		projectURIs[projectURI] = append(projectURIs[projectURI], docUri)
+	}
+
+	for projectURI, uris := range projectURIs {
+		if err := s.analyzeWithProjectURIAndRevision(ctx, conn, projectURI, revision, uris...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Server) analyzeWithProjectURIAndRevision(ctx context.Context, conn *jsonrpc2.Conn, projectURI lsp.DocumentURI, revision int, uris ...lsp.DocumentURI) error {
 	s.logger.Debug("analyzing", zap.Any("uris", uris))
 	defer s.logger.Debug("finished analyzing", zap.Any("uris", uris))
 	if len(uris) == 0 {
@@ -203,8 +229,10 @@ func (s *Server) analyzeWithRevision(ctx context.Context, conn *jsonrpc2.Conn, r
 	}
 
 	cCtx := s.GetContext(conn)
+	analyzedDocuments := cCtx.Documents.AnalyzedDocumentsFor(projectURI)
+
 	c := s.createCompiler(cCtx)
-	result, err := c.Analyze(ctx, cCtx.RootURI, uris...)
+	result, err := c.Analyze(ctx, projectURI, uris...)
 	if err != nil {
 		err := s.handleCompilerError(ctx, handleCompilerErrorOptions{
 			Conn:     conn,
@@ -232,16 +260,15 @@ func (s *Server) analyzeWithRevision(ctx context.Context, conn *jsonrpc2.Conn, r
 		for _, uri := range uris {
 			entryPath := util.UriToRealPath(golsp.DocumentURI(uri))
 			probablyEntryProblem := len(result.Diagnostics) == 0 && stringsContainsAny(result.DiagnosticsWithoutPosition, entryPath)
-			document, ok := cCtx.Documents.Get(uri)
+			_, ok := cCtx.Documents.GetOpenedDocument(uri)
 			if probablyEntryProblem && ok {
-				if document.IsOpen {
-					// This should not happen.
-					// TODO(jesper): report to client and log (potentially creating repro).
-				} else {
-					if err := cCtx.Documents.Delete(uri); err != nil {
-						return err
-					}
-				}
+				// This should not happen.
+				// TODO(floitsch): report to client and log (potentially creating repro).
+				s.logger.Info("LSP server error. Document not opened.", zap.String("URI", string(uri)))
+			}
+			// In any case: delete the entry, if there is one.
+			if err := cCtx.Documents.Delete(uri); err != nil {
+				return err
 			}
 		}
 		// Don't use the analysis result.
@@ -254,14 +281,22 @@ func (s *Server) analyzeWithRevision(ctx context.Context, conn *jsonrpc2.Conn, r
 	reportDiagnosticsDocuments := uri.Set{}
 
 	for _, uri := range uris {
-		doc := cCtx.Documents.GetExisting(uri)
-		if doc.AnalysisRevision < revision && doc.ContentRevision <= revision {
+		doc := analyzedDocuments.GetExisting(uri)
+		contentRevision := -1
+		if openedDoc, ok := cCtx.Documents.GetOpenedDocument(uri); ok {
+			contentRevision = openedDoc.Revision
+		}
+		if doc.AnalysisRevision < revision && contentRevision <= revision {
 			reportDiagnosticsDocuments.Add(uri)
 		}
 	}
 
 	for summaryURI, summary := range result.Summaries {
-		updateResult, err := cCtx.Documents.UpdateAfterAnalysis(summaryURI, revision, summary)
+		contentRevision := -1
+		if openedDoc, ok := cCtx.Documents.GetOpenedDocument(summaryURI); ok {
+			contentRevision = openedDoc.Revision
+		}
+		updateResult, err := analyzedDocuments.UpdateAfterAnalysis(summaryURI, revision, summary, contentRevision)
 		if err != nil {
 			return err
 		}
@@ -280,7 +315,7 @@ func (s *Server) analyzeWithRevision(ctx context.Context, conn *jsonrpc2.Conn, r
 		if hasChangedSummary || firstAnalysisAfterContentChange {
 			reportDiagnosticsDocuments.Add(summaryURI)
 		}
-		depDoc := cCtx.Documents.GetExisting(summaryURI)
+		depDoc := analyzedDocuments.GetExisting(summaryURI)
 
 		requestRevision := depDoc.AnalysisRequestedByRevision
 		if requestRevision != -1 && requestRevision < revision {
@@ -290,7 +325,7 @@ func (s *Server) analyzeWithRevision(ctx context.Context, conn *jsonrpc2.Conn, r
 
 	// All reverse dependencies of changed documents need to have their diagnostics printed.
 	for changedURI := range changedSummaryDocuments {
-		doc := cCtx.Documents.GetExisting(changedURI)
+		doc := analyzedDocuments.GetExisting(changedURI)
 
 		// Local lambda that transitively adds reverse dependencies.
 		// We add all transitive dependencies, as it's hard to track implicit exports.
@@ -303,7 +338,7 @@ func (s *Server) analyzeWithRevision(ctx context.Context, conn *jsonrpc2.Conn, r
 		addReverseDeps = func(revDepURI lsp.DocumentURI) error {
 			if !reportDiagnosticsDocuments.Contains(revDepURI) {
 				reportDiagnosticsDocuments.Add(revDepURI)
-				revDepDoc := cCtx.Documents.GetExisting(revDepURI)
+				revDepDoc := analyzedDocuments.GetExisting(revDepURI)
 				for depDepURI := range revDepDoc.ReverseDependencies {
 					if err := addReverseDeps(depDepURI); err != nil {
 						return err
@@ -322,7 +357,7 @@ func (s *Server) analyzeWithRevision(ctx context.Context, conn *jsonrpc2.Conn, r
 
 	// Send the diagnostics we have to the client.
 	for uri := range reportDiagnosticsDocuments {
-		doc := cCtx.Documents.GetExisting(uri)
+		doc := analyzedDocuments.GetExisting(uri)
 		requestRevision := doc.AnalysisRequestedByRevision
 		_, wasAnalyzed := result.Summaries[uri]
 		if wasAnalyzed {
@@ -334,19 +369,23 @@ func (s *Server) analyzeWithRevision(ctx context.Context, conn *jsonrpc2.Conn, r
 			}
 			if requestRevision != -1 && requestRevision < revision {
 				// Mark the request as done.
-				cCtx.Documents.SetAnalysisRequestedByRevision(doc, -1)
+				analyzedDocuments.SetAnalysisRequestedByRevision(uri, doc, -1)
 			}
 		} else if requestRevision < revision {
-			cCtx.Documents.SetAnalysisRequestedByRevision(doc, revision)
+			analyzedDocuments.SetAnalysisRequestedByRevision(uri, doc, revision)
 		}
 	}
 
 	// See which documents need to be analyzed as a result of changes.
 	documentsNeedsAnalysis := uri.Set{}
 	for uri := range reportDiagnosticsDocuments {
-		doc := cCtx.Documents.GetExisting(uri)
+		doc := analyzedDocuments.GetExisting(uri)
+		documentRevision := -1
+		if openedDoc, ok := cCtx.Documents.GetOpenedDocument(uri); ok {
+			documentRevision = openedDoc.Revision
+		}
 		upToDate := doc.AnalysisRevision >= revision
-		willBeAnalysed := doc.ContentRevision > revision
+		willBeAnalysed := documentRevision > revision
 		if !upToDate && !willBeAnalysed {
 			documentsNeedsAnalysis.Add(uri)
 		}

--- a/tools/toitlsp/lsp/doc_handlers.go
+++ b/tools/toitlsp/lsp/doc_handlers.go
@@ -281,7 +281,7 @@ func (s *Server) analyzeWithProjectURIAndRevision(ctx context.Context, conn *jso
 	reportDiagnosticsDocuments := uri.Set{}
 
 	for _, uri := range uris {
-		doc := analyzedDocuments.GetExisting(uri)
+		doc := analyzedDocuments.GetOrCreate(uri)
 		contentRevision := -1
 		if openedDoc, ok := cCtx.Documents.GetOpenedDocument(uri); ok {
 			contentRevision = openedDoc.Revision

--- a/tools/toitlsp/lsp/documents.go
+++ b/tools/toitlsp/lsp/documents.go
@@ -172,6 +172,7 @@ func (d *Documents) GetOpenedDocument(uri lsp.DocumentURI) (*OpenedDocument, boo
 func (d *Documents) Delete(uri lsp.DocumentURI) error {
 	d.l.Lock()
 	defer d.l.Unlock()
+
 	delete(d.openedDocuments, uri)
 
 	for _, ad := range d.analyzedDocuments {

--- a/tools/toitlsp/lsp/documents.go
+++ b/tools/toitlsp/lsp/documents.go
@@ -25,51 +25,118 @@ import (
 )
 
 type Documents struct {
-	l         sync.RWMutex
-	logger    *zap.Logger
-	documents map[lsp.DocumentURI]*Document
+	l      sync.RWMutex
+	logger *zap.Logger
+
+	// A map from document URI to opened document.
+	// During analysis, this map must be used to find the content of a document.
+	openedDocuments map[lsp.DocumentURI]*OpenedDocument
+
+	// A map from a document URI to its project URI.
+	//
+	// The project URI is the root of the projcet where we can find the
+	// package lock file and the downloaded packages.
+	//
+	// From the user's point of view a document is only in one project. Diagnostics
+	// are only shown for this project.
+	//
+	// Internally, a document might be in more than one project, as local dependencies
+	// can lead to a document being referenced from multiple projects.
+	projectURIs map[lsp.DocumentURI]lsp.DocumentURI
+
+	// A map from document URI to analyzed documents for the specific uri..
+	analyzedDocuments map[lsp.DocumentURI]*AnalyzedDocuments
 }
 
 func NewDocuments(logger *zap.Logger) *Documents {
 	return &Documents{
-		logger:    logger,
-		documents: map[lsp.DocumentURI]*Document{},
+		logger:            logger,
+		openedDocuments:   map[lsp.DocumentURI]*OpenedDocument{},
+		projectURIs:       map[lsp.DocumentURI]lsp.DocumentURI{},
+		analyzedDocuments: map[lsp.DocumentURI]*AnalyzedDocuments{},
 	}
 }
 
-func (d *Documents) Add(uri lsp.DocumentURI, content *string, revision int) error {
+func (d *Documents) AnalyzedDocumentsFor(projectURI lsp.DocumentURI) *AnalyzedDocuments {
 	d.l.Lock()
 	defer d.l.Unlock()
-	doc, ok := d.documents[uri]
+	ad, ok := d.analyzedDocuments[projectURI]
+	if !ok {
+		ad = newAnalyzedDocuments(d.logger)
+		d.analyzedDocuments[projectURI] = ad
+	}
+	return ad
+}
+
+func (d *Documents) AllProjectURIs() []lsp.DocumentURI {
+	d.l.RLock()
+	defer d.l.RUnlock()
+	res := make([]lsp.DocumentURI, 0, len(d.projectURIs))
+	for _, uri := range d.projectURIs {
+		res = append(res, uri)
+	}
+	return res
+}
+
+func (d *Documents) ProjectURIFor(uri lsp.DocumentURI, recompute bool) (lsp.DocumentURI, error) {
+	d.l.Lock()
+	defer d.l.Unlock()
+	projectURI, ok := d.projectURIs[uri]
+	if ok && !recompute {
+		return projectURI, nil
+	}
+	computed, err := computeProjectURI(uri)
+	if err != nil {
+		return "", err
+	}
+	d.projectURIs[uri] = computed
+	if !ok {
+		return computed, nil
+	}
+	// Recompute the project-uri for all documents that are in the same project.
+	// A user might have added or removed a package.{yaml|lock} file.
+	for otherURI, otherProjectURI := range d.projectURIs {
+		if otherProjectURI == projectURI {
+			newURI, err := computeProjectURI(otherURI)
+			if err != nil {
+				return "", err
+			}
+			d.projectURIs[otherURI] = newURI
+		}
+	}
+	return computed, nil
+}
+
+func (d *Documents) Open(uri lsp.DocumentURI, content string, revision int) error {
+	d.l.Lock()
+	defer d.l.Unlock()
+	doc, ok := d.openedDocuments[uri]
 	if ok {
 		d.logger.Debug("document already open", zap.String("uri", string(uri)))
+		// Treat it as if it was an update.
+		doc.Content = &content
+		doc.Revision = revision
 	} else {
-		doc = &Document{
-			URI:                         uri,
-			AnalysisRevision:            -1,
-			AnalysisRequestedByRevision: -1,
-		}
-		d.documents[uri] = doc
+		doc = newOpenedDocument(uri, content, revision)
+		d.openedDocuments[uri] = doc
 	}
-	doc.Content = content
-	doc.ContentRevision = revision
-	doc.IsOpen = true
 	return nil
 }
 
 func (d *Documents) Update(uri lsp.DocumentURI, newContent string, revision int) error {
 	d.l.Lock()
 	defer d.l.Unlock()
-	doc := d.get(uri, true)
+	doc := d.getExistingOpenedDocument(uri)
 	doc.Content = &newContent
-	doc.ContentRevision = revision
+	doc.Revision = revision
 	return nil
 }
 
+// Used when the document has been saved.
 func (d *Documents) Clear(uri lsp.DocumentURI) error {
 	d.l.Lock()
 	defer d.l.Unlock()
-	doc := d.get(uri, true)
+	doc := d.getExistingOpenedDocument(uri)
 	doc.Content = nil
 	return nil
 }
@@ -77,87 +144,42 @@ func (d *Documents) Clear(uri lsp.DocumentURI) error {
 func (d *Documents) Close(uri lsp.DocumentURI) error {
 	d.l.Lock()
 	defer d.l.Unlock()
-	doc := d.get(uri, true)
-	doc.IsOpen = false
-	doc.Content = nil
+	delete(d.openedDocuments, uri)
 	return nil
 }
 
-func (d *Documents) GetExisting(uri lsp.DocumentURI) Document {
-	d.l.RLock()
-	defer d.l.RUnlock()
-	doc := d.get(uri, false)
-	if doc == nil {
-		d.logger.Info("failed to lookup document", zap.String("uri", string(uri)))
-		return Document{}
-	}
-	return *doc
-}
-
-func (d *Documents) Get(uri lsp.DocumentURI) (Document, bool) {
-	d.l.RLock()
-	defer d.l.RUnlock()
-	doc, ok := d.documents[uri]
+func (d *Documents) getExistingOpenedDocument(uri lsp.DocumentURI) *OpenedDocument {
+	d.l.Lock()
+	defer d.l.Unlock()
+	doc, ok := d.openedDocuments[uri]
 	if !ok {
-		return Document{}, ok
+		d.logger.Error("couldn't get existing opened document", zap.String("uri", string(uri)))
+		doc = newOpenedDocument(uri, "", -1)
+		d.openedDocuments[uri] = doc
 	}
-	return *doc, ok
-}
-
-func (d *Documents) Summaries() map[lsp.DocumentURI]*toit.Module {
-	res := map[lsp.DocumentURI]*toit.Module{}
-	d.l.RLock()
-	defer d.l.RUnlock()
-	for url, doc := range d.documents {
-		res[url] = doc.Summary
-	}
-	return res
-}
-
-func (d *Documents) get(uri lsp.DocumentURI, isOpen bool) *Document {
-	doc, ok := d.documents[uri]
-	if !ok {
-		d.logger.Debug("Document doesn't exist yet", zap.String("uri", string(uri)))
-		doc = &Document{
-			URI:    uri,
-			IsOpen: isOpen,
-		}
-		d.documents[uri] = doc
-	}
-
-	if isOpen && !doc.IsOpen {
-		d.logger.Error("Document isn't open as expected", zap.String("uri", string(uri)))
-	}
-
 	return doc
+}
+
+func (d *Documents) GetOpenedDocument(uri lsp.DocumentURI) (*OpenedDocument, bool) {
+	d.l.RLock()
+	defer d.l.RUnlock()
+	doc, ok := d.openedDocuments[uri]
+	if !ok {
+		return nil, false
+	}
+
+	return doc, true
 }
 
 func (d *Documents) Delete(uri lsp.DocumentURI) error {
 	d.l.Lock()
 	defer d.l.Unlock()
-	doc, ok := d.documents[uri]
-	if ok {
-		if doc.Summary != nil {
-			for _, dep := range doc.Summary.Dependencies {
-				doc := d.get(dep, false)
-				doc.ReverseDependencies.Remove(uri)
-			}
-		}
-	}
-	delete(d.documents, uri)
-	return nil
-}
+	delete(d.openedDocuments, uri)
 
-func (d *Documents) SetAnalysisRequestedByRevision(document Document, analysisRequestedByRevision int) {
-	d.l.Lock()
-	defer d.l.Unlock()
-	doc, ok := d.documents[document.URI]
-	if !ok {
-		return
+	for _, ad := range d.analyzedDocuments {
+		ad.Delete(uri)
 	}
-	if doc.AnalysisRequestedByRevision == document.AnalysisRequestedByRevision {
-		doc.AnalysisRequestedByRevision = analysisRequestedByRevision
-	}
+	return nil
 }
 
 const (
@@ -175,6 +197,35 @@ const (
 	FIRST_ANALYSIS_AFTER_CONTENT_CHANGE_BIT = 2
 )
 
+type AnalyzedDocuments struct {
+	l      sync.RWMutex
+	logger *zap.Logger
+	// For this instance of analyzed documents a map from a document URI to its document.
+	// Note that URIs might be in more than one project and thus AnalyzedDocuments object.
+	documents map[lsp.DocumentURI]*AnalyzedDocument
+}
+
+func newAnalyzedDocuments(logger *zap.Logger) *AnalyzedDocuments {
+	return &AnalyzedDocuments{
+		logger:    logger,
+		documents: map[lsp.DocumentURI]*AnalyzedDocument{},
+	}
+}
+
+func (ad *AnalyzedDocuments) Delete(uri lsp.DocumentURI) error {
+	doc, ok := ad.documents[uri]
+	if ok {
+		if doc.Summary != nil {
+			for _, dep := range doc.Summary.Dependencies {
+				doc := ad.get(dep)
+				doc.ReverseDependencies.Remove(uri)
+			}
+		}
+	}
+	delete(ad.documents, uri)
+	return nil
+}
+
 /**
   Updates the $summary for the given $uri.
 
@@ -185,10 +236,10 @@ const (
     diagnostics of this analysis need to be reported.
 */
 
-func (d *Documents) UpdateAfterAnalysis(docUri lsp.DocumentURI, analysisRevision int, summary *toit.Module) (int, error) {
-	d.l.Lock()
-	defer d.l.Unlock()
-	doc := d.get(docUri, false)
+func (ad *AnalyzedDocuments) UpdateAfterAnalysis(docUri lsp.DocumentURI, analysisRevision int, summary *toit.Module, contentRevision int) (int, error) {
+	ad.l.Lock()
+	defer ad.l.Unlock()
+	doc := ad.getDependencyDocument(docUri)
 
 	if doc.AnalysisRevision >= analysisRevision {
 		return 0, nil
@@ -204,9 +255,9 @@ func (d *Documents) UpdateAfterAnalysis(docUri lsp.DocumentURI, analysisRevision
 
 	for oldDep := range oldDeps {
 		if !newDeps.Contains(oldDep) {
-			depDoc := d.get(oldDep, false)
+			depDoc := ad.GetExisting(oldDep)
 			if !depDoc.ReverseDependencies.Contains(docUri) {
-				d.logger.Error("couldn't delete reverse dependency (not dep anymore)", zap.String("uri", string(docUri)), zap.String("dep_uri", string(oldDep)))
+				ad.logger.Error("couldn't delete reverse dependency (not dep anymore)", zap.String("uri", string(docUri)), zap.String("dep_uri", string(oldDep)))
 			} else {
 				depDoc.ReverseDependencies.Remove(docUri)
 			}
@@ -215,7 +266,7 @@ func (d *Documents) UpdateAfterAnalysis(docUri lsp.DocumentURI, analysisRevision
 
 	for newDep := range newDeps {
 		if !oldDeps.Contains(newDep) {
-			depDoc := d.get(newDep, false)
+			depDoc := ad.get(newDep)
 			depDoc.ReverseDependencies.Add(docUri)
 		}
 	}
@@ -225,7 +276,7 @@ func (d *Documents) UpdateAfterAnalysis(docUri lsp.DocumentURI, analysisRevision
 	doc.AnalysisRevision = analysisRevision
 
 	res := 0
-	if oldAnalysisRevision < doc.ContentRevision && analysisRevision >= doc.ContentRevision {
+	if oldAnalysisRevision < contentRevision && analysisRevision >= contentRevision {
 		res |= FIRST_ANALYSIS_AFTER_CONTENT_CHANGE_BIT
 	}
 	if oldSummary == nil || !oldSummary.EqualsExternal(summary) {
@@ -235,13 +286,73 @@ func (d *Documents) UpdateAfterAnalysis(docUri lsp.DocumentURI, analysisRevision
 	return res, nil
 }
 
-type Document struct {
-	URI                 lsp.DocumentURI
-	IsOpen              bool
-	Content             *string
-	Summary             *toit.Module
-	ReverseDependencies uri.Set
+func (ad *AnalyzedDocuments) SetAnalysisRequestedByRevision(uri lsp.DocumentURI, document *AnalyzedDocument, analysisRequestedByRevision int) {
+	ad.l.Lock()
+	defer ad.l.Unlock()
+	doc, ok := ad.documents[uri]
+	if !ok {
+		return
+	}
+	if doc.AnalysisRequestedByRevision == document.AnalysisRequestedByRevision {
+		doc.AnalysisRequestedByRevision = analysisRequestedByRevision
+	}
+}
 
+func (ad *AnalyzedDocuments) Get(docUri lsp.DocumentURI) (*AnalyzedDocument, bool) {
+	ad.l.RLock()
+	defer ad.l.RUnlock()
+	doc, ok := ad.documents[docUri]
+	if !ok {
+		return nil, false
+	}
+	return doc, true
+}
+
+func (ad *AnalyzedDocuments) getDependencyDocument(docUri lsp.DocumentURI) *AnalyzedDocument {
+	ad.l.Lock()
+	defer ad.l.Unlock()
+	doc, ok := ad.documents[docUri]
+	if !ok {
+		doc = newAnalyzedDocument()
+		ad.documents[docUri] = doc
+	}
+	return doc
+}
+
+func (ad *AnalyzedDocuments) GetExisting(docUri lsp.DocumentURI) *AnalyzedDocument {
+	ad.l.RLock()
+	defer ad.l.RUnlock()
+	doc, ok := ad.documents[docUri]
+	if !ok {
+		ad.logger.Error("couldn't get existing document", zap.String("uri", string(docUri)))
+		return nil
+	}
+	return doc
+}
+
+func (ad *AnalyzedDocuments) get(docUri lsp.DocumentURI) *AnalyzedDocument {
+	ad.l.RLock()
+	defer ad.l.RUnlock()
+	doc, ok := ad.documents[docUri]
+	if !ok {
+		return nil
+	}
+	return doc
+}
+
+func (ad *AnalyzedDocuments) Summaries() map[lsp.DocumentURI]*toit.Module {
+	res := map[lsp.DocumentURI]*toit.Module{}
+	ad.l.RLock()
+	defer ad.l.RUnlock()
+	for url, doc := range ad.documents {
+		res[url] = doc.Summary
+	}
+	return res
+}
+
+type OpenedDocument struct {
+	URI     lsp.DocumentURI
+	Content *string
 	/**
 	The revision of the $content.
 
@@ -249,7 +360,20 @@ type Document struct {
 	Any analysis result that is equal or greater than the content revision provides
 		up-to-date results.
 	*/
-	ContentRevision int
+	Revision int
+}
+
+func newOpenedDocument(uri lsp.DocumentURI, content string, revision int) *OpenedDocument {
+	return &OpenedDocument{
+		URI:      uri,
+		Content:  &content,
+		Revision: revision,
+	}
+}
+
+type AnalyzedDocument struct {
+	Summary             *toit.Module
+	ReverseDependencies uri.Set
 
 	// AnalysisRevision, The revision of the analysis that last ran on this document.
 	// -1 if no analysis has been run yet.
@@ -258,4 +382,11 @@ type Document struct {
 	// The revision of an analysis that requested to update the diagnostics of this document.
 	// -1 if no request is pending.
 	AnalysisRequestedByRevision int
+}
+
+func newAnalyzedDocument() *AnalyzedDocument {
+	return &AnalyzedDocument{
+		AnalysisRevision:            -1,
+		AnalysisRequestedByRevision: -1,
+	}
 }

--- a/tools/toitlsp/lsp/file_system.go
+++ b/tools/toitlsp/lsp/file_system.go
@@ -128,7 +128,7 @@ func (fs *DocsCacheFileSystem) PackageCachePaths() ([]string, error) {
 
 func (fs *DocsCacheFileSystem) Read(path string) (compiler.File, error) {
 	uri := uri.PathToURI(path)
-	doc, ok := fs.docs.Get(uri)
+	doc, ok := fs.docs.GetOpenedDocument(uri)
 	if ok && doc.Content != nil {
 		return compiler.File{
 			Path:        path,

--- a/tools/toitlsp/lsp/project_uri.go
+++ b/tools/toitlsp/lsp/project_uri.go
@@ -25,20 +25,21 @@ import (
 )
 
 func computeProjectURI(documentUri lsp.DocumentURI) (lsp.DocumentURI, error) {
-	segments := strings.Split(filepath.ToSlash(string(documentUri)), "/")
+	path := uri.URIToPath(documentUri)
+	segments := strings.Split(filepath.ToSlash(path), "/")
 	// Find the first '.packages' segment. We assume that the project root is
 	// the parent of this segment.
 	for i := 0; i < len(segments); i++ {
 		if segments[i] == ".packages" {
 			segments = segments[:i]
+			resultPath := filepath.Join(segments...)
 			// We don't even check whether there is a package.yaml|lock file.
 			// We just assume that this is the project uri.
-			return lsp.DocumentURI(strings.Join(segments, "/")), nil
+			return uri.PathToURI(resultPath), nil
 		}
 	}
 
 	// Walk up the path until we find a package.yaml|lock file.
-	path := uri.URIToPath(documentUri)
 	for {
 		if hasPackageFile(path) {
 			return uri.PathToURI(path), nil

--- a/tools/toitlsp/lsp/project_uri.go
+++ b/tools/toitlsp/lsp/project_uri.go
@@ -31,10 +31,11 @@ func computeProjectURI(documentUri lsp.DocumentURI) (lsp.DocumentURI, error) {
 	// the parent of this segment.
 	for i := 0; i < len(segments); i++ {
 		if segments[i] == ".packages" {
-			segments = segments[:i]
-			resultPath := filepath.Join(segments...)
 			// We don't even check whether there is a package.yaml|lock file.
 			// We just assume that this is the project uri.
+			segments = segments[:i]
+			resultSlashPath := strings.Join(segments, "/")
+			resultPath := filepath.FromSlash(resultSlashPath)
 			return uri.PathToURI(resultPath), nil
 		}
 	}

--- a/tools/toitlsp/lsp/project_uri.go
+++ b/tools/toitlsp/lsp/project_uri.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2023 Toitware ApS.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+package lsp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sourcegraph/go-lsp"
+	"github.com/toitware/toit.git/toitlsp/lsp/uri"
+)
+
+func computeProjectURI(documentUri lsp.DocumentURI) (lsp.DocumentURI, error) {
+	segments := strings.Split(filepath.ToSlash(string(documentUri)), "/")
+	// Find the first '.packages' segment. We assume that the project root is
+	// the parent of this segment.
+	for i := 0; i < len(segments); i++ {
+		if segments[i] == ".packages" {
+			segments = segments[:i]
+			// We don't even check whether there is a package.yaml|lock file.
+			// We just assume that this is the project uri.
+			return lsp.DocumentURI(strings.Join(segments, "/")), nil
+		}
+	}
+
+	// Walk up the path until we find a package.yaml|lock file.
+	path := uri.URIToPath(documentUri)
+	for {
+		if hasPackageFile(path) {
+			return uri.PathToURI(path), nil
+		}
+		parent := filepath.Dir(path)
+		if parent == path || parent == "" {
+			return uri.PathToURI(path), nil
+		}
+		path = parent
+	}
+}
+
+func hasPackageFile(path string) bool {
+	_, err := os.Stat(filepath.Join(path, "package.yaml"))
+	if err == nil {
+		return true
+	}
+	_, err = os.Stat(filepath.Join(path, "package.lock"))
+	return err == nil
+}


### PR DESCRIPTION
Same as #1972, but for the Go version of the LSP.

Instead of having one shared project root, find the project root for each file before running the analysis on it.

Still missing:
- we shouldn't report diagnostics for files that are in different project roots. Otherwise, we could end up with files that have a warning when they are not opened, and then one when they aren't (depending on the project root that is used to analyze them).
- if a summary has changed, then all projects that contain that file should be analyzed again.
