### PR TITLE
Fix program-path for 'toit'.

### DIFF
--- a/src/toit.cc
+++ b/src/toit.cc
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
     //   initial memory isn't released.
   } else {
     Flags::program_name = argv[0];
-    Flags::program_path = OS::get_executable_path_from_arg(argv[0]);
+    Flags::program_path = OS::get_executable_path();
     // Launch the toit.toit program.
     // TODO(florian): we are currently doing a copy of the snapshot as the
     // snapshot is sent in a message, and then freed as part of the finalizer when

--- a/tools/toit.toit
+++ b/tools/toit.toit
@@ -436,16 +436,14 @@ error message/string:
 bin-dir sdk-dir/string? -> string:
   if sdk-dir:
     return fs.join sdk-dir "bin"
-  else:
-    our-path := system.program-path
-    return fs.dirname our-path
+  our-path := system.program-path
+  return fs.dirname our-path
 
 run sdk-dir/string? tool/string args/List:
   if system.platform == system.PLATFORM-WINDOWS:
     tool = "$(tool).exe"
   tool-path := fs.join (bin-dir sdk-dir) tool
   args = [tool-path] + args
-  print "running: $args"
   pipe.run-program args
 
 compile-or-analyze-or-run --command/string parsed/cli.Parsed:


### PR DESCRIPTION
When running the toit snapshot (toit.toit) we want the program path to be set to the executable 'toit'. Otherwise we can't find the bundled programs, like `toit.compile`, `toit.pkg`, etc.

Currently `toit run` shells out to the `toit.run` executable which will set the program-path correctly for the executable it is running. If we optimize this by running directly then we will need to update the program_path.