### PR TITLE
Remove distinction between update-gold and update-health-gold.

### DIFF
--- a/external/gold/pkg-http__examples__client_get.toit.gold
+++ b/external/gold/pkg-http__examples__client_get.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__examples__client_get_tls.toit.gold
+++ b/external/gold/pkg-http__examples__client_get_tls.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__examples__client_post.toit.gold
+++ b/external/gold/pkg-http__examples__client_post.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__examples__local_ws_client.toit.gold
+++ b/external/gold/pkg-http__examples__local_ws_client.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__examples__server.toit.gold
+++ b/external/gold/pkg-http__examples__server.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__examples__server_tls.toit.gold
+++ b/external/gold/pkg-http__examples__server_tls.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__examples__ws_talk_to_self.toit.gold
+++ b/external/gold/pkg-http__examples__ws_talk_to_self.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__src__chunked.toit.gold
+++ b/external/gold/pkg-http__src__chunked.toit.gold
@@ -1,3 +1,0 @@
-pkg-http/src/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__src__client.toit.gold
+++ b/external/gold/pkg-http__src__client.toit.gold
@@ -1,3 +1,0 @@
-pkg-http/src/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__src__connection.toit.gold
+++ b/external/gold/pkg-http__src__connection.toit.gold
@@ -1,3 +1,0 @@
-pkg-http/src/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__src__http.toit.gold
+++ b/external/gold/pkg-http__src__http.toit.gold
@@ -1,3 +1,0 @@
-pkg-http/src/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__src__request.toit.gold
+++ b/external/gold/pkg-http__src__request.toit.gold
@@ -1,3 +1,0 @@
-pkg-http/src/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__src__response.toit.gold
+++ b/external/gold/pkg-http__src__response.toit.gold
@@ -1,3 +1,0 @@
-pkg-http/src/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__src__server.toit.gold
+++ b/external/gold/pkg-http__src__server.toit.gold
@@ -1,3 +1,0 @@
-pkg-http/src/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__src__web_socket.toit.gold
+++ b/external/gold/pkg-http__src__web_socket.toit.gold
@@ -1,3 +1,0 @@
-pkg-http/src/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__tests__google_404_test.toit.gold
+++ b/external/gold/pkg-http__tests__google_404_test.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__tests__google_test.toit.gold
+++ b/external/gold/pkg-http__tests__google_test.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__tests__headers_test.toit.gold
+++ b/external/gold/pkg-http__tests__headers_test.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__tests__http_finalizer_test.toit.gold
+++ b/external/gold/pkg-http__tests__http_finalizer_test.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__tests__http_overload_test.toit.gold
+++ b/external/gold/pkg-http__tests__http_overload_test.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__tests__http_standalone_test.toit.gold
+++ b/external/gold/pkg-http__tests__http_standalone_test.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__tests__parse_url_test.toit.gold
+++ b/external/gold/pkg-http__tests__parse_url_test.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__tests__redirect_test_httpbin.toit.gold
+++ b/external/gold/pkg-http__tests__redirect_test_httpbin.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__tests__websocket_client_test_paused.toit.gold
+++ b/external/gold/pkg-http__tests__websocket_client_test_paused.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__tests__websocket_standalone_semaphore_test.toit.gold
+++ b/external/gold/pkg-http__tests__websocket_standalone_semaphore_test.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~

--- a/external/gold/pkg-http__tests__websocket_standalone_test.toit.gold
+++ b/external/gold/pkg-http__tests__websocket_standalone_test.toit.gold
@@ -1,3 +1,0 @@
-<pkg:..>/server.toit:265:5: warning: Deprecated 'OutMixin.close-writer_'
-    close_writer_
-    ^~~~~~~~~~~~~


### PR DESCRIPTION
There's not really any time where you only want to update one set of gold files, leaving the other un-updated.