### PR TITLE
Don't do reinterpret casts in BLE code.

### DIFF
--- a/src/event_sources/ble.h
+++ b/src/event_sources/ble.h
@@ -13,8 +13,12 @@
 // The license can be found in the file `LICENSE` in the top level
 // directory of this repository.
 
+#pragma once
+
 #include "../top.h"
 #include "../resource.h"
+#include "../tags.h"
+
 namespace toit {
 
 enum {
@@ -49,6 +53,8 @@ class BleResourceGroup;
 
 class BleResource : public Resource {
  public:
+  TAGS(BleResource);
+
   enum Kind {
     CENTRAL_MANAGER,
     PERIPHERAL_MANAGER,

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -1051,6 +1051,9 @@ Object* get_absolute_path(Process* process, const wchar_t* pathname, wchar_t* ou
 #define _A_T_PcntUnitResource(N, name)    MAKE_UNPACKING_MACRO(PcntUnitResource, N, name)
 #define _A_T_EspNowResource(N, name)      MAKE_UNPACKING_MACRO(EspNowResource, N, name)
 #define _A_T_RmtResource(N, name)         MAKE_UNPACKING_MACRO(RmtResource, N, name)
+#define _A_T_BleResource(N, name)         MAKE_UNPACKING_MACRO(BleResource, N, name)
+#define _A_T_BleReadWriteElement(N, name) MAKE_UNPACKING_MACRO(BleReadWriteElement, N, name)
+#define _A_T_BleErrorCapableResource(N, name)   MAKE_UNPACKING_MACRO(BleErrorCapableResource, N, name)
 #define _A_T_BleCentralManagerResource(N, name) MAKE_UNPACKING_MACRO(BleCentralManagerResource, N, name)
 #define _A_T_BleRemoteDeviceResource(N, name)   MAKE_UNPACKING_MACRO(BleRemoteDeviceResource, N, name)
 

--- a/src/resources/ble_darwin.mm
+++ b/src/resources/ble_darwin.mm
@@ -651,7 +651,7 @@ BleCharacteristicResource* lookup_local_characteristic_resource(CBPeripheralMana
 template <typename T>
 BleServiceResource* ServiceContainer<T>::get_or_create_service_resource(CBService* service, bool can_create) {
   BleResourceHolder* holder = _service_resource_index[[service UUID]];
-  if (holder != nil) return reinterpret_cast<BleServiceResource*>(holder.resource);
+  if (holder != nil) return static_cast<BleServiceResource*>(holder.resource);
   if (!can_create) return null;
 
   auto resource = _new BleServiceResource(group(), type(), service);
@@ -677,7 +677,7 @@ BleCharacteristicResource* BleServiceResource::get_or_create_characteristic_reso
     CBCharacteristic* characteristic,
     bool can_create) {
   BleResourceHolder* holder = _characteristics_resource_index[[characteristic UUID]];
-  if (holder != nil) return reinterpret_cast<BleCharacteristicResource*>(holder.resource);
+  if (holder != nil) return static_cast<BleCharacteristicResource*>(holder.resource);
   if (!can_create) return null;
 
   auto resource = _new BleCharacteristicResource(group(), this, characteristic);
@@ -1266,17 +1266,16 @@ PRIMITIVE(notify_characteristics_value) {
 }
 
 PRIMITIVE(get_att_mtu) {
-  ARGS(Resource, resource);
+  ARGS(BleResource, ble_resource);
   NSUInteger mtu = 23;
-  auto ble_resource = reinterpret_cast<BleResource*>(resource);
   switch (ble_resource->kind()) {
     case BleResource::REMOTE_DEVICE: {
-      auto device = reinterpret_cast<BleRemoteDeviceResource*>(ble_resource);
+      auto device = static_cast<BleRemoteDeviceResource*>(ble_resource);
       mtu = [device->peripheral() maximumWriteValueLengthForType:CBCharacteristicWriteWithResponse];
       break;
     }
     case BleResource::CHARACTERISTIC: {
-      auto characteristic = reinterpret_cast<BleCharacteristicResource*>(ble_resource);
+      auto characteristic = static_cast<BleCharacteristicResource*>(ble_resource);
       mtu = characteristic->mtu();
       break;
     }

--- a/src/tags.h
+++ b/src/tags.h
@@ -49,12 +49,6 @@ namespace toit {
   fn(PcntUnitResource)                  \
   fn(PwmResource)                       \
   fn(RmtResource)                       \
-  fn(BleCentralManagerResource)         \
-  fn(BlePeripheralManagerResource)      \
-  fn(BleRemoteDeviceResource)           \
-  fn(BleServiceResource)                \
-  fn(BleCharacteristicResource)         \
-  fn(BleDescriptorResource)             \
   fn(Directory)                         \
   fn(UdpSocketResource)                 \
   fn(TcpSocketResource)                 \
@@ -67,6 +61,19 @@ namespace toit {
 
 #define TLS_CLASSES_DO(fn)              \
   fn(MbedTlsSocket)                     \
+
+// When adding a class make sure that they all are subclasses of
+// the BleErrorCapableResource. If it isn't update the Min/MaxTag below.
+// Similarly, check, whether the new class is a read-write class.
+#define BLE_CLASSES_DO(fn)              \
+  fn(BleCentralManagerResource)         \
+  fn(BlePeripheralManagerResource)      \
+  fn(BleRemoteDeviceResource)           \
+  fn(BleServiceResource)                \
+
+#define BLE_READ_WRITE_CLASSES_DO(fn)   \
+  fn(BleCharacteristicResource)         \
+  fn(BleDescriptorResource)             \
 
 #define RESOURCE_GROUP_CLASSES_DO(fn)   \
   fn(SimpleResourceGroup)               \
@@ -113,6 +120,14 @@ enum StructTag {
   BaseTlsSocketMinTag,
   TLS_CLASSES_DO(MAKE_ENUM)
   BaseTlsSocketMaxTag,
+  BleResourceMinTag,
+  BleErrorCapableResourceMinTag,
+  BLE_CLASSES_DO(MAKE_ENUM)
+  BleReadWriteElementMinTag,
+  BLE_READ_WRITE_CLASSES_DO(MAKE_ENUM)
+  BleReadWriteElementMaxTag,
+  BleErrorCapableResourceMaxTag,
+  BleResourceMaxTag,
   ResourceMaxTag,
 
   // ResourceGroup subclasses.


### PR DESCRIPTION
Use tags instead.