### PR TITLE
Only report package diagnostics when the file is opened.

### DIFF
--- a/tests/lsp/package-warnings-compiler-test.toit
+++ b/tests/lsp/package-warnings-compiler-test.toit
@@ -1,0 +1,45 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import .lsp-client show LspClient run-client-test
+import expect show *
+import host.directory
+import host.file
+
+main args:
+  foo-path := "$directory.cwd/package-warnings/foo.toit"
+  pkg1-path := "$directory.cwd/package-warnings/.packages/pkg1/src/pkg1.toit"
+
+  expect (file.is-file foo-path)
+  expect (file.is-file pkg1-path)
+
+  2.repeat:
+    should-report := it == 0
+    pre-initializer := : | client/LspClient initialize-params/Map |
+      client.configuration["reportPackageDiagnostics"] = should-report
+
+    run-client-test args --pre-initialize=pre-initializer:
+      test it foo-path pkg1-path --should-report=should-report
+    run-client-test --use-toitlsp args --pre-initialize=pre-initializer:
+      test it foo-path pkg1-path --should-report=should-report
+
+test client/LspClient foo-path/string pkg1-path/string --should-report/bool:
+  client.send-did-open --path=foo-path
+  diagnostics := client.diagnostics-for --path=pkg1-path
+  if should-report:
+    expect-equals 1 diagnostics.size
+  else:
+    expect-null diagnostics
+
+  client.send-did-open --path=pkg1-path
+  // When opened directly, the pkg1-path always has errors.
+  diagnostics = client.diagnostics-for --path=pkg1-path
+  expect-equals 1 diagnostics.size
+
+  client.send-did-close --path=pkg1-path
+  // When closed, the pkg1-path falls back to the original setting.
+  diagnostics = client.diagnostics-for --path=pkg1-path
+  expect-equals (should-report ? 1 : 0) diagnostics.size
+
+

--- a/tests/lsp/package-warnings/README.md
+++ b/tests/lsp/package-warnings/README.md
@@ -1,0 +1,1 @@
+Note that this directory contains a .packages folder with the actual test.

--- a/tests/lsp/package-warnings/foo.toit
+++ b/tests/lsp/package-warnings/foo.toit
@@ -1,0 +1,8 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import pkg1
+
+main:
+  pkg1.foo

--- a/tests/lsp/package-warnings/package.lock
+++ b/tests/lsp/package-warnings/package.lock
@@ -1,0 +1,5 @@
+prefixes:
+  pkg1: pkg1
+packages:
+  pkg1:
+    path: .packages/pkg1

--- a/tools/toitlsp/lsp/request.go
+++ b/tools/toitlsp/lsp/request.go
@@ -32,31 +32,34 @@ const (
 
 type WorkspaceSettings struct {
 	// TODO(jesper): each connection should have its on logger changed on the verbose.
-	Verbose                 bool          `json:"verbose"`
-	ShouldWriteReproOnCrash bool          `json:"shouldWriteReproOnCrash"`
-	Timeout                 time.Duration `json:"timeout"`
-	SDKPath                 string        `json:"sdkPath"`
-	ToitcPath               string        `json:"toitcPath"`
-	ReproDirectory          string        `json:"reproDir"`
+	Verbose                        bool          `json:"verbose"`
+	ShouldWriteReproOnCrash        bool          `json:"shouldWriteReproOnCrash"`
+	ShouldReportPackageDiagnostics bool          `json:"reportPackageDiagnostics"`
+	Timeout                        time.Duration `json:"timeout"`
+	SDKPath                        string        `json:"sdkPath"`
+	ToitcPath                      string        `json:"toitcPath"`
+	ReproDirectory                 string        `json:"reproDir"`
 }
 
 type parseWorkspaceSettings struct {
-	Verbose                 bool   `json:"verbose"`
-	ShouldWriteReproOnCrash bool   `json:"shouldWriteReproOnCrash"`
-	TimeoutMs               *int   `json:"timeoutMs"`
-	SDKPath                 string `json:"sdkPath"`
-	ToitcPath               string `json:"toitcPath"`
-	ReproDirectory          string `json:"reproDir"`
+	Verbose                        bool   `json:"verbose"`
+	ShouldWriteReproOnCrash        bool   `json:"shouldWriteReproOnCrash"`
+	ShouldReportPackageDiagnostics bool   `json:"reportPackageDiagnostics"`
+	TimeoutMs                      *int   `json:"timeoutMs"`
+	SDKPath                        string `json:"sdkPath"`
+	ToitcPath                      string `json:"toitcPath"`
+	ReproDirectory                 string `json:"reproDir"`
 }
 
 func (s parseWorkspaceSettings) WorkspaceSettings() *WorkspaceSettings {
 	res := &WorkspaceSettings{
-		Verbose:                 s.Verbose,
-		ShouldWriteReproOnCrash: s.ShouldWriteReproOnCrash,
-		Timeout:                 defaultTimeout,
-		SDKPath:                 s.SDKPath,
-		ToitcPath:               s.ToitcPath,
-		ReproDirectory:          defaultReproDir,
+		Verbose:                        s.Verbose,
+		ShouldWriteReproOnCrash:        s.ShouldWriteReproOnCrash,
+		ShouldReportPackageDiagnostics: s.ShouldReportPackageDiagnostics,
+		Timeout:                        defaultTimeout,
+		SDKPath:                        s.SDKPath,
+		ToitcPath:                      s.ToitcPath,
+		ReproDirectory:                 defaultReproDir,
 	}
 
 	if s.TimeoutMs != nil {


### PR DESCRIPTION
Or if the user selected the "reportPackageDiagnostics".