### PR TITLE
Fix CI dependency for AUR workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1004,7 +1004,7 @@ jobs:
   AUR:
     name: Update AUR package
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [combine]
     if: github.event_name == 'release' &&
         !github.event.release.prerelease &&
         github.repository_owner == 'toitlang'


### PR DESCRIPTION
The AUR dependency needs the combine step to have uploaded the vessels. Otherwise it can't compute the hashsum of the file.