### PR TITLE
Change objects.h to get better code quality on Xtensa.

### DIFF
--- a/src/objects.h
+++ b/src/objects.h
@@ -368,19 +368,21 @@ class HeapObject : public Object {
 
   void _set_header(Program* program, Smi* id);
 
-  uword _raw() const { return reinterpret_cast<uword>(this) - HEAP_TAG; }
-  uword* _raw_at(int offset) { return reinterpret_cast<uword*>(_raw() + offset); }
-  const uword* _raw_at(int offset) const { return reinterpret_cast<const uword*>(_raw() + offset); }
+  inline uword _raw() const { return reinterpret_cast<uword>(this) - HEAP_TAG; }
+  inline uword* _raw_at()           { return reinterpret_cast<uword*>(reinterpret_cast<uword>(this) - HEAP_TAG); }
+  inline uword* _raw_at(int offset) { return reinterpret_cast<uword*>(reinterpret_cast<uword>(this) - HEAP_TAG + offset); }
+  inline const uword* _raw_at()           const { return reinterpret_cast<const uword*>(reinterpret_cast<uword>(this) - HEAP_TAG); }
+  inline const uword* _raw_at(int offset) const { return reinterpret_cast<const uword*>(reinterpret_cast<uword>(this) - HEAP_TAG + offset); }
 
-  Object* _at(int offset) const { return *reinterpret_cast<Object* const*>(_raw_at(offset)); }
-  void _at_put(int offset, Object* value) { *reinterpret_cast<Object**>(_raw_at(offset)) = value; }
-  Object** _root_at(int offset) { return reinterpret_cast<Object**>(_raw_at(offset)); }
+  Object* _at(int offset) const { return reinterpret_cast<Object* const*>(_raw_at())[offset / WORD_SIZE]; }
+  void _at_put(int offset, Object* value) { reinterpret_cast<Object**>(_raw_at())[offset / WORD_SIZE] = value; }
+  Object** _root_at(int offset) { return reinterpret_cast<Object**>(_raw_at()) + offset / WORD_SIZE; }
 
-  uword _word_at(int offset) const { return *_raw_at(offset); }
-  void _word_at_put(int offset, uword value) { *_raw_at(offset) = value; }
+  uword _word_at(int offset) const { return _raw_at()[offset / WORD_SIZE]; }
+  void _word_at_put(int offset, uword value) { _raw_at()[offset / WORD_SIZE] = value; }
 
-  uint8 _byte_at(int offset) const { return *reinterpret_cast<const uint8*>(_raw_at(offset)); }
-  void _byte_at_put(int offset, uint8 value) { *reinterpret_cast<uint8*>(_raw_at(offset)) = value; }
+  uint8 _byte_at(int offset) const { return reinterpret_cast<const uint8*>(_raw_at())[offset]; }
+  void _byte_at_put(int offset, uint8 value) { reinterpret_cast<uint8*>(_raw_at())[offset] = value; }
 
   uhalf_word _half_word_at(int offset) const { return *reinterpret_cast<const uhalf_word*>(_raw_at(offset)); }
   void _half_word_at_put(int offset, uhalf_word value) { *reinterpret_cast<uhalf_word*>(_raw_at(offset)) = value; }
@@ -443,7 +445,6 @@ class Array : public HeapObject {
   }
 
   uint8* content() { return reinterpret_cast<uint8*>(_raw() + _offset_from(0)); }
-
 
   int size() const { return allocation_size(length()); }
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -368,30 +368,30 @@ class HeapObject : public Object {
 
   void _set_header(Program* program, Smi* id);
 
-  inline uword _raw() const { return reinterpret_cast<uword>(this) - HEAP_TAG; }
-  inline uword* _raw_at()           { return reinterpret_cast<uword*>(reinterpret_cast<uword>(this) - HEAP_TAG); }
-  inline uword* _raw_at(int offset) { return reinterpret_cast<uword*>(reinterpret_cast<uword>(this) - HEAP_TAG + offset); }
-  inline const uword* _raw_at()           const { return reinterpret_cast<const uword*>(reinterpret_cast<uword>(this) - HEAP_TAG); }
-  inline const uword* _raw_at(int offset) const { return reinterpret_cast<const uword*>(reinterpret_cast<uword>(this) - HEAP_TAG + offset); }
+  INLINE uword _raw() const { return reinterpret_cast<uword>(this) - HEAP_TAG; }
+  INLINE uword* _raw_at() { return reinterpret_cast<uword*>(reinterpret_cast<uword>(this) - HEAP_TAG); }
+  INLINE uword* _raw_at(int offset) { return reinterpret_cast<uword*>(reinterpret_cast<uword>(this) - HEAP_TAG + offset); }
+  INLINE const uword* _raw_at() const { return reinterpret_cast<const uword*>(reinterpret_cast<uword>(this) - HEAP_TAG); }
+  INLINE const uword* _raw_at(int offset) const { return reinterpret_cast<const uword*>(reinterpret_cast<uword>(this) - HEAP_TAG + offset); }
 
-  Object* _at(int offset) const { return reinterpret_cast<Object* const*>(_raw_at())[offset / WORD_SIZE]; }
-  void _at_put(int offset, Object* value) { reinterpret_cast<Object**>(_raw_at())[offset / WORD_SIZE] = value; }
-  Object** _root_at(int offset) { return reinterpret_cast<Object**>(_raw_at()) + offset / WORD_SIZE; }
+  INLINE Object* _at(int offset) const { return reinterpret_cast<Object* const*>(_raw_at())[offset / WORD_SIZE]; }
+  INLINE void _at_put(int offset, Object* value) { reinterpret_cast<Object**>(_raw_at())[offset / WORD_SIZE] = value; }
+  INLINE Object** _root_at(int offset) { return reinterpret_cast<Object**>(_raw_at()) + offset / WORD_SIZE; }
 
-  uword _word_at(int offset) const { return _raw_at()[offset / WORD_SIZE]; }
-  void _word_at_put(int offset, uword value) { _raw_at()[offset / WORD_SIZE] = value; }
+  INLINE uword _word_at(int offset) const { return _raw_at()[offset / WORD_SIZE]; }
+  INLINE void _word_at_put(int offset, uword value) { _raw_at()[offset / WORD_SIZE] = value; }
 
-  uint8 _byte_at(int offset) const { return reinterpret_cast<const uint8*>(_raw_at())[offset]; }
-  void _byte_at_put(int offset, uint8 value) { reinterpret_cast<uint8*>(_raw_at())[offset] = value; }
+  INLINE uint8 _byte_at(int offset) const { return reinterpret_cast<const uint8*>(_raw_at())[offset]; }
+  INLINE void _byte_at_put(int offset, uint8 value) { reinterpret_cast<uint8*>(_raw_at())[offset] = value; }
 
-  uhalf_word _half_word_at(int offset) const { return *reinterpret_cast<const uhalf_word*>(_raw_at(offset)); }
-  void _half_word_at_put(int offset, uhalf_word value) { *reinterpret_cast<uhalf_word*>(_raw_at(offset)) = value; }
+  INLINE uhalf_word _half_word_at(int offset) const { return *reinterpret_cast<const uhalf_word*>(_raw_at(offset)); }
+  INLINE void _half_word_at_put(int offset, uhalf_word value) { *reinterpret_cast<uhalf_word*>(_raw_at(offset)) = value; }
 
-  double _double_at(int offset) const { return bit_cast<double>(_int64_at(offset)); }
-  void _double_at_put(int offset, double value) { _int64_at_put(offset, bit_cast<int64>(value)); }
+  INLINE double _double_at(int offset) const { return bit_cast<double>(_int64_at(offset)); }
+  INLINE void _double_at_put(int offset, double value) { _int64_at_put(offset, bit_cast<int64>(value)); }
 
-  int64 _int64_at(int offset) const { return *reinterpret_cast<const int64*>(_raw_at(offset)); }
-  void _int64_at_put(int offset, int64 value) { *reinterpret_cast<int64*>(_raw_at(offset)) = value; }
+  INLINE int64 _int64_at(int offset) const { return *reinterpret_cast<const int64*>(_raw_at(offset)); }
+  INLINE void _int64_at_put(int offset, int64 value) { *reinterpret_cast<int64*>(_raw_at(offset)) = value; }
 
   static int _align(int byte_size) { return (byte_size + (WORD_SIZE - 1)) & ~(WORD_SIZE - 1); }
 


### PR DESCRIPTION
Old code:

400e7de8 <toit::Object::byte_content(toit::Program*, unsigned char const**, int*, toit::BlobKind) const>: ...
400e7dfc:	ffcb22        	addi	a2, a11, -1
400e7dff:	002222        	l32i	a2, a2, 0
...
400e7e24:	2b3b      	addi.n	a2, a11, 3
400e7e26:	0238      	l32i.n	a3, a2, 0
400e7e28:	0183d6        	bgez	a3, 400e7e44 <toit::Object::byte_content(toit::Program*, unsigned char const**, int*, toit::BlobKind) const+0x5c>
400e7e2b:	2bbb      	addi.n	a2, a11, 11
400e7e2d:	0268      	l32i.n	a6, a2, 0
400e7e2f:	0e2d      	mov.n	a2, a14
400e7e31:	fc5656        	bnez	a6, 400e7dfa <toit::Object::byte_content(toit::Program*, unsigned char const**, int*, toit::BlobKind) const+0x12>
400e7e34:	bb7b      	addi.n	a11, a11, 7
400e7e36:	f27c      	movi.n	a2, -1
400e7e38:	0bb8      	l32i.n	a11, a11, 0

New code:

400e7764 <toit::Object::byte_content(toit::Program*, unsigned char const**, int*, toit::BlobKind) const>: ...
400e7776:	ffc292        	addi	a9, a2, -1
400e7779:	002982        	l32i	a8, a9, 0
...
400e77a0:	1938      	l32i.n	a3, a9, 4
400e77a2:	0123d6        	bgez	a3, 400e77b8 <toit::Object::byte_content(toit::Program*, unsigned char const**, int*, toit::BlobKind) const+0x54>
400e77a5:	3968      	l32i.n	a6, a9, 12
400e77a7:	0e2d      	mov.n	a2, a14
400e77a9:	fc7656        	bnez	a6, 400e7774 <toit::Object::byte_content(toit::Program*, unsigned char const**, int*, toit::BlobKind) const+0x10>
400e77ac:	f67c      	movi.n	a6, -1
400e77ae:	2928      	l32i.n	a2, a9, 8