### PR TITLE
Add a test-range when a completion prefix ends with '-'

### DIFF
--- a/src/compiler/compiler.cc
+++ b/src/compiler/compiler.cc
@@ -1041,15 +1041,16 @@ Source* CompletionPipeline::_load_file(const char* path, const PackageLock& pack
   }
 
   if (start_offset == offset || !IdentifierValidator::is_identifier_start(text[start_offset])) {
-    handler()->set_prefix(Symbols::empty_string);
+    handler()->set_and_emit_prefix(Symbols::empty_string, result->range(start_offset, start_offset));
   } else {
+    auto range = result->range(start_offset, offset);
     int len = offset - start_offset;
     auto dash_canonicalized = IdentifierValidator::canonicalize(&text[start_offset], len);
     auto canonicalized = symbol_canonicalizer()->canonicalize_identifier(dash_canonicalized, &dash_canonicalized[len]);
     if (canonicalized.kind == Token::Kind::IDENTIFIER) {
-      handler()->set_prefix(canonicalized.symbol);
+      handler()->set_and_emit_prefix(canonicalized.symbol, range);
     } else {
-      handler()->set_prefix(Token::symbol(canonicalized.kind));
+      handler()->set_and_emit_prefix(Token::symbol(canonicalized.kind), range);
     }
   }
   return result;

