### PR TITLE
Use the 'name' field in the package.lock file.

### DIFF
--- a/src/compiler/compiler.cc
+++ b/src/compiler/compiler.cc
@@ -1103,7 +1103,7 @@ enum class AddSegmentResult {
 /// If 'should_check_is_toit_file' is true, checks that the result is a regular file.
 /// If 'should_check_is_toit_file' is false, checks that the result is a directory.
 static AddSegmentResult add_segment(PathBuilder* path_builder,
-                                    Symbol segment,
+                                    const char* segment,
                                     Filesystem* fs,
                                     bool should_check_is_toit_file) {
   auto check_path = [&]() {
@@ -1133,15 +1133,13 @@ static AddSegmentResult add_segment(PathBuilder* path_builder,
   // So remember the length of the path before we add the segment.
   int path_length_before_segment = path_builder->length();
 
-  const char* segment_c = segment.c_str();
-
   // First add the segment verbatim. In most cases that will just work.
-  path_builder->join(segment_c);
+  path_builder->join(segment);
   auto result = check_path();
   if (result != AddSegmentResult::NOT_FOUND) return result;
 
-  const char* old_style = IdentifierValidator::deprecated_underscore_identifier(segment_c, strlen(segment_c));
-  if (old_style == segment_c) {
+  const char* old_style = IdentifierValidator::deprecated_underscore_identifier(segment, strlen(segment));
+  if (old_style == segment) {
     // Didn't contain any '-'.
     return AddSegmentResult::NOT_FOUND;
   }
@@ -1348,11 +1346,15 @@ Source* Pipeline::_load_import(ast::Unit* unit,
     // Something like `import foo` where `foo` is the name of a package.
     // We only allow `foo.toit` (inside the package's `src` directory), but
     // not `foo/foo.toit`.
-    // TODO(florian): the file name should not be based on the import
-    // segment, but on the package name.
+    // If we know the name of the package, then use that to find the library. Otherwise,
+    // use the last segment of the import. The latter is deprecated.
     int length_before_segment = import_path_builder.length();
+    auto name = import_package.name();
+    const char* next_segment = (name == Package::NO_NAME)
+        ? segments[segments.length() - 1]->data().c_str()
+        : name.c_str();
     auto result = add_segment(&import_path_builder,
-                              segments[segments.length() - 1]->data(),
+                              next_segment,
                               filesystem(),
                               true);  // Must be a toit file.
     if (result != AddSegmentResult::OK) {
@@ -1381,7 +1383,7 @@ Source* Pipeline::_load_import(ast::Unit* unit,
     bool is_last_segment = i == segments.length() - 1;
     int length_before_new_segment = import_path_builder.length();
     auto result = add_segment(&import_path_builder,
-                              segment,
+                              segment.c_str(),
                               filesystem(),
                               is_last_segment);  // Check whether it's a toit file for the last segment.
     if (result != AddSegmentResult::OK) {
@@ -1406,7 +1408,7 @@ Source* Pipeline::_load_import(ast::Unit* unit,
         // For example, for `import foo` we search for `foo.toit` and `foo/foo.toit`.
         import_path_builder.reset_to(length_before_new_segment);
         result = add_segment(&import_path_builder,
-                             segment,
+                             segment.c_str(),
                              filesystem(),
                              false);  // Now it must be a directory.
         bool found_alternative_directory = result == AddSegmentResult::OK;
@@ -1416,7 +1418,7 @@ Source* Pipeline::_load_import(ast::Unit* unit,
 
           // We found a directory, so we duplicate the last segment.
           result = add_segment(&import_path_builder,
-                               segment,
+                               segment.c_str(),
                                filesystem(),
                                true);  // Now it must be a toit file.
         }

--- a/src/compiler/package.h
+++ b/src/compiler/package.h
@@ -59,10 +59,14 @@ class Package {
   // yet, or where we don't have any access to the package id.
   static constexpr const char* INVALID_PACKAGE_ID = "<invalid>";
 
+  // The string that is used for packages that don't have a name.
+  static constexpr const char* NO_NAME = "";
+
   // Constructor must be valid, as we use the class as values in a map.
   Package() {}
 
   std::string id() const { return id_; }
+  std::string name() const { return name_; }
   std::string absolute_path() const { return absolute_path_; }
   ErrorState error_state() const { return error_state_; }
 
@@ -95,7 +99,8 @@ class Package {
   }
 
  private:
-  Package(const std::string id,
+  Package(const std::string& id,
+          const std::string& name,
           const std::string& absolute_path,
           const std::string& absolute_error_path,
           const std::string& relative_error_path,
@@ -103,6 +108,7 @@ class Package {
           Map<std::string, std::string> prefixes,
           bool is_path_package)
       : id_(id)
+      , name_(name)
       , absolute_path_(absolute_path)
       , absolute_error_path_(absolute_error_path)
       , relative_error_path_(relative_error_path)
@@ -111,6 +117,7 @@ class Package {
       , is_path_package_(is_path_package) {}
 
   std::string id_ = std::string(INVALID_PACKAGE_ID);
+  std::string name_ = std::string("");
   std::string absolute_path_ = std::string("");
   // The absolute location of the relative error path.
   // Usually the same as the absolute_path. Can be different for the entry package.

--- a/tests/lock_file/named_test/README
+++ b/tests/lock_file/named_test/README
@@ -1,0 +1,1 @@
+Makes sure the 'name' entry in the lock-file is respected.

--- a/tests/lock_file/named_test/foo/src/foo.toit
+++ b/tests/lock_file/named_test/foo/src/foo.toit
@@ -1,0 +1,5 @@
+// Copyright (C) 2020 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+identify: return "foo"

--- a/tests/lock_file/named_test/package.lock
+++ b/tests/lock_file/named_test/package.lock
@@ -1,0 +1,7 @@
+prefixes:
+  foo-other-name: foo-1.0
+
+packages:
+  foo-1.0:
+    name: foo
+    path: foo

--- a/tests/lock_file/named_test/test.toit
+++ b/tests/lock_file/named_test/test.toit
@@ -1,0 +1,9 @@
+// Copyright (C) 2020 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import foo-other-name
+import expect show *
+
+main:
+  expect-equals "foo" foo-other-name.identify


### PR DESCRIPTION
When having an `import foo` use the name of the package to find the correct library in the import.

This is only relevant if the prefix of the import was changed.