### PR TITLE
Ensure byte-array is big enough in firmware-copy primitive.

### DIFF
--- a/lib/system/firmware.toit
+++ b/lib/system/firmware.toit
@@ -35,6 +35,17 @@ Map the current firmware into memory, so the content
 
 The mapping is only valid while executing the given
   $block.
+
+# Examples
+
+```
+map: | mapping/FirmwareMapping |
+  print "Size of firmware: $mapping.size"
+  print "First byte of firmware: $mapping[0]"
+  bytes := ByteArray 128
+  mapping.copy 0 128 --into=bytes
+  print "First 128 bytes of firmware: $bytes"
+```
 */
 map --from/int=0 --to/int?=null [block] -> none:
   mapping/FirmwareMapping_? := null
@@ -253,6 +264,7 @@ class FirmwareMapping_ implements FirmwareMapping:
 
   copy from/int to/int --into/ByteArray -> none:
     if not 0 <= from <= to <= size: throw "OUT_OF_BOUNDS"
+    if into.size < to - from: throw "OUT_OF_BOUNDS"
     // Determine if we can do an aligned block copy taking
     // the offset into account.
     offset := offset_

--- a/src/primitive_core.cc
+++ b/src/primitive_core.cc
@@ -2523,6 +2523,7 @@ PRIMITIVE(firmware_mapping_at) {
 
 PRIMITIVE(firmware_mapping_copy) {
   ARGS(Instance, receiver, int, from, int, to, ByteArray, into, int, index);
+  if (index < 0) FAIL(OUT_OF_BOUNDS);
   int offset = Smi::value(receiver->at(1));
   int size = Smi::value(receiver->at(2));
   if (!Utils::is_aligned(from + offset, sizeof(uint32)) ||
@@ -2539,6 +2540,7 @@ PRIMITIVE(firmware_mapping_copy) {
   // always reading whole words to avoid issues with this.
   ByteArray::Bytes output(into);
   int bytes = to - from;
+  if (index + bytes > output.length()) FAIL(OUT_OF_BOUNDS);
   iram_safe_memcpy(output.address() + index, input.address() + from + offset, bytes);
   return Smi::from(index + bytes);
 }


### PR DESCRIPTION
We were writing unconditionally at the byte-array at the given address without checking that there was enough space.