### PR TITLE
Fix yaml parser.

### DIFF
--- a/lib/encoding/yaml/encoder.toit
+++ b/lib/encoding/yaml/encoder.toit
@@ -29,11 +29,11 @@ class YamlEncoder extends EncoderBase_:
     // To determine if the str needs to be double quoted, we try to parse it, and if it comes back as a string,
     // then the string can be written in yaml as an unquoted string, i.e "foo" and "bar" does not need to be quoted,
     // but "[a" and "{a" does.
-    // Multuline strings will also be quoted even though not strictly nescessay in all cases, but will be done
+    // Multiline strings will also be quoted even though not strictly nescessay in all cases, but will be done
     // for simplicity.
-    should_quote := not (parse --on-error=(: null) str) is string or
-                    str.contains "\n" or
-                    str.contains "\r"
+    should_quote := str.contains "\n" or
+                    str.contains "\r" or
+                    not (parse --on-error=(: null) str) is string
 
     escaped := escape-string str
 

--- a/lib/encoding/yaml/encoder.toit
+++ b/lib/encoding/yaml/encoder.toit
@@ -29,7 +29,7 @@ class YamlEncoder extends EncoderBase_:
     // To determine if the str needs to be double quoted, we try to parse it, and if it comes back as a string,
     // then the string can be written in yaml as an unquoted string, i.e "foo" and "bar" does not need to be quoted,
     // but "[a" and "{a" does.
-    // Multiline strings will also be quoted even though not strictly nescessay in all cases, but will be done
+    // Multiline strings will also be quoted even though not strictly necessary in all cases, but will be done
     // for simplicity.
     should_quote := str.contains "\n" or
                     str.contains "\r" or

--- a/lib/encoding/yaml/parser.toit
+++ b/lib/encoding/yaml/parser.toit
@@ -691,10 +691,11 @@ class Parser_ extends PegParserBase_:
     return null
 
   c-l-block-seq-entry n/int -> ValueNode_?:
-    return try-parse:
-      match-char C-SEQUENCE-ENTRY_ and
-         (lookahead: not ns-char) and
-         s-l-plus-block-indented n BLOCK-IN_
+    try-parse:
+      if match-char C-SEQUENCE-ENTRY_ and
+          (lookahead: not ns-char):
+        return s-l-plus-block-indented n BLOCK-IN_
+    return null
 
   s-l-plus-block-indented n/int c/int -> ValueNode_?:
     try-parse:
@@ -1334,7 +1335,7 @@ class Parser_ extends PegParserBase_:
 
   nb-ns-double-in-line -> string:
     runes/List := []
-    repeat: 
+    repeat:
       white := repeat: s-white
       rune := ns-double-char
       if rune:

--- a/tests/yaml-test.toit
+++ b/tests/yaml-test.toit
@@ -65,6 +65,7 @@ test-stringify:
   expect-equals "a:\nb:\n" (yaml.stringify {"a":  null, "b": null})
   expect-equals """- a\n""" (yaml.stringify ["a"])
   expect-equals """- a\n- b\n""" (yaml.stringify ["a","b"])
+  expect-equals "- -O0\n" (yaml.stringify ["-O0"])
 
   expect-equals "\"\\\\ \\b \\f \\n \\r \\t\"" (yaml.stringify "\\ \b \f \n \r \t")
 
@@ -234,6 +235,7 @@ test-json-parse:
   expect-equals "a: b\n" (yaml.stringify (yaml.parse "{\"a\":\"b\"}"))
   expect-equals "a: b\n" (yaml.stringify (yaml.parse " { \"a\" : \"b\" } "))
   expect-equals "- a\n- b\n" (yaml.stringify (yaml.parse " [ \"a\" , \"b\" ] "))
+  expect-equals "- -O0\n" (yaml.stringify (yaml.parse "[\"-O0\"]"))
 
   expect-equals "=\"\\/bfnrt"
       (yaml.parse "\"\\u003d\\u0022\\u005c\\u002F\\u0062\\u0066\\u006e\\u0072\\u0074\"")
@@ -296,6 +298,7 @@ test-encode:
 
 test-decode:
   expect-equals "testing" (yaml.decode "testing".to-byte-array)
+  expect-list-equals ["-O0"] (yaml.decode """["-O0"]""".to-byte-array)
 
 BIG-JSON ::= """
 [


### PR DESCRIPTION
The parser was failing on "list-like" elements with the following trace:
```
As check failed: a bool (false) is not a ValueNode_.
  0: Parser_.c-l-block-seq-entry <sdk>/encoding/yaml/parser.toit:694:5
  1: Parser_.l-plus-block-sequence.<block> <sdk>/encoding/yaml/parser.toit:671:21
  2: PegParserBase_.try-parse  <sdk>/encoding/yaml/parser.toit:211:20
  3: Parser_.try-parse         <sdk>/encoding/yaml/parser.toit:409:16
...
```