### PR TITLE
Add debug  information.

### DIFF
--- a/tests/strip/as-fail-test.toit
+++ b/tests/strip/as-fail-test.toit
@@ -23,5 +23,9 @@ main args:
 
     variants[1..].do:
       output = backticks-failing [runner, it]
+      if not output.contains EXPECTED-EXCEPTION-OUTPUT:
+        print "Expected exception '$EXPECTED-EXCEPTION-OUTPUT' not found in output:"
+        print "Output:"
+        print "  $output"
       expect (output.contains EXPECTED-EXCEPTION-OUTPUT)
       expect-not (output.contains ".toit")

--- a/tests/strip/as-fail-test.toit
+++ b/tests/strip/as-fail-test.toit
@@ -25,7 +25,6 @@ main args:
       output = backticks-failing [runner, it]
       if not output.contains EXPECTED-EXCEPTION-OUTPUT:
         print "Expected exception '$EXPECTED-EXCEPTION-OUTPUT' not found in output:"
-        print "Output:"
         print "  $output"
       expect (output.contains EXPECTED-EXCEPTION-OUTPUT)
       expect-not (output.contains ".toit")


### PR DESCRIPTION
The as-fail-test failed on the buildbot. Add more information to debug what went wrong.