### PR TITLE
Replace code accidentally removed from ESP32 mem management

### DIFF
--- a/src/third_party/dartino/object_memory.cc
+++ b/src/third_party/dartino/object_memory.cc
@@ -231,9 +231,29 @@ void Chunk::find(uword word, const char* name) {
 #endif
 
 Chunk* ObjectMemory::allocate_chunk(Space* owner, uword size) {
+#ifdef TOIT_FREERTOS
+  static const int UNUSABLE_SIZE = 50;
+  void* unusable_pages[UNUSABLE_SIZE];
+  size = Utils::round_up(size, TOIT_PAGE_SIZE);
+  uword lowest = GcMetadata::lowest_old_space_address();
+  for (int i = 0; i < UNUSABLE_SIZE; i++) {
+    void* memory = OS::allocate_pages(size);
+    if (memory == null ||
+        (GcMetadata::in_metadata_range(memory) &&
+         GcMetadata::in_metadata_range(reinterpret_cast<uword>(memory) + size - 1))) {
+      for (int j = 0; j < i; j++) OS::free_pages(unusable_pages[j], size);
+      return allocate_chunk_helper(owner, size, memory);
+    }
+    unusable_pages[i] = memory;
+  }
+  printf("New allocation %p-%p\n", unusable_pages[0], unvoid_cast<char*>(unusable_pages[0]) + size);
+  printf("Metadata range %p-%p\n", reinterpret_cast<void*>(lowest), reinterpret_cast<uint8*>(lowest) + GcMetadata::heap_extent());
+  FATAL("Toit heap outside expected range");
+#else
   void* memory = OS::allocate_pages(Utils::round_up(size, TOIT_PAGE_SIZE));
   if (!memory) return null;
   return allocate_chunk_helper(owner, size, memory);
+#endif
 }
 
 Chunk* ObjectMemory::allocate_chunk_helper(Space* owner, uword size, void* memory) {


### PR DESCRIPTION
This just puts exactly the code that was previously there.
There may be room for improvement.