### PR TITLE
Fix yaml text starting with "Q".

### DIFF
--- a/lib/encoding/yaml/parser.toit
+++ b/lib/encoding/yaml/parser.toit
@@ -34,8 +34,8 @@ C-MAPPING-VALUE_    ::= ':'
 C-ALIAS_            ::= '*'
 C-SINGLE-QUOTE_     ::= '\''
 C-DOUBLE-QUOTE_     ::= '"'
-C-RESERVCED-1_      ::= '@'
-C-RESERVCED-2_      ::= '`'
+C-RESERVED-1_      ::= '@'
+C-RESERVED-2_      ::= '`'
 C-ESCAPE_           ::= '\\'
 
 C-FLOW-INDICATOR_  ::= { C-COLLECT-ENTRY_, C-SEQUENCE-START_, C-SEQUENCE-END_, C-MAPPING-START_, C-MAPPING-END_ }

--- a/lib/encoding/yaml/parser.toit
+++ b/lib/encoding/yaml/parser.toit
@@ -34,7 +34,7 @@ C-MAPPING-VALUE_    ::= ':'
 C-ALIAS_            ::= '*'
 C-SINGLE-QUOTE_     ::= '\''
 C-DOUBLE-QUOTE_     ::= '"'
-C-RESERVCED-1_      ::= 'Q'
+C-RESERVCED-1_      ::= '@'
 C-RESERVCED-2_      ::= '`'
 C-ESCAPE_           ::= '\\'
 

--- a/lib/encoding/yaml/parser.toit
+++ b/lib/encoding/yaml/parser.toit
@@ -34,15 +34,15 @@ C-MAPPING-VALUE_    ::= ':'
 C-ALIAS_            ::= '*'
 C-SINGLE-QUOTE_     ::= '\''
 C-DOUBLE-QUOTE_     ::= '"'
-C-RESERVED-1_      ::= '@'
-C-RESERVED-2_      ::= '`'
+C-RESERVED-1_       ::= '@'
+C-RESERVED-2_       ::= '`'
 C-ESCAPE_           ::= '\\'
 
 C-FLOW-INDICATOR_  ::= { C-COLLECT-ENTRY_, C-SEQUENCE-START_, C-SEQUENCE-END_, C-MAPPING-START_, C-MAPPING-END_ }
 C-INDICATOR_       ::= { C-SEQUENCE-ENTRY_, C-MAPPING-KEY_, C-MAPPING-VALUE_, C-COLLECT-ENTRY_, C-SEQUENCE-START_,
                          C-SEQUENCE-END_, C-MAPPING-START_, C-MAPPING-END_, C-COMMENT_, C-ANCHOR_, C-ALIAS_,
                          C-TAG_, C-LITERAL_, C-FOLDED_, C-SINGLE-QUOTE_, C-DOUBLE-QUOTE_, C-DIRECTIVE_,
-                         C-RESERVCED-1_, C-RESERVCED-2_}
+                         C-RESERVED-1_, C-RESERVED-2_}
 
 S-SECONDARY-TAG-HANDLE_ ::= "!!"
 

--- a/tests/yaml-test.toit
+++ b/tests/yaml-test.toit
@@ -21,6 +21,7 @@ main:
   test-from-spec
   test-stream
   test-value-converter
+  test-reserved
 
 test-stringify:
   expect-equals "testing" (yaml.stringify "testing")
@@ -300,6 +301,7 @@ test-encode:
 test-decode:
   expect-equals "testing" (yaml.decode "testing".to-byte-array)
   expect-list-equals ["-O0"] (yaml.decode """["-O0"]""".to-byte-array)
+  expect-structural-equals { "x": "Q" } (yaml.decode "x: Q".to-byte-array)
 
 BIG-JSON ::= """
 [
@@ -574,3 +576,7 @@ test-value-converter:
   expect result["int"] is int
   expect result["float-as-string"] is string
   expect result["int-as-string"] is string
+
+test-reserved:
+  expect-throw "INVALID_YAML_DOCUMENT": yaml.parse "x: @"
+  expect-throw "INVALID_YAML_DOCUMENT": yaml.parse "x: `"


### PR DESCRIPTION
Yaml currently reserves '@' for beginnings of blocks, as in:
```
foo: @
```
However, we accidentally reserved "Q".

Any block that started with "Q" was marked as invalid. Example:
```
description: Qualification of the author.
```