### PR TITLE
Add more syntax.

### DIFF
--- a/tests/syntax-test.toit
+++ b/tests/syntax-test.toit
@@ -37,6 +37,8 @@ export global-x
 export global-x global-y
 export *
 
+import .syntax as as-prefix
+
 import-foo:
 show-foo:
 


### PR DESCRIPTION
Add an example of 'as', which was broken: https://github.com/toitware/ide-tools/issues/246