### PR TITLE
Run 64-bit debug tests when pushing to master.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,14 @@ jobs:
           fi
           ccache -s
 
+      # Build 64-bit debug if we are doing a release.
+      - name: Build 64-bit debug
+        if: github.event_name == 'release' && runner.os == 'Linux'
+        run: |
+          ccache -s
+          make HOST=host64-debug BUILD_TYPE=Debug sdk
+          ccache -s
+
       # Test.
       - name: Test
         shell: bash  # This is crucial, as the powershell doesn't abort when there is an error.
@@ -224,6 +232,11 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           make HOST=host32 BUILD_TYPE=Debug test
+
+      - name: Test 64-bit debug
+        if: github.event_name == 'release' && runner.os == 'Linux'
+        run: |
+          make HOST=host64-debug BUILD_TYPE=Debug test
 
       - name: Test install
         if : matrix.shard == 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,9 +198,9 @@ jobs:
           fi
           ccache -s
 
-      # Build 64-bit debug if we are doing a release.
+      # Build 64-bit debug if we are comitting to master.
       - name: Build 64-bit debug
-        if: github.event_name == 'release' && runner.os == 'Linux'
+        if: runner.os == 'Linux' && github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           ccache -s
           make BUILD=build-debug BUILD_TYPE=Debug sdk
@@ -234,7 +234,7 @@ jobs:
           make HOST=host32 BUILD_TYPE=Debug test
 
       - name: Test 64-bit debug
-        if: github.event_name == 'release' && runner.os == 'Linux'
+        if: runner.os == 'Linux' && github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           make BUILD=build-debug BUILD_TYPE=Debug test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
         if: github.event_name == 'release' && runner.os == 'Linux'
         run: |
           ccache -s
-          make HOST=host64-debug BUILD_TYPE=Debug sdk
+          make BUILD=build-debug BUILD_TYPE=Debug sdk
           ccache -s
 
       # Test.
@@ -236,7 +236,7 @@ jobs:
       - name: Test 64-bit debug
         if: github.event_name == 'release' && runner.os == 'Linux'
         run: |
-          make HOST=host64-debug BUILD_TYPE=Debug test
+          make BUILD=build-debug BUILD_TYPE=Debug test
 
       - name: Test install
         if : matrix.shard == 1


### PR DESCRIPTION
It's a bit heavy to do them all the time, but just for the releases should be fine.