### PR TITLE
Fix service discovery timeout so it works with tags

### DIFF
--- a/lib/system/api/service_discovery.toit
+++ b/lib/system/api/service_discovery.toit
@@ -9,9 +9,9 @@ interface ServiceDiscoveryService:
   static SELECTOR ::= ServiceSelector
       --uuid="dc58d7e1-1b1f-4a93-a9ac-bd45a47d7de8"
       --major=0
-      --minor=3
+      --minor=4
 
-  discover uuid/string --wait/bool -> List?
+  discover uuid/string --wait/bool --tags/List? -> List?
   static DISCOVER-INDEX /int ::= 0
 
   watch pid/int -> none
@@ -38,8 +38,8 @@ class ServiceDiscoveryServiceClient extends ServiceClient implements ServiceDisc
     client := _open_ selector --pid=-1 --id=0  // Hardcoded in system process.
     return client and this
 
-  discover uuid/string --wait/bool -> List?:
-    return invoke_ ServiceDiscoveryService.DISCOVER-INDEX [uuid, wait]
+  discover uuid/string --wait/bool --tags/List? -> List?:
+    return invoke_ ServiceDiscoveryService.DISCOVER-INDEX [uuid, wait, tags]
 
   watch pid/int -> none:
     invoke_ ServiceDiscoveryService.WATCH-INDEX pid

--- a/lib/system/services.toit
+++ b/lib/system/services.toit
@@ -66,9 +66,14 @@ class ServiceSelector:
   is-allowed_ --name/string --major/int --minor/int --tags/List? -> bool:
     return true
 
+  mandatory-tags_ -> List?: return null
+
 class ServiceSelectorRestricted extends ServiceSelector:
   tags_ := {:}    // Map<string, bool>
   names_ ::= {:}  // Map<string, List<ServiceSelectorRestriction_>>
+
+  mandatory-tags_ -> List?:
+    return tags_.keys.filter: tags_[it]
 
   tags-include-allowed_/bool := false
   names-include-allowed_/bool := false
@@ -170,9 +175,9 @@ class ServiceClient:
     discovered/List? := null
     if timeout:
       catch --unwind=(: it != DEADLINE-EXCEEDED-ERROR):
-        with-timeout timeout: discovered = _client_.discover selector.uuid --wait
+        with-timeout timeout: discovered = _client_.discover selector.uuid --wait --tags=selector.mandatory-tags_
     else:
-      discovered = _client_.discover selector.uuid --no-wait
+      discovered = _client_.discover selector.uuid --no-wait --tags=_tags_
     if not discovered: return if-absent.call
 
     candidate-index := null

--- a/system/services.toit
+++ b/system/services.toit
@@ -45,7 +45,7 @@ class SystemServiceManager extends ServiceProvider
   handle index/int arguments/any --gid/int --client/int -> any:
     pid := pid --client=client
     if index == ServiceDiscoveryService.DISCOVER-INDEX:
-      return discover arguments[0] --wait=arguments[1]
+      return discover arguments[0] --wait=arguments[1] --tags=arguments[2]
     if index == ServiceDiscoveryService.WATCH-INDEX:
       return watch pid arguments
     if index == ServiceDiscoveryService.LISTEN-INDEX:
@@ -99,12 +99,16 @@ class SystemServiceManager extends ServiceProvider
     service-managers_.remove pid
     services-by-pid_.remove pid
 
-  discover uuid/string --wait/bool -> List?:
+  discover uuid/string --wait/bool --tags/List? -> List?:
     services/List? := null
     if wait:
       signal_.wait:
         services = services-by-uuid_.get uuid
-        services != null
+        if tags and services:
+          services = services.filter: | service/DiscoverableService |
+            tags.every: | tag/string |
+              service.tags.contains tag
+        services and services.size > 0
     else:
       services = services-by-uuid_.get uuid
       if not services: return null

--- a/tests/services-tags-timeout-test.toit
+++ b/tests/services-tags-timeout-test.toit
@@ -1,0 +1,51 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+// Test that connecting to a service with a tag does not fail if the
+// service is only installed with a different tag.
+
+import system.services show ServiceClient ServiceSelector ServiceResourceProxy
+import system.services show ServiceProvider ServiceHandler ServiceResource
+
+main args/List:
+  2.repeat: | index |
+    spawn::
+      if index == 1:
+        // Index 1 will not be there yet when we ask for it.
+        sleep --ms=1000
+      service := TagTimeoutTestServiceProvider index
+      service.install
+      service.uninstall --wait
+
+  2.repeat: | index |
+    task::
+      client := TagTimeoutTestServiceClient index
+      client.open --timeout=(Duration --s=30)
+      client.close
+
+interface TagTimeoutTestService:
+  static SELECTOR ::= ServiceSelector
+      --uuid="20e698fd-b89a-4964-a0c0-68e90ca37635"
+      --major=1
+      --minor=0
+
+class TagTimeoutTestServiceClient extends ServiceClient implements TagTimeoutTestService:
+  static SELECTOR ::= TagTimeoutTestService.SELECTOR
+
+  constructor index/int:
+    selective-selector := TagTimeoutTestService.SELECTOR.restrict.allow --tag="$index"
+    assert: selective-selector.matches SELECTOR
+    super selective-selector
+
+class TagTimeoutTestServiceProvider extends ServiceProvider
+    implements ServiceHandler:
+
+  index/int
+
+  constructor .index/int:
+    super "tests/tag-timeout-test" --major=1 --minor=0
+    provides TagTimeoutTestService.SELECTOR --handler=this --tags=["$index"]
+
+  handle index/int arguments/any --gid/int --client/int -> any:
+    unreachable


### PR DESCRIPTION
It could be that we want to handle this with retries on the client side instead. Let me know what you think.