### PR TITLE
Faster byte array slices

### DIFF
--- a/lib/core/collections.toit
+++ b/lib/core/collections.toit
@@ -1332,8 +1332,9 @@ abstract class ByteArrayBase_ implements ByteArray:
   abstract operator []= n/int value/int -> int
 
   operator [..] --from/int=0 --to/int=size -> ByteArray:
-    if not 0 <= from <= to <= size: throw "OUT_OF_BOUNDS"
     if from == 0 and to == size: return this
+    // Don't bother checking the bounds, since the ByteArraySlice_
+    // constructor does this.
     return ByteArraySlice_ this from to
 
   /**
@@ -1620,6 +1621,8 @@ class ByteArraySlice_ extends ByteArrayBase_:
   to_ / int
 
   constructor .byte-array_ .from_ .to_:
+    // We must check the bounds because the [..] operator on ByteArray
+    // does not check.
     if not 0 <= from_ <= to_ <= byte-array_.size:
       throw "OUT_OF_BOUNDS"
 

--- a/tests/byte-array-test.toit
+++ b/tests/byte-array-test.toit
@@ -20,7 +20,8 @@ test-warnings:
 main:
   test-basic
   test-warnings
-  test-slices
+  test-slices-succeed
+  test-slices-fail
   test-cow-mutable-byte-content
   test-to-string
   test-hash-code
@@ -125,7 +126,7 @@ test-basic:
   b5 = ByteArray 0
   b5 = #[1 + 1]
 
-test-slices:
+test-slices-succeed:
   for i := 0; i < 4; i++:
     bytes := #[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
     bytes-long := #[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
@@ -183,6 +184,17 @@ test-slices:
     str := slice.to-string
     expect-equals "hello" str
     test-index-of slice
+
+test-slices-fail:
+  cow := #[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+  rw := cow.copy
+  slice := rw[1 .. rw.size - 1]
+
+  [cow, rw, slice].do: | bytes |
+    expect-throw "OUT_OF_BOUNDS": bytes[.. bytes.size + 1]
+    expect-throw "OUT_OF_BOUNDS": bytes[..-1]
+    expect-throw "OUT_OF_BOUNDS": bytes[-1..]
+    expect-throw "OUT_OF_BOUNDS": bytes[1..0]
 
 cow-byte-array := #[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
 test-cow-mutable-byte-content:


### PR DESCRIPTION
This is about 20% on top of the faster instance creation.

Perhaps we can do something similar for strings.