### PR TITLE
Yaml parse value conversion fix

### DIFF
--- a/lib/encoding/yaml/parser.toit
+++ b/lib/encoding/yaml/parser.toit
@@ -85,7 +85,8 @@ STANDARD_INT_TAG_   ::= "!!int"
 class ValueNode_:
   tag/string? := null
   value/any
-  constructor .value:
+  force-string/bool
+  constructor .value --.force-string=false:
 
   constructor.map-from-collection list/List:
     // Assume list is alternating [key1, value1, key2, value2, ...]
@@ -95,6 +96,7 @@ class ValueNode_:
       key_ := list[2 * it]
       value_ :=  list[2 * it + 1]
       value[key_] = value_
+    force-string = false
 
   // Either use the supplied tag to construct a toit object representing the value or use
   // the core schema tag resolution
@@ -116,7 +118,7 @@ class ValueNode_:
   canonical-value -> any:
     if this == EMPTY-NODE_: return null
 
-    if value is string:
+    if value is string and not force-string:
       if NULL.contains value: return null
       if TRUE.contains value: return true
       if FALSE.contains value: return false
@@ -1261,7 +1263,7 @@ class Parser_ extends PegParserBase_:
       if match-char C-SINGLE-QUOTE_:
         if res := nb-single-text n c:
           if match-char C-SINGLE-QUOTE_:
-            return ValueNode_ (res.replace --all "''" "'")
+            return ValueNode_ (res.replace --all "''" "'") --force-string
     return null
 
   c-double-quoted n/int c/int -> ValueNode_?:
@@ -1269,7 +1271,7 @@ class Parser_ extends PegParserBase_:
       if match-char C-DOUBLE-QUOTE_:
         if res := nb-double-text n c:
           if match-char C-DOUBLE-QUOTE_:
-            return ValueNode_ (res.join "")
+            return ValueNode_ (res.join "") --force-string
     return null
 
   nb-single-text n/int c/int -> string?:

--- a/tests/yaml-test.toit
+++ b/tests/yaml-test.toit
@@ -20,6 +20,7 @@ main:
   test-block-parse
   test-from-spec
   test-stream
+  test-value-converter
 
 test-stringify:
   expect-equals "testing" (yaml.stringify "testing")
@@ -540,6 +541,19 @@ test-from-spec:
                 # Comment
                """
 
+test-value-converter:
+  result := yaml.parse
+      """
+      float: 1.0
+      int: 4
+      float-as-string: "1.0"
+      int-as-string: "4"
+      """
+
+  expect result["float"] is float
+  expect result["int"] is int
+  expect result["float-as-string"] is string
+  expect result["int-as-string"] is string
 
 class TestReader implements Reader:
   pos := 0


### PR DESCRIPTION
Fixed a situation where the automatic value conversion would convert "1.1" to a float and "5" to a int and not keep them as string.