--- a/src/compiler/diagnostic.cc
+++ b/src/compiler/diagnostic.cc
@@ -284,7 +284,7 @@ bool LanguageServerAnalysisDiagnostics::emit(Severity severity,
                                              const char* format,
                                              va_list& arguments) {
   lsp()->diagnostics()->emit(severity,
-                             range_to_lsp_range(range, source_manager()),
+                             range_to_lsp_location(range, source_manager()),
                              format,
                              arguments);
   return true;

--- a/src/compiler/lsp/completion.cc
+++ b/src/compiler/lsp/completion.cc
@@ -26,7 +26,15 @@ namespace toit {
 namespace compiler {
 
 void CompletionHandler::terminate() {
+  ASSERT(prefix_.is_valid());
   exit(0);
+}
+
+void CompletionHandler::set_and_emit_prefix(Symbol prefix, const Source::Range& range) {
+  ASSERT(!prefix_.is_valid());
+  prefix_ = prefix;
+  protocol()->completion()->emit_prefix(prefix.c_str());
+  protocol()->completion()->emit_prefix_range(range_to_lsp_range(range, source_manager_));
 }
 
 void CompletionHandler::class_interface_or_mixin(ast::Node* node,
@@ -478,10 +486,10 @@ void CompletionHandler::complete_if_visible(Symbol name,
 }
 
 void CompletionHandler::complete(const std::string& name, CompletionKind kind) {
-  if (emitted.contains(name)) return;
+  if (emitted_.contains(name)) return;
   // Filter out completions that don't match the prefix.
   if (strncmp(name.c_str(), prefix_.c_str(), strlen(prefix_.c_str())) != 0) return;
-  emitted.insert(name);
+  emitted_.insert(name);
   protocol()->completion()->emit(name, kind);
 }
 

--- a/src/compiler/lsp/completion.h
+++ b/src/compiler/lsp/completion.h
@@ -36,10 +36,7 @@ class CompletionHandler : public LspSelectionHandler {
       : LspSelectionHandler(protocol)
       , source_manager_(source_manager) {}
 
-  void set_prefix(Symbol prefix) {
-    ASSERT(!prefix_.is_valid());
-    prefix_ = prefix;
-  }
+  void set_and_emit_prefix(Symbol prefix, const Source::Range& range);
 
   void set_package_id(const std::string& package_id) {
     package_id_ = package_id;
@@ -124,7 +121,7 @@ class CompletionHandler : public LspSelectionHandler {
   Symbol prefix_ = Symbol::invalid();
   std::string package_id_ = std::string(Package::INVALID_PACKAGE_ID);
   SourceManager* source_manager_;
-  UnorderedSet<std::string> emitted;
+  UnorderedSet<std::string> emitted_;
 };
 
 } // namespace toit::compiler

--- a/src/compiler/lsp/goto_definition.cc
+++ b/src/compiler/lsp/goto_definition.cc
@@ -27,7 +27,7 @@ void GotoDefinitionHandler::terminate() {
 void GotoDefinitionHandler::_print_range(Source::Range range) {
   if (printed_definitions_.contains(range)) return;
   printed_definitions_.insert(range);
-  protocol()->goto_definition()->emit(range_to_lsp_range(range, source_manager_));
+  protocol()->goto_definition()->emit(range_to_lsp_location(range, source_manager_));
 }
 
 void GotoDefinitionHandler::_print_range(ir::Node* resolved) {
@@ -304,12 +304,14 @@ void GotoDefinitionHandler::import_path(const char* path,
                                         const PackageLock& package_lock,
                                         Filesystem* fs) {
   if (resolved != null) {
-    auto import_range = LspRange {
+    auto import_range = LspLocation {
       .path = resolved,
-      .from_line = 0,
-      .from_column= 0,
-      .to_line= 0,
-      .to_column = 0,
+      .range = {
+        .from_line = 0,
+        .from_column= 0,
+        .to_line= 0,
+        .to_column = 0,
+      },
     };
     protocol()->goto_definition()->emit(import_range);
   }

--- a/tests/lsp/cancel-compiler-test.toit
+++ b/tests/lsp/cancel-compiler-test.toit
@@ -36,7 +36,7 @@ test client/LspClient:
   cancel-succeeded := false
   while sleep-amount < 1000_000:
     mock-compiler.set-completion-result
-      "SLOW\n$sleep-amount\nfoo\n-1\nbar\n-1\n"
+      "SLOW\n$sleep-amount\n\n0\n0\n0\n0\nfoo\n-1\nbar\n-1\n"
     client.wait-for-idle
 
     completions := client.send-completion-request --uri=uri 1 2 --id-callback=:
@@ -55,7 +55,7 @@ test client/LspClient:
 
   // Now try to cancel a request where we were too slow for the cancel.
   mock-compiler.set-completion-result
-    "foo\n-1\nbar\n-1\n"
+    "\n0\n0\n0\n0\nfoo\n-1\nbar\n-1\n"
   id := null
   completions := client.send-completion-request --uri=uri 1 2 --id-callback=:
     id = it

--- a/tools/lsp/server/compiler.toit
+++ b/tools/lsp/server/compiler.toit
@@ -236,21 +236,39 @@ class Compiler:
       latch.set (completed-successfully ? result : null)
     return latch.get
 
-  complete --project-uri/string? uri/string line-number/int column-number/int -> List/*<string>*/:
+  /**
+  Gets all the completion from the compiler and calls the given $block
+    with a prefix, a prefix-range and a list of completions.
+  If not completions are found, the block is called with the empty string and
+    and empty list.
+  */
+  complete -> none
+      --project-uri/string?
+      uri/string
+      line-number/int
+      column-number/int
+      [block]:
     path := uri-path-translator_.to-path uri --to-compiler
     // We don't care if the compiler crashed.
     // Just send whatever completions we get.
     run --project-uri=project-uri
         --compiler-input="COMPLETE\n$path\n$line-number\n$column-number\n":
       |reader /BufferedReader|
-      suggestions := []
+      prefix := reader.read-line
+      if not prefix:
+        block.call "" null []
+        return
+      edit-range := read-range reader
 
+      suggestions := []
       while true:
         line := reader.read-line
         if line == null: break
         kind := int.parse reader.read-line
         suggestions.add (CompletionItem --label=line --kind=kind)
-      return suggestions
+
+      block.call prefix edit-range suggestions
+      return
     unreachable
 
   goto-definition --project-uri/string? uri/string line-number/int column-number/int -> List/*<Location>*/:

--- a/tools/lsp/server/protocol/completion.toit
+++ b/tools/lsp/server/protocol/completion.toit
@@ -77,3 +77,38 @@ class CompletionItem extends MapWrapper:
       --kind  /int:
     map_["label"] = label
     if kind != -1: map_["kind"] = kind
+
+  set-text-edit edit/TextEdit: map_["textEdit"] = edit
+  label -> string: return at_ "label"
+
+/**
+A collection of $CompletionItem elements.
+*/
+class CompletionList extends MapWrapper:
+  /**
+  Creates a completion-list.
+
+  If $is-incomplete is true, indicates that the completion list is not complete.
+  */
+  constructor
+      --items         /List  // of CompletionItem
+      --is-incomplete /bool = false
+      --item-defaults /CompletionItemDefaults?:
+    map_["items"] = items
+    if is-incomplete: map_["isIncomplete"] = is-incomplete
+    if item-defaults: map_["itemDefaults"] = item-defaults
+
+/**
+Properties that are shared among many completion items, and are
+the default if not overridden by the individual completion items.
+*/
+class CompletionItemDefaults extends MapWrapper:
+  /**
+  Creates a new instance.
+
+  The $edit-range specifies the range of the document that should be replaced by
+    the completion item. It's the "prefix" of the completion items.
+  */
+  constructor
+      --edit-range /Range?:
+    if edit-range: map_["editRange"] = edit-range

--- a/tools/lsp/server/protocol/document.toit
+++ b/tools/lsp/server/protocol/document.toit
@@ -193,3 +193,13 @@ class TextDocumentPositionParams extends MapWrapper:
   */
   position -> Position:
     return at_ "position": Position.from-map it
+
+/**
+A textual edit applicable to a text document.
+*/
+class TextEdit extends MapWrapper:
+  constructor
+      --range/Range
+      --new-text/string:
+    map_["range"]    = range.map_
+    map_["newText"]  = new-text

--- a/tools/lsp/server/protocol/initialization.toit
+++ b/tools/lsp/server/protocol/initialization.toit
@@ -15,6 +15,7 @@
 
 import ..rpc
 import .experimental
+import .completion show CompletionList // For Toitdoc.
 
 class WorkspaceEditCapabilities extends MapWrapper:
   constructor json-map/Map: super json-map
@@ -244,6 +245,19 @@ class CompletionItemKindCapabilities extends MapWrapper:
   value-set -> List?/*<int>*/:
     return lookup_ "valueSet"
 
+class CompletionListCapabilities extends MapWrapper:
+  constructor json-map/Map: super json-map
+
+  /**
+  The list of item-defaults the client supports in the
+    $CompletionList'.item-defaults' object.
+
+  In null, then no properties are supported.
+  */
+  item-defaults -> List?:
+    return lookup_ "itemDefaults"
+
+
 class CompletionCapabilities extends DynamicRegistrationCapability:
   constructor json-map/Map: super json-map
 
@@ -262,6 +276,9 @@ class CompletionCapabilities extends DynamicRegistrationCapability:
   */
   context-support -> bool?:
     return lookup_ "contextSupport"
+
+  completion-list -> CompletionListCapabilities?:
+    return lookup_ "completionList": CompletionListCapabilities it
 
 class HoverCapabilities extends DynamicRegistrationCapability:
   constructor json-map/Map: super json-map

--- a/tools/lsp/server/server.toit
+++ b/tools/lsp/server/server.toit
@@ -315,7 +315,7 @@ class LspServer:
       | prefix/string edit-range/Range? completions/List |
       if completions.is-empty: return completions
       if not prefix.ends-with "-": return completions
-      // The prefix ends with a '-'. Vscode doesn't like that and assumes that any completion we
+      // The prefix ends with a '-'. VS Code doesn't like that and assumes that any completion we
       // give is a new word. We therefore either adda default-range, or run through all
       // completions and add a textEdit.
       if client-supports-completion-range_:

--- a/tools/toitlsp/go.mod
+++ b/tools/toitlsp/go.mod
@@ -29,4 +29,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/sourcegraph/go-lsp => github.com/toitware/go-lsp v0.0.0-20210105143647-eaf37e31f21d
+replace github.com/sourcegraph/go-lsp => github.com/toitware/go-lsp v0.0.0-20240220075859-6b0ca01316f0

--- a/tools/toitlsp/go.sum
+++ b/tools/toitlsp/go.sum
@@ -40,6 +40,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/toitware/go-lsp v0.0.0-20210105143647-eaf37e31f21d h1:LgycHUFf6qzsuwcmprJdEXW7SiJK9QpyWB6rL2z1Gs4=
 github.com/toitware/go-lsp v0.0.0-20210105143647-eaf37e31f21d/go.mod h1:n6X1+PsbSFrScLxBW773zbAfqOz4mhUR5tzk8kvJwCc=
+github.com/toitware/go-lsp v0.0.0-20240220075859-6b0ca01316f0 h1:fKjlrh/svv727YIOfMjyJ8PjHKyQUJ8cjaikU2Nl5sM=
+github.com/toitware/go-lsp v0.0.0-20240220075859-6b0ca01316f0/go.mod h1:n6X1+PsbSFrScLxBW773zbAfqOz4mhUR5tzk8kvJwCc=
 go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/dig v1.7.0 h1:E5/L92iQTNJTjfgJF2KgU+/JpMaiuvK2DHLBj0+kSZk=

--- a/tools/toitlsp/lsp/compiler/compiler.go
+++ b/tools/toitlsp/lsp/compiler/compiler.go
@@ -165,7 +165,7 @@ func (c *Compiler) GotoDefinition(ctx context.Context, projectURI lsp.DocumentUR
 	return res.result, res.err
 }
 
-func (c *Compiler) Complete(ctx context.Context, projectURI lsp.DocumentURI, docURI lsp.DocumentURI, position lsp.Position) ([]lsp.CompletionItem, error) {
+func (c *Compiler) Complete(ctx context.Context, projectURI lsp.DocumentURI, docURI lsp.DocumentURI, position lsp.Position) (string, *lsp.Range, []lsp.CompletionItem, error) {
 	ctx, cancel := c.ctx(ctx)
 	defer cancel()
 
@@ -173,17 +173,19 @@ func (c *Compiler) Complete(ctx context.Context, projectURI lsp.DocumentURI, doc
 
 	var res struct {
 		err    error
+		prefix string
+		range_ *lsp.Range
 		result []lsp.CompletionItem
 	}
 
 	err := c.run(ctx, projectURI, fmt.Sprintf("COMPLETE\n%s\n%d\n%d\n", path, position.Line, position.Character), func(ctx context.Context, stdout io.Reader) {
-		res.result, res.err = c.parser.CompleteOutput(stdout)
+		res.prefix, res.range_, res.result, res.err = c.parser.CompleteOutput(stdout)
 	})
 	if err != nil {
-		return nil, err
+		return "", nil, nil, err
 	}
 
-	return res.result, res.err
+	return res.prefix, res.range_, res.result, res.err
 }
 
 func (c *Compiler) SemanticTokens(ctx context.Context, projectURI lsp.DocumentURI, docURI lsp.DocumentURI) (*lsp.SemanticTokens, error) {

--- a/tools/toitlsp/lsp/conn.go
+++ b/tools/toitlsp/lsp/conn.go
@@ -60,13 +60,14 @@ type connection struct {
 type callbackFunc func(ctx context.Context, conn *jsonrpc2.Conn)
 
 type ConnContext struct {
-	SupportsConfiguration bool
-	LastCrashReport       time.Time
-	RootURI               lsp.DocumentURI
-	Verbose               bool
-	Settings              *WorkspaceSettings
-	Documents             *Documents
-	ReadySignal           chan struct{}
+	SupportsConfiguration          bool
+	SupportsCompletionDefaultRange bool
+	LastCrashReport                time.Time
+	RootURI                        lsp.DocumentURI
+	Verbose                        bool
+	Settings                       *WorkspaceSettings
+	Documents                      *Documents
+	ReadySignal                    chan struct{}
 
 	NextAnalysisRevision int
 }

--- a/tools/toitlsp/lsp/handlers.go
+++ b/tools/toitlsp/lsp/handlers.go
@@ -53,6 +53,12 @@ func (s *Server) Initialize(ctx context.Context, conn *jsonrpc2.Conn, req lsp.In
 	if req.RootURI != "" {
 		cCtx.RootURI = uri.Canonicalize(req.RootURI)
 	}
+	for _, v := range req.Capabilities.TextDocument.Completion.CompletionList.ItemDefaults {
+		if v == "editRange" {
+			cCtx.SupportsCompletionDefaultRange = true
+			break
+		}
+	}
 	s.SetContext(conn, cCtx)
 	return &lsp.InitializeResult{
 		Capabilities: lsp.ServerCapabilities{
@@ -142,7 +148,9 @@ func (s *Server) Cancel(ctx context.Context, conn *jsonrpc2.Conn, req lsp.Cancel
 
 // reflectHandler promotes a generic function into a handlerFunc.
 // It assumes a function on the type:
-//  func(ctx context.Context,conn *jsonrpc2.Conn, [param Any], [req *jsonrpc2.Request]) ([result Any],  errr error)
+//
+//	func(ctx context.Context,conn *jsonrpc2.Conn, [param Any], [req *jsonrpc2.Request]) ([result Any],  errr error)
+//
 // if a specific type is used for param the req.Params will be json unmarshalled into the type of param.
 func reflectHandler(fn interface{}) (handleFunc, error) {
 	rv := reflect.ValueOf(fn)


### PR DESCRIPTION
Vscode would complete 'foo-' (with completion 'foo-bar') to 'foo-foo-bar'. By adding a range it correctly replaces the prefix.