### PR TITLE
Fix local/slash confusion on package-path.

### DIFF
--- a/src/compiler/lock.cc
+++ b/src/compiler/lock.cc
@@ -919,15 +919,17 @@ PackageLock PackageLock::read(const std::string& lock_file_path,
       std::string error_path;
       bool is_path_package = !entry.path.empty();
       if (is_path_package) {
-        char* localized = FilesystemLocal::to_local_path(entry.path.c_str());
         ASSERT(i == -1);
+        // The entry_path is always with slashes.
+        auto entry_path = entry.path.c_str();
+        char* localized = FilesystemLocal::to_local_path(entry_path);
         if (!fs->is_absolute(localized)) {
           // TODO(florian): this is not correct for Windows paths that are drive-relative: '\foo'.
-          builder.join(package_lock_dir);
+          builder.add(package_lock_dir);
         }
-        error_path = std::string(localized);
-        builder.join(error_path);
+        builder.joinSlashPath(std::string(entry_path));
         builder.canonicalize();
+        error_path = std::string(localized);
         free(localized);
       } else {
         if (i == -1) continue;

--- a/src/compiler/lock.cc
+++ b/src/compiler/lock.cc
@@ -927,7 +927,7 @@ PackageLock PackageLock::read(const std::string& lock_file_path,
           // TODO(florian): this is not correct for Windows paths that are drive-relative: '\foo'.
           builder.add(package_lock_dir);
         }
-        builder.joinSlashPath(std::string(entry_path));
+        builder.join_slash_path(std::string(entry_path));
         builder.canonicalize();
         error_path = std::string(localized);
         free(localized);

--- a/src/compiler/util.h
+++ b/src/compiler/util.h
@@ -124,25 +124,22 @@ class PathBuilder {
 
   // Joins the given sub_path to this builder.
   // The sub_path must use slashes as path separators.
-  void joinSlashPath(const std::string& sub_path) {
+  void join_slash_path(const std::string& sub_path) {
     if (sub_path.empty()) return;
-    size_t last_start = 0;
-    size_t pos = 0;
-    if (sub_path[0] == '/') {
-      join("/");
-      last_start = 1;
-    }
-    while (pos < sub_path.size()) {
-      if (sub_path[pos] == '/') {
-        if (pos > last_start) {
-          join(sub_path.substr(last_start, pos - last_start));
-        }
-        last_start = pos + 1;
+    size_t start_pos = 0;
+    while (start_pos < sub_path.size()) {
+      auto slash_pos = sub_path.find_first_of('/', start_pos);
+      if (slash_pos == std::string::npos) {
+        // No more slashes, use the rest of the string.
+        slash_pos = sub_path.size();
       }
-      pos++;
-    }
-    if (pos > last_start) {
-      join(sub_path.substr(last_start, pos - last_start));
+      // For absolute paths we need to add the leading "/".
+      if (slash_pos == 0 && buffer_.empty()) {
+        buffer_ += fs_->path_separator();
+      } else if (slash_pos > start_pos) {
+        join(sub_path.substr(start_pos, slash_pos - start_pos));
+      }
+      start_pos = slash_pos + 1;
     }
   }
 

--- a/src/compiler/util.h
+++ b/src/compiler/util.h
@@ -136,7 +136,7 @@ class PathBuilder {
       // For absolute paths we need to add the leading "/".
       if (slash_pos == 0 && buffer_.empty()) {
         buffer_ += fs_->path_separator();
-      } else if (slash_pos > start_pos) {
+      } else {
         join(sub_path.substr(start_pos, slash_pos - start_pos));
       }
       start_pos = slash_pos + 1;

--- a/src/compiler/util.h
+++ b/src/compiler/util.h
@@ -122,6 +122,30 @@ class PathBuilder {
     join(segment4);
   }
 
+  // Joins the given sub_path to this builder.
+  // The sub_path must use slashes as path separators.
+  void joinSlashPath(const std::string& sub_path) {
+    if (sub_path.empty()) return;
+    size_t last_start = 0;
+    size_t pos = 0;
+    if (sub_path[0] == '/') {
+      join("/");
+      last_start = 1;
+    }
+    while (pos < sub_path.size()) {
+      if (sub_path[pos] == '/') {
+        if (pos > last_start) {
+          join(sub_path.substr(last_start, pos - last_start));
+        }
+        last_start = pos + 1;
+      }
+      pos++;
+    }
+    if (pos > last_start) {
+      join(sub_path.substr(last_start, pos - last_start));
+    }
+  }
+
   void canonicalize();
 
  private:


### PR DESCRIPTION
On Windows we were joining a local path (`..\foo`) to a filesystem that was using slashes (the LSP filesystem). This lead to the path not being correctly canonicalized.