### PR TITLE
Add more debug information.

### DIFF
--- a/tests/strip/throw-test.toit
+++ b/tests/strip/throw-test.toit
@@ -18,10 +18,14 @@ main args:
 
     non-stripped-snapshot := variants[0]
     output := backticks-failing [runner, non-stripped-snapshot]
+    print "Variant 0:"
+    print output
     expect (output.contains EXPECTED-EXCEPTION-OUTPUT)
     expect (output.contains ".toit")  // At least on stack trace frame.
 
     variants[1..].do:
       output = backticks-failing [runner, it]
+      print "Variant $it:"
+      print output
       expect (output.contains EXPECTED-EXCEPTION-OUTPUT)
       expect-not (output.contains ".toit")


### PR DESCRIPTION
The throw-test failed on the build-bot.
Adding more debug printing.