### PR TITLE
Remove misleading code.

### DIFF
--- a/tools/toitlsp/cmd/toitdoc.go
+++ b/tools/toitlsp/cmd/toitdoc.go
@@ -151,18 +151,6 @@ func runToitdoc(sdkVersion string) func(cmd *cobra.Command, args []string) error
 			}
 		}
 
-		sdkURI := pathToURI(sdk)
-		if !strings.HasSuffix(string(sdkURI), "/") {
-			sdkURI += "/"
-		}
-		if excludeSDK {
-			for u := range uris {
-				if strings.HasPrefix(string(u), string(sdkURI)) {
-					uris.Remove(u)
-				}
-			}
-		}
-
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -177,6 +165,11 @@ func runToitdoc(sdkVersion string) func(cmd *cobra.Command, args []string) error
 		})
 		if err != nil {
 			return err
+		}
+
+		sdkURI := pathToURI(sdk)
+		if !strings.HasSuffix(string(sdkURI), "/") {
+			sdkURI += "/"
 		}
 
 		f, err := os.Create(out)

--- a/tools/toitlsp/lsp/documents.go
+++ b/tools/toitlsp/lsp/documents.go
@@ -34,7 +34,7 @@ type Documents struct {
 
 	// A map from a document URI to its project URI.
 	//
-	// The project URI is the root of the projcet where we can find the
+	// The project URI is the root of the project where we can find the
 	// package lock file and the downloaded packages.
 	//
 	// From the user's point of view a document is only in one project. Diagnostics
@@ -44,7 +44,7 @@ type Documents struct {
 	// can lead to a document being referenced from multiple projects.
 	projectURIs map[lsp.DocumentURI]lsp.DocumentURI
 
-	// A map from document URI to analyzed documents for the specific uri..
+	// A map from document URI to analyzed documents for the specific uri.
 	analyzedDocuments map[lsp.DocumentURI]*AnalyzedDocuments
 }
 
@@ -71,8 +71,8 @@ func (d *Documents) AnalyzedDocumentsFor(projectURI lsp.DocumentURI) *AnalyzedDo
 func (d *Documents) AllProjectURIs() []lsp.DocumentURI {
 	d.l.RLock()
 	defer d.l.RUnlock()
-	res := make([]lsp.DocumentURI, 0, len(d.projectURIs))
-	for _, uri := range d.projectURIs {
+	res := make([]lsp.DocumentURI, 0, len(d.analyzedDocuments))
+	for uri, _ := range d.analyzedDocuments {
 		res = append(res, uri)
 	}
 	return res


### PR DESCRIPTION
The SDK isn't filtered out in the beginning, but during the export.