### PR TITLE
Use the last '.packages' as project root.

### DIFF
--- a/tools/lsp/server/project-uri.toit
+++ b/tools/lsp/server/project-uri.toit
@@ -31,7 +31,7 @@ compute-project-uri --uri/string --translator/UriPathTranslator -> string:
 
   slash-dir := dir.replace --all "\\" "/"
   segments := slash-dir.split "/"
-  dot-packages-index := segments.index-of ".packages"
+  dot-packages-index := segments.index-of --last ".packages"
 
   if dot-packages-index != -1:
     // We don't even check whether there is a package.yaml|lock file.

--- a/tools/toitlsp/lsp/project_uri.go
+++ b/tools/toitlsp/lsp/project_uri.go
@@ -27,9 +27,9 @@ import (
 func computeProjectURI(documentUri lsp.DocumentURI) (lsp.DocumentURI, error) {
 	path := uri.URIToPath(documentUri)
 	segments := strings.Split(filepath.ToSlash(path), "/")
-	// Find the first '.packages' segment. We assume that the project root is
+	// Find the last '.packages' segment. We assume that the project root is
 	// the parent of this segment.
-	for i := 0; i < len(segments); i++ {
+	for i := len(segments) - 1; i >= 0; i-- {
 		if segments[i] == ".packages" {
 			// We don't even check whether there is a package.yaml|lock file.
 			// We just assume that this is the project uri.


### PR DESCRIPTION
If we run `toit.pkg install` inside the .packages directory we now see the installed files.

Pretty much a corner case that shouldn't be super important, but this feels more correct.