### PR TITLE
Make it easier/possible to change channel for espnow.

### DIFF
--- a/examples/espnow.toit
+++ b/examples/espnow.toit
@@ -15,10 +15,8 @@ import esp32.espnow
 PMK ::= espnow.Key.from-string "pmk1234567890123"
 
 main:
-  service := espnow.Service.station --key=PMK
-  service.add-peer
-      espnow.BROADCAST-ADDRESS
-      --channel=1
+  service := espnow.Service.station --key=PMK --channel=1
+  service.add-peer espnow.BROADCAST-ADDRESS
   task:: send-task service
   task:: receive-task service
 

--- a/lib/esp32/espnow.toit
+++ b/lib/esp32/espnow.toit
@@ -117,7 +117,7 @@ class Service:
 
   The $channel parameter must be a valid Wi-Fi channel number.
   */
-  constructor.station --key/Key? --rate/int?=null --.channel=1:
+  constructor.station --key/Key? --rate/int?=null --.channel=6:
     if not 0 < channel <= 14: throw "INVALID_ARGUMENT"
 
     key-data := key ? key.data : #[]

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -707,7 +707,7 @@ namespace toit {
 
 #define MODULE_ESPNOW(PRIMITIVE)             \
   PRIMITIVE(init, 0)                         \
-  PRIMITIVE(create, 4)                       \
+  PRIMITIVE(create, 5)                       \
   PRIMITIVE(close, 1)                        \
   PRIMITIVE(send, 3)                         \
   PRIMITIVE(send_succeeded, 1)               \

--- a/src/resources/espnow_esp32.cc
+++ b/src/resources/espnow_esp32.cc
@@ -403,7 +403,7 @@ PRIMITIVE(init) {
 }
 
 PRIMITIVE(create) {
-  ARGS(EspNowResourceGroup, group, int, mode, Blob, pmk, int, rate);
+  ARGS(EspNowResourceGroup, group, int, mode, Blob, pmk, int, rate, int, channel);
 
   wifi_phy_rate_t phy_rate = WIFI_PHY_RATE_1M_L;
   if (rate != -1) {
@@ -438,6 +438,11 @@ PRIMITIVE(create) {
 
   group->register_resource(resource);
   proxy->set_external_address(resource);
+
+  esp_err_t err = esp_wifi_set_channel(channel, WIFI_SECOND_CHAN_NONE);
+  if (err != ESP_OK) {
+    return Primitive::os_error(err, process);
+  }
 
   return proxy;
 }

--- a/tests/esp32/espnow1-board1.toit
+++ b/tests/esp32/espnow1-board1.toit
@@ -22,11 +22,9 @@ import expect show *
 import .espnow1-shared
 
 main:
-  service ::= espnow.Service.station --key=PMK
+  service ::= espnow.Service.station --key=PMK --channel=CHANNEL
 
-  service.add-peer
-      espnow.BROADCAST-ADDRESS
-      --channel=CHANNEL
+  service.add-peer espnow.BROADCAST-ADDRESS
 
   print "Listening for messages."
   with-timeout --ms=10_000:

--- a/tests/esp32/espnow1-board2.toit
+++ b/tests/esp32/espnow1-board2.toit
@@ -10,11 +10,9 @@ import esp32.espnow
 import .espnow1-shared
 
 main:
-  service ::= espnow.Service.station --key=PMK
+  service ::= espnow.Service.station --key=PMK --channel=CHANNEL
 
-  service.add-peer
-      espnow.BROADCAST-ADDRESS
-      --channel=CHANNEL
+  service.add-peer espnow.BROADCAST-ADDRESS
 
   TEST-DATA.do:
     service.send


### PR DESCRIPTION
We were seeing "Peer channel is not equal to the home channel" errors.

Also see https://esp32.com/viewtopic.php?t=18291