### PR TITLE
Use word instead of int.

### DIFF
--- a/src/ar.cc
+++ b/src/ar.cc
@@ -46,9 +46,9 @@ static const int FILE_MODE_SIZE = FILE_BYTE_SIZE_OFFSET - FILE_MODE_OFFSET;
 static const int FILE_BYTE_SIZE_SIZE = FILE_ENDING_CHARS_OFFSET - FILE_BYTE_SIZE_OFFSET;
 static const int FILE_ENDING_CHARS_SIZE = FILE_HEADER_SIZE - FILE_ENDING_CHARS_OFFSET;
 
-static void write_string(uint8* buffer, const char* str, int length) {
+static void write_string(uint8* buffer, const char* str, word length) {
   // The string is truncated if it is too long.
-  for (int i = 0; i < length; i++) {
+  for (word i = 0; i < length; i++) {
     char c = *str;
     if (c == '\0') {
       // Pad with spaces.
@@ -60,19 +60,19 @@ static void write_string(uint8* buffer, const char* str, int length) {
   }
 }
 
-static void write_number(uint8* buffer, int number, int length, int base) {
+static void write_number(uint8* buffer, int number, word length, int base) {
   // The number is trimmed if it doesn't fit.
   // For simplicity, we write the number right to left, and then shift the
   // computed values.
-  int i = length - 1;
+  word i = length - 1;
   for (; i >= 0; i--) {
     buffer[i] = '0' + number % base;
     number = number / base;
     if (number == 0) break;
   }
   // 'i' is the last entry where we wrote a significant digit.
-  int nb_digits = length - i;
-  int offset = i;
+  word nb_digits = length - i;
+  word offset = i;
   for (int j = 0; j < nb_digits; j++) {
     buffer[j] = buffer[j + offset];
   }
@@ -81,11 +81,11 @@ static void write_number(uint8* buffer, int number, int length, int base) {
   }
 }
 
-static void write_decimal(uint8* buffer, int number, int length) {
+static void write_decimal(uint8* buffer, int number, word length) {
   write_number(buffer, number, length, 10);
 }
 
-static void write_octal(uint8* buffer, int number, int length) {
+static void write_octal(uint8* buffer, int number, word length) {
   write_number(buffer, number, length, 8);
 }
 
@@ -121,7 +121,7 @@ static void write_ar_file_header(uint8* buffer, const File& file) {
                FILE_ENDING_CHARS_SIZE);
 }
 
-static bool needs_padding(int content_size) {
+static bool needs_padding(word content_size) {
   return (content_size & 1) != 0;
 }
 
@@ -134,12 +134,12 @@ int MemoryBuilder::open() {
 }
 
 int MemoryBuilder::add(File file) {
-  int needed_size = FILE_HEADER_SIZE + file.byte_size;
+  word needed_size = FILE_HEADER_SIZE + file.byte_size;
   if (needs_padding(file.byte_size)) needed_size++;
-  int new_size = size_ + needed_size;
+  word new_size = size_ + needed_size;
   buffer_ = unvoid_cast<uint8*>(realloc(buffer_, new_size));
   if (buffer_ == null) return AR_OUT_OF_MEMORY;
-  int offset = size_;
+  word offset = size_;
   write_ar_file_header(&buffer_[offset], file);
   offset += FILE_HEADER_SIZE;
   memcpy(&buffer_[offset], file.content(), file.byte_size);
@@ -154,7 +154,7 @@ int MemoryBuilder::add(File file) {
 int FileBuilder::open(const char* archive_path) {
   file_ = fopen(archive_path, "wb");
   if (file_ == NULL) return AR_ERRNO_ERROR;
-  int written = fwrite(AR_HEADER, 1, AR_HEADER_SIZE, file_);
+  word written = fwrite(AR_HEADER, 1, AR_HEADER_SIZE, file_);
   if (written != AR_HEADER_SIZE) return AR_ERRNO_ERROR;
   return 0;
 }
@@ -171,7 +171,7 @@ int FileBuilder::close() {
 int FileBuilder::add(File file) {
   uint8 buffer[FILE_HEADER_SIZE];
   write_ar_file_header(buffer, file);
-  int written = fwrite(buffer, 1, FILE_HEADER_SIZE, file_);
+  word written = fwrite(buffer, 1, FILE_HEADER_SIZE, file_);
   if (written != FILE_HEADER_SIZE) return AR_ERRNO_ERROR;
   written = fwrite(file.content(), 1, file.byte_size, file_);
   if (written != file.byte_size) return AR_ERRNO_ERROR;
@@ -196,8 +196,8 @@ static int parse_ar_file_header(const uint8* data, File* file) {
 
   // We parse the size first, as parsing the name can't lead to errors, and we
   // don't want to allocate memory if there is an error.
-  int byte_size = 0;
-  for (int i = 0; i < FILE_BYTE_SIZE_SIZE; i++) {
+  word byte_size = 0;
+  for (word i = 0; i < FILE_BYTE_SIZE_SIZE; i++) {
     char c = data[FILE_BYTE_SIZE_OFFSET + i];
     if ('0' <= c && c <= '9') {
       byte_size = byte_size * 10 + c - '0';
@@ -213,7 +213,7 @@ static int parse_ar_file_header(const uint8* data, File* file) {
   memcpy(name, &data[FILE_NAME_OFFSET], FILE_NAME_SIZE);
   name[FILE_NAME_SIZE] = '\0';
   // Remove the padding.
-  for (int i = FILE_NAME_SIZE - 1; i >= 0; i--) {
+  for (word i = FILE_NAME_SIZE - 1; i >= 0; i--) {
     if (name[i] == ' ') {
       name[i] = '\0';
     } else if (name[i] == '/') {

--- a/src/blake2s.h
+++ b/src/blake2s.h
@@ -34,8 +34,8 @@ class Blake2s : public SimpleResource {
     child->length_ = length_;
   }
 
-  static const int BLOCK_SIZE = 64;
-  static const int MAX_HASH_SIZE = 32;
+  static const word BLOCK_SIZE = 64;
+  static const word MAX_HASH_SIZE = 32;
 
  private:
   static const uint32_t BLOCK_MASK = BLOCK_SIZE - 1;

--- a/src/compiler/backend.cc
+++ b/src/compiler/backend.cc
@@ -173,7 +173,7 @@ Program* Backend::emit(ir::Program* ir_program) {
 
   DispatchTable dispatch_table = DispatchTable::build(ir_program);
 
-  dispatch_table.for_each_selector_offset([&](DispatchSelector selector, int offset) {
+  dispatch_table.for_each_selector_offset([&](DispatchSelector selector, word offset) {
     source_mapper()->register_selector_offset(offset, selector.name().c_str());
   });
 

--- a/src/compiler/dispatch_table.cc
+++ b/src/compiler/dispatch_table.cc
@@ -311,12 +311,12 @@ class DispatchTableBuilder : public TraversingVisitor {
     selectors_.insert(selector);
   }
 
-  Map<DispatchSelector, int>& selector_offsets() { return selector_offsets_; }
+  Map<DispatchSelector, word>& selector_offsets() { return selector_offsets_; }
   List<Method*> dispatch_table() { return dispatch_table_; }
 
  private:
   Set<DispatchSelector> selectors_;
-  Map<DispatchSelector, int> selector_offsets_;
+  Map<DispatchSelector, word> selector_offsets_;
   List<Method*> dispatch_table_;
 
   void handle_methods(List<Method*> methods);

--- a/src/compiler/dispatch_table.h
+++ b/src/compiler/dispatch_table.h
@@ -64,17 +64,17 @@ class DispatchTable {
   }
   int id_for(const ir::Class* klass) const { return klass->start_id(); }
 
-  void for_each_selector_offset(std::function<void (DispatchSelector, int)> callback) {
+  void for_each_selector_offset(std::function<void (DispatchSelector, word)> callback) {
     selector_offsets_.for_each(callback);
   }
 
  private:
   DispatchTable(List<ir::Method*> table,
-                const Map<DispatchSelector, int>& selector_offsets)
+                const Map<DispatchSelector, word>& selector_offsets)
       : table_(table), selector_offsets_(selector_offsets) {}
 
   List<ir::Method*> table_;
-  Map<DispatchSelector, int> selector_offsets_;
+  Map<DispatchSelector, word> selector_offsets_;
 };
 
 } // namespace toit::compiler

--- a/src/compiler/program_builder.cc
+++ b/src/compiler/program_builder.cc
@@ -135,7 +135,7 @@ void ProgramBuilder::push_lazy_initializer_id(int id) {
   push(lazy_initializer);
 }
 
-int ProgramBuilder::create_method(int selector_offset,
+int ProgramBuilder::create_method(word selector_offset,
                                   bool is_field_accessor,
                                   int arity,
                                   List<uint8> bytecodes,

--- a/src/compiler/program_builder.h
+++ b/src/compiler/program_builder.h
@@ -64,7 +64,7 @@ class ProgramBuilder {
 
   // Removes the top 'len' elements and replaces them with an array containing those elements.
   void create_class(int id, const char* name, int instance_size, bool is_runtime);
-  int create_method(int selector_offset, bool is_field_stub, int arity, List<uint8> codes, int max_height);
+  int create_method(word selector_offset, bool is_field_stub, int arity, List<uint8> codes, int max_height);
   int create_lambda(int captured_count, int arity, List<uint8> codes, int max_height);
   int create_block(int arity, List<uint8> codes, int max_height);
   int absolute_bci_for(int method_id);

--- a/src/compiler/propagation/type_propagator.cc
+++ b/src/compiler/propagation/type_propagator.cc
@@ -412,7 +412,7 @@ void TypePropagator::call_static(MethodTemplate* caller, TypeScope* scope, uint8
   std::vector<ConcreteType> arguments;
   stack->push_empty();
 
-  int offset = target.selector_offset();
+  word offset = target.selector_offset();
   bool handle_as_static = (offset == -1);
   if (offset >= 0) {
     ASSERT(arity > 0);
@@ -475,7 +475,7 @@ void TypePropagator::call_static(MethodTemplate* caller, TypeScope* scope, uint8
   stack->drop_arguments(target.arity());
 }
 
-void TypePropagator::call_virtual(MethodTemplate* caller, TypeScope* scope, uint8* site, int arity, int offset) {
+void TypePropagator::call_virtual(MethodTemplate* caller, TypeScope* scope, uint8* site, int arity, word offset) {
   TypeStack* stack = scope->top();
   TypeSet receiver = stack->local(arity - 1);
   if (site) add_input(site, stack, arity);
@@ -1082,26 +1082,26 @@ static TypeScope* process(TypeScope* scope, uint8* bcp, std::vector<Worklist*>& 
   OPCODE_END();
 
   OPCODE_BEGIN_WITH_WIDE(INVOKE_VIRTUAL, arity);
-    int offset = Utils::read_unaligned_uint16(bcp + 2);
+    word offset = Utils::read_unaligned_uint16(bcp + 2);
     propagator->call_virtual(method, scope, bcp, arity + 1, offset);
     if (stack->top_is_empty()) return scope;
   OPCODE_END();
 
   OPCODE_BEGIN(INVOKE_VIRTUAL_GET);
-    int offset = Utils::read_unaligned_uint16(bcp + 1);
+    word offset = Utils::read_unaligned_uint16(bcp + 1);
     propagator->call_virtual(method, scope, bcp, 1, offset);
     if (stack->top_is_empty()) return scope;
   OPCODE_END();
 
   OPCODE_BEGIN(INVOKE_VIRTUAL_SET);
-    int offset = Utils::read_unaligned_uint16(bcp + 1);
+    word offset = Utils::read_unaligned_uint16(bcp + 1);
     propagator->call_virtual(method, scope, bcp, 2, offset);
     if (stack->top_is_empty()) return scope;
   OPCODE_END();
 
 #define INVOKE_VIRTUAL_BINARY(opcode)                         \
   OPCODE_BEGIN(opcode);                                       \
-    int offset = program->invoke_bytecode_offset(opcode);     \
+    word offset = program->invoke_bytecode_offset(opcode);    \
     propagator->call_virtual(method, scope, bcp, 2, offset);  \
     if (stack->top_is_empty()) return scope;                  \
   OPCODE_END();
@@ -1129,13 +1129,13 @@ static TypeScope* process(TypeScope* scope, uint8* bcp, std::vector<Worklist*>& 
 #undef INVOKE_VIRTUAL_BINARY
 
   OPCODE_BEGIN(INVOKE_AT_PUT);
-    int offset = program->invoke_bytecode_offset(INVOKE_AT_PUT);
+    word offset = program->invoke_bytecode_offset(INVOKE_AT_PUT);
     propagator->call_virtual(method, scope, bcp, 3, offset);
     if (stack->top_is_empty()) return scope;
   OPCODE_END();
 
   OPCODE_BEGIN(INVOKE_SIZE);
-    int offset = program->invoke_bytecode_offset(INVOKE_SIZE);
+    word offset = program->invoke_bytecode_offset(INVOKE_SIZE);
     propagator->call_virtual(method, scope, bcp, 1, offset);
     if (stack->top_is_empty()) return scope;
   OPCODE_END();

--- a/src/compiler/propagation/type_propagator.h
+++ b/src/compiler/propagation/type_propagator.h
@@ -52,7 +52,7 @@ class TypePropagator {
   void propagate(TypeDatabase* types);
 
   void call_static(MethodTemplate* caller, TypeScope* scope, uint8* site, Method target);
-  void call_virtual(MethodTemplate* caller, TypeScope* scope, uint8* site, int arity, int offset);
+  void call_virtual(MethodTemplate* caller, TypeScope* scope, uint8* site, int arity, word offset);
   void call_block(TypeScope* scope, uint8* site, int arity);
 
   void load_block(MethodTemplate* loader, TypeScope* scope, Method method, bool linked, std::vector<Worklist*>& worklists);

--- a/src/compiler/propagation/type_set.cc
+++ b/src/compiler/propagation/type_set.cc
@@ -165,11 +165,11 @@ int TypeSet::remove_typecheck_interface(Program* program, int index, bool is_nul
   int words_per_type = TypeSet::words_per_type(program);
   bool contains_null_before = contains_null(program);
   int size_before = size(words_per_type);
-  int selector_offset = program->interface_check_offsets[index];
+  word selector_offset = program->interface_check_offsets[index];
   Iterator it(*this, words_per_type);
   while (it.has_next()) {
     unsigned id = it.next();
-    int entry_index = id + selector_offset;
+    word entry_index = id + selector_offset;
     int entry_id = program->dispatch_table[entry_index];
     if (entry_id != -1) {
       Method target(program->bytecodes, entry_id);

--- a/src/compiler/tree.cc
+++ b/src/compiler/tree.cc
@@ -639,17 +639,21 @@ static void shake(Program* program,
     }
   }
   if (Flags::report_tree_shaking) {
+    int remaining_classes_length = remaining_classes.length();
+    int program_classes_length = program->classes().length();
     printf("Kept %d out of %d classes\n",
-           remaining_classes.length(),
-           program->classes().length());
+           remaining_classes_length,
+           program_classes_length);
   }
   program->replace_classes(remaining_classes.build());
 
   auto remaining_methods = shake_methods(program->methods(), grown_methods);
   if (Flags::report_tree_shaking) {
+    int remaining_methods_length = remaining_methods.length();
+    int program_methods_length = program->methods().length();
     printf("Kept %d out of %d global functions\n",
-           remaining_methods.length(),
-           program->methods().length());
+           remaining_methods_length,
+           program_methods_length);
   }
   program->replace_methods(remaining_methods);
 
@@ -660,9 +664,11 @@ static void shake(Program* program,
     }
   }
   if (Flags::report_tree_shaking) {
+    int remaining_globals_length = remaining_globals.length();
+    int program_globals_length = program->globals().length();
     printf("Kept %d out of %d globals\n",
-           remaining_globals.length(),
-           program->globals().length());
+           remaining_globals_length,
+           program_globals_length);
   }
   program->replace_globals(remaining_globals.build());
 

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -28,9 +28,9 @@ class EncodeVisitor : public Visitor {
  public:
   explicit EncodeVisitor(ProgramOrientedEncoder* encoder) : encoder_(encoder), level_(0) {};
 
-  void visit_byte_array(const uint8* bytes, int length) {
+  void visit_byte_array(const uint8* bytes, word length) {
     encoder_->write_byte_array_header(length);
-    for (int i = 0; i < length; i++) {
+    for (word i = 0; i < length; i++) {
       encoder_->write_byte(bytes[i]);
     }
   }
@@ -39,9 +39,9 @@ class EncodeVisitor : public Visitor {
   EncodeVisitor(ProgramOrientedEncoder* encoder, int level) : encoder_(encoder), level_(level) {};
 
   // Restrictions when encoding collections.
-  const int MAX_NOF_STRING_ELEMENTS = 255;
-  const int MAX_NOF_BYTEARRAY_ELEMENTS = 40;
-  const int MAX_NOF_ARRAY_ELEMENTS = 10;
+  const word MAX_NOF_STRING_ELEMENTS = 255;
+  const word MAX_NOF_BYTEARRAY_ELEMENTS = 40;
+  const word MAX_NOF_ARRAY_ELEMENTS = 10;
 
   void visit_smi(Smi* smi) {
     encoder_->write_int(Smi::value(smi));
@@ -76,7 +76,7 @@ class EncodeVisitor : public Visitor {
     encoder_->write_int(array->length());
     encoder_->write_byte('[');
     encoder_->write_byte('#');
-    const int limit = Utils::min(array->length(), MAX_NOF_ARRAY_ELEMENTS);
+    const word limit = Utils::min(array->length(), MAX_NOF_ARRAY_ELEMENTS);
     encoder_->write_int(limit);
     EncodeVisitor sub(encoder_, level_ + 1);
     for (int i = 0; i < limit; i++) {
@@ -99,12 +99,12 @@ class EncodeVisitor : public Visitor {
 
   void visit_stack(Stack* stack);
 
-  void visit_list(Instance* instance, Array* backing_array, int size) {
+  void visit_list(Instance* instance, Array* backing_array, word size) {
     encoder_->write_header(2, 'L');
     encoder_->write_int(size);
     encoder_->write_byte('[');
     encoder_->write_byte('#');
-    const int limit = Utils::min(size, MAX_NOF_ARRAY_ELEMENTS);
+    const word limit = Utils::min(size, MAX_NOF_ARRAY_ELEMENTS);
     encoder_->write_int(limit);
     EncodeVisitor sub(encoder_, level_ + 1);
     for (int i = 0; i < limit; i++) {
@@ -283,7 +283,7 @@ void Encoder::write_byte(uint8 c) {
   buffer_->put_byte(c);
 }
 
-void Encoder::write_header(int size, uint8 tag) {
+void Encoder::write_header(word size, uint8 tag) {
   write_byte('[');
   write_byte('#');
   write_int32(size + 1);
@@ -329,7 +329,7 @@ void Encoder::write_double(double value) {
   buffer_->put_int64(raw);
 }
 
-void Encoder::write_byte_array_header(int length) {
+void Encoder::write_byte_array_header(word length) {
   write_byte('[');
   write_byte('$');
   write_byte('U');

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -58,11 +58,11 @@ class Buffer {
 
 class MallocedBuffer : public Buffer {
  public:
-  explicit MallocedBuffer(int length) : buffer_(null) {
+  explicit MallocedBuffer(word length) : buffer_(null) {
     allocate(length);
   }
 
-  void allocate(int length) {
+  void allocate(word length) {
     ASSERT(length > 0);
     ASSERT(buffer_ == null);
     buffer_ = reinterpret_cast<uint8*>(malloc(length));
@@ -93,12 +93,12 @@ class MallocedBuffer : public Buffer {
     return pos_ >= length_;
   }
 
-  int size() { return pos_; }
+  word size() { return pos_; }
 
  private:
   uint8* buffer_;
-  int length_;
-  int pos_;
+  word length_;
+  word pos_;
 };
 
 class Encoder {
@@ -109,9 +109,9 @@ class Encoder {
 
   void write_byte(uint8 c);
   void write_int(int64 value);
-  void write_header(int size, uint8 tag);
+  void write_header(word size, uint8 tag);
   void write_double(double value);
-  void write_byte_array_header(int length);
+  void write_byte_array_header(word length);
   void write_string(const char* string);
   // Always uses the 32 bit encoding even if a smaller one would suffice.  This
   // helps make the size of something predictable.

--- a/src/event_sources/epoll_linux.cc
+++ b/src/event_sources/epoll_linux.cc
@@ -35,10 +35,10 @@ enum {
   kRemove,
 };
 
-bool write_full(int fd, uint8_t* data, int length) {
-  int offset = 0;
+bool write_full(int fd, uint8_t* data, word length) {
+  word offset = 0;
   while (offset < length) {
-    int wrote = write(fd, data + offset, length - offset);
+    word wrote = write(fd, data + offset, length - offset);
     if (wrote < 0 && errno != EINTR) {
       return false;
     }
@@ -47,10 +47,10 @@ bool write_full(int fd, uint8_t* data, int length) {
   return true;
 }
 
-bool read_full(int fd, uint8_t* data, int length) {
-  int offset = 0;
+bool read_full(int fd, uint8_t* data, word length) {
+  word offset = 0;
   while (offset < length) {
-    int wrote = read(fd, data + offset, length - offset);
+    word wrote = read(fd, data + offset, length - offset);
     if (wrote < 0 && errno != EINTR) {
       return false;
     }

--- a/src/event_sources/kqueue_bsd.cc
+++ b/src/event_sources/kqueue_bsd.cc
@@ -40,10 +40,10 @@ enum {
   kRemove,
 };
 
-bool write_full(int fd, uint8_t* data, int length) {
-  int offset = 0;
+bool write_full(int fd, uint8_t* data, word length) {
+  word offset = 0;
   while (offset < length) {
-    int wrote = write(fd, data + offset, length - offset);
+    word wrote = write(fd, data + offset, length - offset);
     if (wrote < 0 && errno != EINTR) {
       return false;
     }
@@ -52,10 +52,10 @@ bool write_full(int fd, uint8_t* data, int length) {
   return true;
 }
 
-bool read_full(int fd, uint8_t* data, int length) {
-  int offset = 0;
+bool read_full(int fd, uint8_t* data, word length) {
+  word offset = 0;
   while (offset < length) {
-    int wrote = read(fd, data + offset, length - offset);
+    word wrote = read(fd, data + offset, length - offset);
     if (wrote < 0 && errno != EINTR) {
       return false;
     }

--- a/src/flash_allocation.cc
+++ b/src/flash_allocation.cc
@@ -54,7 +54,7 @@ uint32 FlashAllocation::Header::compute_checksum(const void* memory) const {
 FlashAllocation::Header::Header(const void* memory,
                                 uint8 type,
                                 const uint8* id,
-                                int size,
+                                word size,
                                 const uint8* metadata) {
   marker_ = FORMAT_MARKER;
   initialize(id_, id, sizeof(id_));
@@ -86,7 +86,7 @@ bool FlashAllocation::Header::is_valid(bool embedded) const {
   return memcmp(uuid_, EmbeddedData::uuid(), UUID_SIZE) == 0;
 }
 
-bool FlashAllocation::commit(const void* memory, int size, const Header* header) {
+bool FlashAllocation::commit(const void* memory, word size, const Header* header) {
   if (static_cast<unsigned>(size) < sizeof(Header)) return false;
   uint32 offset = FlashRegistry::offset(memory);
   bool success = FlashRegistry::write_chunk(header, offset, sizeof(Header));
@@ -94,7 +94,7 @@ bool FlashAllocation::commit(const void* memory, int size, const Header* header)
   return success && static_cast<const FlashAllocation*>(memory)->is_valid();
 }
 
-int FlashAllocation::program_assets_size(uint8** bytes, int* length) const {
+int FlashAllocation::program_assets_size(uint8** bytes, word* length) const {
   if (!program_has_assets()) return 0;
   uword allocation_address = reinterpret_cast<uword>(this);
   uword assets_address = allocation_address + size();

--- a/src/flash_allocation.h
+++ b/src/flash_allocation.h
@@ -40,10 +40,10 @@ class FlashAllocation {
     static const unsigned ID_SIZE = UUID_SIZE;
     static const unsigned METADATA_SIZE = 5;  // Picked for 16 byte alignment.
 
-    Header(const void* memory, uint8 type, const uint8* id, int size, const uint8* metadata);
+    Header(const void* memory, uint8 type, const uint8* id, word size, const uint8* metadata);
 
     const uint8* id() const { return id_; }
-    int size() const { return size_in_pages_ << FLASH_PAGE_SIZE_LOG2; }
+    word size() const { return size_in_pages_ << FLASH_PAGE_SIZE_LOG2; }
 
    private:
     // Data section for the header.
@@ -68,7 +68,7 @@ class FlashAllocation {
   bool is_region() const { return type() == FLASH_ALLOCATION_TYPE_REGION; }
 
   // Simple accessors.
-  int size() const { return header_.size(); }
+  word size() const { return header_.size(); }
   uint8 type() const { return header_.type(); }
   const uint8* id() const { return header_.id(); }
   const uint8* metadata() const { return header_.metadata(); }
@@ -81,7 +81,7 @@ class FlashAllocation {
   // whether the allocation is valid after the commit.
   // Includes the virtual memory address of the allocation in the checksum
   // just in case the flash is mapped at an incompatible address.
-  static bool commit(const void* memory, int size, const Header* header);
+  static bool commit(const void* memory, word size, const Header* header);
 
   // Get the flags encoded in the first metadata byte. Only valid for programs.
   int program_flags() const { ASSERT(is_program()); return header_.metadata()[0]; }
@@ -92,10 +92,10 @@ class FlashAllocation {
   }
 
   // Get the total size of the appended program assets if any.
-  int program_assets_size(uint8** bytes, int* length) const;
+  int program_assets_size(uint8** bytes, word* length) const;
 
  protected:
-  FlashAllocation(const uint8* id, int size) : header_(0, FLASH_ALLOCATION_TYPE_PROGRAM, id, size, null) {}
+  FlashAllocation(const uint8* id, word size) : header_(0, FLASH_ALLOCATION_TYPE_PROGRAM, id, size, null) {}
 
  private:
   Header header_;
@@ -105,15 +105,15 @@ class Reservation;
 typedef LinkedList<Reservation> ReservationList;
 class Reservation : public ReservationList::Element {
  public:
-  Reservation(int offset, int size) : offset_(offset), size_(size) {}
+  Reservation(word offset, word size) : offset_(offset), size_(size) {}
 
-  int left() const { return offset_; }
-  int right() const { return offset_ + size_; }
-  int size() const { return size_; }
+  word left() const { return offset_; }
+  word right() const { return offset_ + size_; }
+  word size() const { return size_; }
 
  private:
-  int offset_;
-  int size_;
+  word offset_;
+  word size_;
 };
 
 class RegionGrant;

--- a/src/flash_registry.h
+++ b/src/flash_registry.h
@@ -29,23 +29,23 @@ class FlashRegistry {
   static void flush();
 
   // Find next empty slot.
-  static int find_next(int offset, ReservationList::Iterator* reservations);
+  static int find_next(word offset, ReservationList::Iterator* reservations);
 
   // Get a pointer to the memory of an allocation.
-  static const FlashAllocation* allocation(int offset);
+  static const FlashAllocation* allocation(word offset);
 
   // Get a pointer to the memory of a region.
-  static uint8* region(int offset, int size) {
+  static uint8* region(word offset, word size) {
     ASSERT(is_allocations_set_up());
     ASSERT(0 <= offset && offset + size <= allocations_size());
     return reinterpret_cast<uint8*>(allocations_memory()) + offset;
   }
 
   // Flash writing support.
-  static bool write_chunk(const void* chunk, int offset, int size);
+  static bool write_chunk(const void* chunk, word offset, word size);
 
   // Get the offset from the cursor.
-  static int offset(const void* cursor) {
+  static word offset(const void* cursor) {
     ASSERT(is_allocations_set_up());
     word offset = Utils::address_distance(allocations_memory(), cursor);
     ASSERT(0 <= offset && offset < allocations_size());
@@ -53,8 +53,8 @@ class FlashRegistry {
   }
 
   // Flash erasing support.
-  static bool is_erased(int offset, int size);
-  static int erase_chunk(int offset, int size);
+  static bool is_erased(word offset, word size);
+  static int erase_chunk(word offset, word size);
   static bool erase_flash_registry();
 
   // Get the size of the allocations area in bytes.

--- a/src/flash_registry_esp32.cc
+++ b/src/flash_registry_esp32.cc
@@ -30,17 +30,17 @@ static const esp_partition_t* allocations_partition = null;
 static spi_flash_mmap_handle_t allocations_handle;
 uint8* FlashRegistry::allocations_memory_ = null;
 
-static bool is_erased_page(int offset) {
+static bool is_erased_page(word offset) {
   ASSERT(Utils::is_aligned(offset, FLASH_PAGE_SIZE));
   return FlashRegistry::is_erased(offset, FLASH_PAGE_SIZE);
 }
 
-static esp_err_t ensure_erased(int offset, int size) {
+static esp_err_t ensure_erased(word offset, word size) {
   FlashRegistry::flush();
   ASSERT(Utils::is_aligned(offset, FLASH_PAGE_SIZE));
   ASSERT(Utils::is_aligned(size, FLASH_PAGE_SIZE));
   int to = offset + size;
-  for (int cursor = offset; cursor < to; cursor += FLASH_PAGE_SIZE) {
+  for (word cursor = offset; cursor < to; cursor += FLASH_PAGE_SIZE) {
     if (!is_erased_page(cursor)) {
       // Determine size of dirty range.
       int dirty_to = cursor + FLASH_PAGE_SIZE;
@@ -85,7 +85,7 @@ int FlashRegistry::allocations_size() {
   return static_cast<int>(allocations_partition->size);
 }
 
-int FlashRegistry::erase_chunk(int offset, int size) {
+int FlashRegistry::erase_chunk(word offset, word size) {
   ASSERT(Utils::is_aligned(offset, FLASH_PAGE_SIZE));
   size = Utils::round_up(size, FLASH_PAGE_SIZE);
   esp_err_t result = ensure_erased(offset, size);
@@ -98,7 +98,7 @@ int FlashRegistry::erase_chunk(int offset, int size) {
   }
 }
 
-bool FlashRegistry::write_chunk(const void* chunk, int offset, int size) {
+bool FlashRegistry::write_chunk(const void* chunk, word offset, word size) {
   esp_err_t result = esp_partition_write(allocations_partition, offset, chunk, size);
   return result == ESP_OK;
 }

--- a/src/flash_registry_posix.cc
+++ b/src/flash_registry_posix.cc
@@ -41,14 +41,14 @@ uint8* FlashRegistry::allocations_memory_ = null;
 static bool is_file_backed = false;
 
 static long pagesize = 0;
-static int dirty_start = INT32_MAX;
-static int dirty_end = 0;
+static word dirty_start = INT32_MAX;
+static word dirty_end = 0;
 
 static bool is_dirty() {
   return dirty_start < dirty_end;
 }
 
-static void mark_dirty(int offset, int size) {
+static void mark_dirty(word offset, word size) {
   dirty_start = Utils::min(dirty_start, offset);
   dirty_end = Utils::max(dirty_end, offset + size);
 }
@@ -115,8 +115,8 @@ void FlashRegistry::tear_down() {
 
 void FlashRegistry::flush() {
   if (!is_file_backed || !is_dirty()) return;
-  int offset = Utils::round_down(dirty_start, pagesize);
-  int size = Utils::round_up(dirty_end - offset, pagesize);
+  word offset = Utils::round_down(dirty_start, pagesize);
+  word size = Utils::round_up(dirty_end - offset, pagesize);
   if (msync(void_cast(allocations_memory_ + offset), size, MS_SYNC) != 0) {
     perror("FlashRegistry::flush/msync");
   }
@@ -129,7 +129,7 @@ int FlashRegistry::allocations_size() {
   return ALLOCATION_SIZE;
 }
 
-int FlashRegistry::erase_chunk(int offset, int size) {
+int FlashRegistry::erase_chunk(word offset, word size) {
   ASSERT(Utils::is_aligned(offset, FLASH_PAGE_SIZE));
   size = Utils::round_up(size, FLASH_PAGE_SIZE);
   memset(region(offset, size), 0xff, size);
@@ -137,10 +137,10 @@ int FlashRegistry::erase_chunk(int offset, int size) {
   return size;
 }
 
-bool FlashRegistry::write_chunk(const void* chunk, int offset, int size) {
+bool FlashRegistry::write_chunk(const void* chunk, word offset, word size) {
   uint8* destination = region(offset, size);
   const uint8* source = static_cast<const uint8*>(chunk);
-  for (int i = 0; i < size; i++) destination[i] &= source[i];
+  for (word i = 0; i < size; i++) destination[i] &= source[i];
   mark_dirty(offset, size);
   return true;
 }

--- a/src/flash_registry_shared.cc
+++ b/src/flash_registry_shared.cc
@@ -20,7 +20,7 @@
 
 namespace toit {
 
-int FlashRegistry::find_next(int offset, ReservationList::Iterator* it) {
+int FlashRegistry::find_next(word offset, ReservationList::Iterator* it) {
   ASSERT(is_allocations_set_up());
   if (offset >= allocations_size()) return -1;
 
@@ -36,7 +36,7 @@ int FlashRegistry::find_next(int offset, ReservationList::Iterator* it) {
   }
 
   // We are at a hole. Return the first address that is not part of the hole.
-  for (int i = offset + FLASH_PAGE_SIZE; i < allocations_size(); i += FLASH_PAGE_SIZE) {
+  for (word i = offset + FLASH_PAGE_SIZE; i < allocations_size(); i += FLASH_PAGE_SIZE) {
     if ((*it) != ReservationList::Iterator(null) && (*it)->left() == i) return i;
     const FlashAllocation* probe = reinterpret_cast<const FlashAllocation*>(allocations_memory() + i);
     if (probe->is_valid()) return i;
@@ -44,7 +44,7 @@ int FlashRegistry::find_next(int offset, ReservationList::Iterator* it) {
   return allocations_size();
 }
 
-const FlashAllocation* FlashRegistry::allocation(int offset) {
+const FlashAllocation* FlashRegistry::allocation(word offset) {
   const FlashAllocation* result = null;
   if ((offset & 1) == 0) {
     FlashAllocation* probe = reinterpret_cast<FlashAllocation*>(region(offset, 0));
@@ -59,14 +59,14 @@ const FlashAllocation* FlashRegistry::allocation(int offset) {
   return result;
 }
 
-static bool is_erased_unaligned(const uint8* memory, int from, int to) {
-  for (int i = from; i < to; i++) {
+static bool is_erased_unaligned(const uint8* memory, word from, word to) {
+  for (word i = from; i < to; i++) {
     if (memory[i] != 0xff) return false;
   }
   return true;
 }
 
-static bool is_erased_aligned(const uint8* memory, int from, int to) {
+static bool is_erased_aligned(const uint8* memory, word from, word to) {
   ASSERT(Utils::is_aligned(memory + from, sizeof(uword)));
   ASSERT(Utils::is_aligned(memory + to, sizeof(uword)));
   const uword* cursor = reinterpret_cast<const uword*>(memory + from);
@@ -78,22 +78,22 @@ static bool is_erased_aligned(const uint8* memory, int from, int to) {
   return true;
 }
 
-bool FlashRegistry::is_erased(int offset, int size) {
+bool FlashRegistry::is_erased(word offset, word size) {
   const uint8* memory = region(offset, size);
-  int cursor = 0;
+  word cursor = 0;
 
-  int from_aligned = Utils::round_up(offset, sizeof(uword));
-  int unaligned_prefix = from_aligned - offset;
+  word from_aligned = Utils::round_up(offset, sizeof(uword));
+  word unaligned_prefix = from_aligned - offset;
   if (unaligned_prefix > 0) {
     if (!is_erased_unaligned(memory, 0, unaligned_prefix)) return false;
     cursor = unaligned_prefix;
   }
 
-  int to = offset + size;
-  int to_aligned = Utils::round_down(to, sizeof(uword));
-  int aligned_middle = to_aligned - from_aligned;
+  word to = offset + size;
+  word to_aligned = Utils::round_down(to, sizeof(uword));
+  word aligned_middle = to_aligned - from_aligned;
   if (aligned_middle > 0) {
-    int cursor_next = cursor + aligned_middle;
+    word cursor_next = cursor + aligned_middle;
     if (!is_erased_aligned(memory, cursor, cursor_next)) return false;
     cursor = cursor_next;
   }

--- a/src/flash_registry_win.cc
+++ b/src/flash_registry_win.cc
@@ -22,7 +22,7 @@
 
 namespace toit {
 
-static const int ALLOCATION_SIZE = 2 * MB;
+static const word ALLOCATION_SIZE = 2 * MB;
 
 // An aligned (FLASH_BASED_SIZE) view into the allocations_malloced.
 uint8* FlashRegistry::allocations_memory_ = null;
@@ -52,17 +52,17 @@ int FlashRegistry::allocations_size() {
   return ALLOCATION_SIZE;
 }
 
-int FlashRegistry::erase_chunk(int offset, int size) {
+int FlashRegistry::erase_chunk(word offset, word size) {
   ASSERT(Utils::is_aligned(offset, FLASH_PAGE_SIZE));
   size = Utils::round_up(size, FLASH_PAGE_SIZE);
   memset(region(offset, size), 0xff, size);
   return size;
 }
 
-bool FlashRegistry::write_chunk(const void* chunk, int offset, int size) {
+bool FlashRegistry::write_chunk(const void* chunk, word offset, word size) {
   uint8* destination = region(offset, size);
   const uint8* source = static_cast<const uint8*>(chunk);
-  for (int i = 0; i < size; i++) destination[i] &= source[i];
+  for (word i = 0; i < size; i++) destination[i] &= source[i];
   return true;
 }
 

--- a/src/heap.cc
+++ b/src/heap.cc
@@ -35,7 +35,7 @@
 namespace toit {
 
 Instance* ObjectHeap::allocate_instance(Smi* class_id) {
-  int size = program()->allocation_instance_size_for(class_id);
+  word size = program()->allocation_instance_size_for(class_id);
   TypeTag class_tag = program()->class_tag_for(class_id);
   word result_word = allocate_new_space(size);
   if (!result_word) return null;  // Allocation failure.
@@ -49,7 +49,7 @@ Instance* ObjectHeap::allocate_instance(Smi* class_id) {
   return Instance::cast(result);
 }
 
-Array* ObjectHeap::allocate_array(int length, Object* filler) {
+Array* ObjectHeap::allocate_array(word length, Object* filler) {
   ASSERT(length >= 0);
   ASSERT(length <= Array::max_length_in_process());
   HeapObject* result = _allocate_raw(Array::allocation_size(length));
@@ -62,7 +62,7 @@ Array* ObjectHeap::allocate_array(int length, Object* filler) {
   return Array::cast(result);
 }
 
-ByteArray* ObjectHeap::allocate_internal_byte_array(int length) {
+ByteArray* ObjectHeap::allocate_internal_byte_array(word length) {
   ASSERT(length >= 0);
   // Byte array should fit within one heap block.
   ASSERT(length <= ByteArray::max_internal_size_in_process());
@@ -92,7 +92,7 @@ LargeInteger* ObjectHeap::allocate_large_integer(int64 value) {
   return LargeInteger::cast(result);
 }
 
-String* ObjectHeap::allocate_internal_string(int length) {
+String* ObjectHeap::allocate_internal_string(word length) {
   ASSERT(length >= 0);
   ASSERT(length <= String::max_internal_size_in_process());
   HeapObject* result = _allocate_raw(String::internal_allocation_size(length));
@@ -208,7 +208,7 @@ void ObjectHeap::unregister_external_allocation(word size) {
   ASSERT(old_external_memory >= external_memory);
 }
 
-ByteArray* ObjectHeap::allocate_external_byte_array(int length, uint8* memory, bool dispose, bool clear_content) {
+ByteArray* ObjectHeap::allocate_external_byte_array(word length, uint8* memory, bool dispose, bool clear_content) {
   ByteArray* result = unvoid_cast<ByteArray*>(_allocate_raw(ByteArray::external_allocation_size()));
   if (result == null) return null;  // Allocation failure.
   // Initialize object.
@@ -216,7 +216,7 @@ ByteArray* ObjectHeap::allocate_external_byte_array(int length, uint8* memory, b
   result->_initialize_external_memory(length, memory, clear_content);
   //  We add a specialized finalizer on the result so we can free the external memory.
   if (dispose) {
-    if (Flags::allocation) printf("External memory for byte array %p [length = %d] setup for finalization.\n", memory, length);
+    if (Flags::allocation) printf("External memory for byte array %p [length = %" PRIdPTR "] setup for finalization.\n", memory, length);
     Process* process = owner();
     ASSERT(process != null);
     if (!add_vm_finalizer(result)) {
@@ -227,7 +227,7 @@ ByteArray* ObjectHeap::allocate_external_byte_array(int length, uint8* memory, b
   return result;
 }
 
-String* ObjectHeap::allocate_external_string(int length, uint8* memory, bool dispose) {
+String* ObjectHeap::allocate_external_string(word length, uint8* memory, bool dispose) {
   String* result = unvoid_cast<String*>(_allocate_raw(String::external_allocation_size()));
   if (result == null) return null;  // Allocation failure.
   // Initialize object.
@@ -243,7 +243,7 @@ String* ObjectHeap::allocate_external_string(int length, uint8* memory, bool dis
   }
   if (dispose) {
     // Ensure finalizer is created for string with external memory.
-    if (Flags::allocation) printf("External memory for string %p [length = %d] setup for finalization.\n", memory, length);
+    if (Flags::allocation) printf("External memory for string %p [length = %" PRIdPTR "] setup for finalization.\n", memory, length);
     Process* process = owner();
     ASSERT(process != null);
     if (!add_vm_finalizer(result)) {
@@ -270,8 +270,8 @@ Task* ObjectHeap::allocate_task() {
   return result;
 }
 
-Stack* ObjectHeap::allocate_stack(int length) {
-  int size = Stack::allocation_size(length);
+Stack* ObjectHeap::allocate_stack(word length) {
+  word size = Stack::allocation_size(length);
   Stack* result = unvoid_cast<Stack*>(_allocate_raw(size));
   if (result == null) return null;  // Allocation failure.
   // Initialize object.

--- a/src/heap.h
+++ b/src/heap.h
@@ -54,8 +54,7 @@ class ObjectHeap {
   ObjectHeap(Program* program, Process* owner, Chunk* initial_chunk, Object** global_variables, Mutex* mutex);
   ~ObjectHeap();
 
-  // TODO: In the new heap there need not be a max allocation size.
-  static int max_allocation_size() { return TOIT_PAGE_SIZE - 96; }
+  static word max_allocation_size() { return TOIT_PAGE_SIZE - 96; }
 
   inline void do_objects(const std::function<void (HeapObject*)>& func) {
     two_space_heap_.do_objects(func);
@@ -66,11 +65,11 @@ class ObjectHeap {
   // Shared allocation operations.
   // Allocates an instance object in new space and fills it with nulls.
   Instance* allocate_instance(Smi* class_id);
-  Array* allocate_array(int length, Object* filler);
-  ByteArray* allocate_external_byte_array(int length, uint8* memory, bool dispose, bool clear_content = true);
-  String* allocate_external_string(int length, uint8* memory, bool dispose);
-  ByteArray* allocate_internal_byte_array(int length);
-  String* allocate_internal_string(int length);
+  Array* allocate_array(word length, Object* filler);
+  ByteArray* allocate_external_byte_array(word length, uint8* memory, bool dispose, bool clear_content = true);
+  String* allocate_external_string(word length, uint8* memory, bool dispose);
+  ByteArray* allocate_internal_byte_array(word length);
+  String* allocate_internal_string(word length);
   Double* allocate_double(double value);
   LargeInteger* allocate_large_integer(int64 value);
 
@@ -114,7 +113,7 @@ class ObjectHeap {
   ObjectHeap(Program* program, Process* owner);
 
   Task* allocate_task();
-  Stack* allocate_stack(int length);
+  Stack* allocate_stack(word length);
   // Convenience methods for allocating proxy like objects.
   ByteArray* allocate_proxy(int length, uint8* memory, bool dispose = false) {
     return allocate_external_byte_array(length, memory, dispose, false);
@@ -177,11 +176,11 @@ class ObjectHeap {
 
  private:
   Program* const program_;
-  HeapObject* _allocate_raw(int byte_size) {
+  HeapObject* _allocate_raw(word byte_size) {
     return two_space_heap_.allocate(byte_size);
   }
 
-  inline word allocate_new_space(int byte_size) {
+  inline word allocate_new_space(word byte_size) {
     return two_space_heap_.allocate_new_space(byte_size);
   }
 

--- a/src/heap_report.h
+++ b/src/heap_report.h
@@ -61,7 +61,7 @@ class HeapFragmentationDumper : public Buffer {
 
   void log_allocation(void* allocation, uword size, void* tag);
   void write_start();
-  void rewrite_start(int size, int pages);
+  void rewrite_start(word size, word pages);
   void write_end();
 
   void flush() {

--- a/src/heap_roots.cc
+++ b/src/heap_roots.cc
@@ -34,10 +34,10 @@ static bool recursive_zap_dead_values(Program* program, Object* backing_array_ob
   if (!is_heap_object(backing_array_object)) return false;  // Defensive.
   if (is_array(backing_array_object)) {
     Array* backing_array = Array::cast(backing_array_object);
-    int size = backing_array->length();
+    word size = backing_array->length();
     // The backing has the order key, value, key, value...
     // We only zap the values.
-    for (int i = 1; i < size; i += 2) {
+    for (word i = 1; i < size; i += 2) {
       Object* entry_object = backing_array->at(i);
       if (is_smi(entry_object)) continue;
       HeapObject* entry = HeapObject::cast(entry_object);
@@ -54,8 +54,8 @@ static bool recursive_zap_dead_values(Program* program, Object* backing_array_ob
     Object* vector_object = instance->at(Instance::LARGE_ARRAY_VECTOR_INDEX);
     if (!is_array(vector_object)) return false;  // Defensive.
     Array* vector = Array::cast(vector_object);
-    int size = vector->length();
-    for (int i = 0; i < size; i++) {
+    word size = vector->length();
+    for (word i = 0; i < size; i++) {
       bool arraylet_had_zaps = recursive_zap_dead_values(program, vector->at(i), oracle);
       if (arraylet_had_zaps) has_zapped = true;
     }
@@ -82,7 +82,7 @@ static bool zap_dead_values(Program* program, Instance* map, RootCallback* cb, L
 class MarkingShim : public RootCallback {
  public:
   MarkingShim(RootCallback* cb) : cb_(cb) {}
-  virtual void do_roots(Object** roots, int length) {
+  virtual void do_roots(Object** roots, word length) {
     cb_->do_roots(roots, length);
   }
   virtual bool shrink_stacks() const { UNREACHABLE(); }

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -240,16 +240,16 @@ Object** Interpreter::handle_stack_overflow(Object** sp, OverflowState* state, M
   }
 
   Process* process = process_;
-  int length = process->task()->stack()->length();
-  int new_length = -1;
+  word length = process->task()->stack()->length();
+  word new_length = -1;
   if (length < Stack::max_length()) {
-    int needed_space = method.max_height() + RESERVED_STACK_FOR_CALLS;
-    int headroom = sp - limit_;
+    word needed_space = method.max_height() + RESERVED_STACK_FOR_CALLS;
+    word headroom = sp - limit_;
     ASSERT(headroom < needed_space);  // We shouldn't try to grow the stack otherwise.
 
     new_length = Utils::max(length + (length >> 1), (length - headroom) + needed_space);
     new_length = Utils::min(Stack::max_length(), new_length);
-    int new_headroom = headroom + (new_length - length);
+    word new_headroom = headroom + (new_length - length);
     if (new_headroom < needed_space) new_length = -1;  // Growing the stack will not give us enough space.
   }
 
@@ -265,7 +265,7 @@ Object** Interpreter::handle_stack_overflow(Object** sp, OverflowState* state, M
   for (int attempts = 1; new_stack == null && attempts < 4; attempts++) {
 #ifdef TOIT_GC_LOGGING
     if (attempts == 3) {
-      printf("[gc @ %p%s | 3rd time stack allocate failure %d->%d]\n",
+      printf("[gc @ %p%s | 3rd time stack allocate failure % " PRIdPTR "->% " PRIdPTR "]\n",
           process, VM::current()->scheduler()->is_boot_process(process) ? "*" : " ",
           length, new_length);
     }

--- a/src/interpreter_run.cc
+++ b/src/interpreter_run.cc
@@ -81,12 +81,12 @@ inline bool Interpreter::typecheck_interface(Program* program,
                                              int interface_selector_index,
                                              bool is_nullable) const {
   if (is_nullable && value == program->null_object()) return true;
-  int selector_offset = program->interface_check_offsets[interface_selector_index];
+  word selector_offset = program->interface_check_offsets[interface_selector_index];
   Method target = program->find_method(value, selector_offset);
   return target.is_valid();
 }
 
-Method Program::find_method(Object* receiver, int offset) {
+Method Program::find_method(Object* receiver, word offset) {
   Smi* class_id = is_smi(receiver) ? smi_class_id() : HeapObject::cast(receiver)->class_id();
   int index = Smi::value(class_id) + offset;
   int entry_id = dispatch_table[index];
@@ -697,7 +697,7 @@ Interpreter::Result Interpreter::run() {
 
   OPCODE_BEGIN_WITH_WIDE(INVOKE_VIRTUAL, stack_offset);
     Object* receiver = STACK_AT(stack_offset);
-    int selector_offset = Utils::read_unaligned_uint16(bcp + 2);
+    word selector_offset = Utils::read_unaligned_uint16(bcp + 2);
     Method target = program->find_method(receiver, selector_offset);
     if (!target.is_valid()) {
       PUSH(receiver);
@@ -709,7 +709,7 @@ Interpreter::Result Interpreter::run() {
 
   OPCODE_BEGIN(INVOKE_VIRTUAL_GET);
     Object* receiver = STACK_AT(0);
-    unsigned offset = Utils::read_unaligned_uint16(bcp + 1);
+    word offset = Utils::read_unaligned_uint16(bcp + 1);
     Method target = program->find_method(receiver, offset);
     if (!target.is_valid()) {
       PUSH(receiver);
@@ -741,7 +741,7 @@ Interpreter::Result Interpreter::run() {
 
   OPCODE_BEGIN(INVOKE_VIRTUAL_SET);
     Object* receiver = STACK_AT(1);
-    unsigned offset = Utils::read_unaligned_uint16(bcp + 1);
+    word offset = Utils::read_unaligned_uint16(bcp + 1);
     Method target = program->find_method(receiver, offset);
     if (!target.is_valid()) {
       PUSH(receiver);

--- a/src/messaging.cc
+++ b/src/messaging.cc
@@ -140,7 +140,7 @@ bool TisonEncoder::encode(Object* object) {
   // Later, when we're not encoding for size, we know the payload size
   // and will encode this before the payload.
   if (encoding_for_size()) {
-    unsigned payload_size = size() - sizeof(uint32);
+    uword payload_size = size() - sizeof(uint32);
     ASSERT(payload_size > 0 && payload_size_ == 0);
     // Make the payload size available to the outside.
     payload_size_ = payload_size;
@@ -182,8 +182,8 @@ bool MessageEncoder::encode_any(Object* object) {
       Object* from_object = instance->at(Instance::LIST_SLICE_FROM_INDEX);
       Object* to_object = instance->at(Instance::LIST_SLICE_TO_INDEX);
       if (!is_smi(from_object) || !is_smi(to_object)) return false;
-      int from = Smi::value(from_object);
-      int to = Smi::value(to_object);
+      word from = Smi::value(from_object);
+      word to = Smi::value(to_object);
       if (is_array(list)) return encode_array(Array::cast(list), from, to);
       return encode_list(Instance::cast(list), from, to);
     } else if (class_id == program->map_class_id()) {
@@ -229,17 +229,17 @@ bool MessageEncoder::encode_any(Object* object) {
   return false;
 }
 
-bool MessageEncoder::encode_array(Array* object, int from, int to) {
+bool MessageEncoder::encode_array(Array* object, word from, word to) {
   ASSERT(from <= to);
   write_uint8(TAG_ARRAY);
   write_cardinal(to - from);
-  for (int i = from; i < to; i++) {
+  for (word i = from; i < to; i++) {
     if (!encode_any(object->at(i))) return false;
   }
   return true;
 }
 
-bool MessageEncoder::encode_list(Instance* instance, int from, int to) {
+bool MessageEncoder::encode_list(Instance* instance, word from, word to) {
   Object* backing = instance->at(Instance::LIST_ARRAY_INDEX);
   if (is_smi(backing)) return false;
   Smi* class_id = HeapObject::cast(backing)->class_id();
@@ -279,8 +279,8 @@ bool MessageEncoder::encode_map(Instance* instance) {
     return false;
   }
   Array* array = Array::cast(backing);
-  int count = 0;
-  for (int i = 0; count < size; i += 2) {
+  word count = 0;
+  for (word i = 0; count < size; i += 2) {
     Object* key = array->at(i);
     Object* value = array->at(i + 1);
     if (is_smi(key) || HeapObject::cast(key)->class_id() != program_->tombstone_class_id()) {
@@ -315,7 +315,7 @@ bool MessageEncoder::encode_arguments(char** argv, int argc) {
   write_uint8(TAG_ARRAY);
   write_cardinal(argc);
   for (int i = 0; i < argc; i++) {
-    int length = strlen(argv[i]);
+    word length = strlen(argv[i]);
     write_uint8(TAG_STRING_INLINE);
     write_cardinal(length);
     if (!encoding_for_size()) {
@@ -334,7 +334,7 @@ bool MessageEncoder::encode_bundles(SnapshotBundle system, SnapshotBundle applic
 }
 #endif
 
-bool MessageEncoder::encode_bytes_external(void* data, int length, bool free_on_failure) {
+bool MessageEncoder::encode_bytes_external(void* data, word length, bool free_on_failure) {
   if (encoding_tison()) return false;
   write_uint8(TAG_BYTE_ARRAY);
   write_cardinal(length);
@@ -355,7 +355,7 @@ bool MessageEncoder::encode_copy(Object* object, int tag) {
   ASSERT(TAG_BYTE_ARRAY_INLINE == TAG_BYTE_ARRAY + 1);
 
   const uint8* source;
-  int length = 0;
+  word length = 0;
   if (!object->byte_content(program_, &source, &length, STRINGS_OR_BYTE_ARRAYS)) {
     // TODO(kasper): Report meaningful error.
     return false;
@@ -423,7 +423,7 @@ void MessageEncoder::write_uint64(uint64 value) {
 
 MessageDecoder::MessageDecoder(Process* process,
                                const uint8* buffer,
-                               int size,
+                               word size,
                                MessageFormat format)
     : process_(process)
     , program_(process ? process->program() : null)
@@ -457,7 +457,7 @@ void MessageDecoder::remove_disposing_finalizers() {
   }
 }
 
-void MessageDecoder::register_external(HeapObject* object, int length) {
+void MessageDecoder::register_external(HeapObject* object, word length) {
   ASSERT(!decoding_tison());
   unsigned index = externals_count();
   if (index >= ARRAY_SIZE(externals_)) {
@@ -483,7 +483,7 @@ Object* TisonDecoder::decode() {
     }
     return mark_malformed();
   }
-  int payload_size = read_cardinal();
+  word payload_size = read_cardinal();
   if (payload_size != remaining()) return mark_malformed();
   Object* result = decode_any();
   if (!success()) return result;
@@ -554,16 +554,16 @@ void MessageDecoder::deallocate() {
       break;
     case TAG_STRING_INLINE:
     case TAG_BYTE_ARRAY_INLINE: {
-      int length = read_cardinal();
+      word length = read_cardinal();
       cursor_ += length;
       break;
     }
     case TAG_ARRAY:
     case TAG_MAP: {
-      int length = read_cardinal();
+      word length = read_cardinal();
       // Maps have two nested encodings per entry.
       if (tag == TAG_MAP) length *= 2;
-      for (int i = 0; i < length; i++) deallocate();
+      for (word i = 0; i < length; i++) deallocate();
       break;
     }
     case TAG_DOUBLE:
@@ -576,7 +576,7 @@ void MessageDecoder::deallocate() {
 }
 
 Object* MessageDecoder::decode_string(bool inlined) {
-  int length = read_cardinal();
+  word length = read_cardinal();
   if (length == 0 && overflown()) return mark_malformed();
   String* result = null;
   if (inlined) {
@@ -594,11 +594,11 @@ Object* MessageDecoder::decode_string(bool inlined) {
 }
 
 Object* MessageDecoder::decode_array() {
-  int length = read_cardinal();
+  word length = read_cardinal();
   if (length == 0 && overflown()) return mark_malformed();
   Array* result = process_->object_heap()->allocate_array(length, Smi::zero());
   if (result == null) return mark_allocation_failed();
-  for (int i = 0; i < length; i++) {
+  for (word i = 0; i < length; i++) {
     Object* inner = decode_any();
     if (!success()) return inner;
     result->at_put(i, inner);
@@ -607,7 +607,7 @@ Object* MessageDecoder::decode_array() {
 }
 
 Object* MessageDecoder::decode_map() {
-  int size = read_cardinal();
+  word size = read_cardinal();
   if (size == 0 && overflown()) return mark_malformed();
   Instance* result = process_->object_heap()->allocate_instance(program_->map_class_id());
   if (result == null) return mark_allocation_failed();
@@ -620,7 +620,7 @@ Object* MessageDecoder::decode_map() {
   }
   Array* array = process_->object_heap()->allocate_array(size * 2, Smi::zero());
   if (array == null) return mark_allocation_failed();
-  for (int i = 0; i < size * 2; i++) {
+  for (word i = 0; i < size * 2; i++) {
     Object* inner = decode_any();
     if (!success()) return inner;
     array->at_put(i, inner);
@@ -633,7 +633,7 @@ Object* MessageDecoder::decode_map() {
 }
 
 Object* MessageDecoder::decode_byte_array(bool inlined) {
-  int length = read_cardinal();
+  word length = read_cardinal();
   if (length == 0 && overflown()) return mark_malformed();
   ByteArray* result = null;
   if (inlined) {
@@ -654,7 +654,7 @@ Object* MessageDecoder::decode_byte_array(bool inlined) {
   return result;
 }
 
-bool MessageDecoder::decode_byte_array_external(void** data, int* length) {
+bool MessageDecoder::decode_byte_array_external(void** data, word* length) {
   if (decoding_tison()) return false;
   int tag = read_uint8();
   if (tag == TAG_BYTE_ARRAY) {
@@ -693,8 +693,8 @@ Object* MessageDecoder::decode_large_integer() {
 
 uint8* MessageDecoder::read_pointer() {
   uint8* result = null;
-  int cursor = cursor_;
-  int next = cursor + sizeof(result);
+  word cursor = cursor_;
+  word next = cursor + sizeof(result);
   if (next <= size_) {
     memcpy(&result, &buffer_[cursor], sizeof(result));
   }
@@ -718,8 +718,8 @@ uword MessageDecoder::read_cardinal() {
 
 uint32 MessageDecoder::read_uint32() {
   uint32 result = 0;
-  int cursor = cursor_;
-  int next = cursor + sizeof(result);
+  word cursor = cursor_;
+  word next = cursor + sizeof(result);
   if (next <= size_) {
     memcpy(&result, &buffer_[cursor], sizeof(result));
   }
@@ -729,8 +729,8 @@ uint32 MessageDecoder::read_uint32() {
 
 uint64 MessageDecoder::read_uint64() {
   uint64 result = 0;
-  int cursor = cursor_;
-  int next = cursor + sizeof(result);
+  word cursor = cursor_;
+  word next = cursor + sizeof(result);
   if (next <= size_) {
     memcpy(&result, &buffer_[cursor], sizeof(result));
   }
@@ -761,8 +761,8 @@ bool ExternalSystemMessageHandler::set_priority(uint8 priority) {
   return (pid < 0) ? false : vm_->scheduler()->set_priority(pid, priority);
 }
 
-bool ExternalSystemMessageHandler::send(int pid, int type, void* data, int length, bool free_on_failure) {
-  int buffer_size = 0;
+bool ExternalSystemMessageHandler::send(int pid, int type, void* data, word length, bool free_on_failure) {
+  word buffer_size = 0;
   { MessageEncoder encoder(null);
     encoder.encode_bytes_external(data, length);
     buffer_size = encoder.size();
@@ -801,7 +801,7 @@ Interpreter::Result ExternalSystemMessageHandler::run() {
       SystemMessage* system_message = static_cast<SystemMessage*>(message);
       MessageDecoder decoder(system_message->data());
       void* data = null;
-      int length = 0;
+      word length = 0;
       bool success = decoder.decode_byte_array_external(&data, &length);
 
       // If the allocation failed, we ask the handler if we should retry the failed

--- a/src/messaging.cc
+++ b/src/messaging.cc
@@ -803,6 +803,9 @@ Interpreter::Result ExternalSystemMessageHandler::run() {
       void* data = null;
       word length = 0;
       bool success = decoder.decode_byte_array_external(&data, &length);
+      if (success && length > INT_MAX) {
+        abort();
+      }
 
       // If the allocation failed, we ask the handler if we should retry the failed
       // allocation. If so, we leave the message in place and try again. Otherwise,

--- a/src/messaging.h
+++ b/src/messaging.h
@@ -365,7 +365,7 @@ class ExternalSystemMessageHandler : private ProcessRunner {
   bool set_priority(uint8 priority);
 
   // Callback for received messages.
-  virtual void on_message(int sender, int type, void* data, word length) = 0;
+  virtual void on_message(int sender, int type, void* data, int length) = 0;
 
   // Send a message to a specific pid, using Scheduler::send_message. Returns
   // true if the data was sent or false if an error occurred. The data is

--- a/src/objects.cc
+++ b/src/objects.cc
@@ -25,7 +25,7 @@
 
 namespace toit {
 
-bool Object::byte_content(Program* program, const uint8** content, int* length, BlobKind strings_only) const {
+bool Object::byte_content(Program* program, const uint8** content, word* length, BlobKind strings_only) const {
   if (is_string(this)) {
     String::Bytes bytes(String::cast(this));
     *length = bytes.length();
@@ -62,8 +62,8 @@ bool Object::byte_content(Program* program, const uint8** content, int* length, 
       // TODO(florian): we could eventually accept larger integers here.
       if (!is_smi(from)) return false;
       if (!is_smi(to)) return false;
-      int from_value = Smi::value(from);
-      int to_value = Smi::value(to);
+      word from_value = Smi::value(from);
+      word to_value = Smi::value(to);
       bool inner_success = HeapObject::cast(wrapped)->byte_content(program, content, length, strings_only);
       if (!inner_success) return false;
       if (0 <= from_value && from_value <= to_value && to_value <= *length) {
@@ -79,7 +79,7 @@ bool Object::byte_content(Program* program, const uint8** content, int* length, 
 
 bool Object::byte_content(Program* program, Blob* blob, BlobKind strings_only) const {
   const uint8* content = null;
-  int length = 0;
+  word length = 0;
   bool result = byte_content(program, &content, &length, strings_only);
   *blob = Blob(content, length);
   return result;
@@ -90,8 +90,8 @@ bool Blob::slow_equals(const char* c_string) const {
   return memcmp(address(), c_string, length()) == 0;
 }
 
-int HeapObject::size(Program* program) const {
-  int size = program->instance_size_for(this);
+word HeapObject::size(Program* program) const {
+  word size = program->instance_size_for(this);
   if (size != 0) return size;
   switch (class_tag()) {
     case TypeTag::ARRAY_TAG:
@@ -187,8 +187,8 @@ bool HeapObject::is_a_free_object() {
 class PointerRootCallback : public RootCallback {
  public:
   explicit PointerRootCallback(PointerCallback* callback) : callback(callback) {}
-  void do_roots(Object** roots, int length) {
-    for (int i = 0; i < length; i++) {
+  void do_roots(Object** roots, word length) {
+    for (word i = 0; i < length; i++) {
       callback->object_address(&roots[i]);
     }
   }
@@ -217,7 +217,7 @@ bool HeapObject::can_be_toit_finalized(Program* program) const {
   // but don't have identity.  We reuse the byte_content function to check
   // this.
   const uint8* dummy1;
-  int dummy2;
+  word dummy2;
   if (byte_content(program, &dummy1, &dummy2, STRINGS_OR_BYTE_ARRAYS)) {
     // Can't finalize strings and byte arrays.  This is partly because it
     // doesn't make sense, but also because we only have one finalizer bit in
@@ -284,7 +284,7 @@ void Stack::roots_do(Program* program, RootCallback* cb) {
       memmove(destin, source, (length() - reduction) << WORD_SIZE_LOG_2);
       // We don't need to update the remembered set/write barrier because the
       // start of the stack object has not moved.
-      int len = length() - reduction;
+      word len = length() - reduction;
       top -= reduction;
       _set_length(len);
       _set_top(top);
@@ -313,7 +313,7 @@ int Stack::frames_do(Program* program, FrameCallback* cb) {
   // method that is currently on the frame.
   uint8* last_return_bcp = null;
   bool is_first_frame = true;
-  for (int index = 0; index < stack_length - 1; index++) {
+  for (word index = 0; index < stack_length - 1; index++) {
     Object* probe = at(index);
     if (probe != program->frame_marker()) continue;
     uint8* return_bcp = reinterpret_cast<uint8*>(at(index + 1));
@@ -344,7 +344,7 @@ bool Object::encode_on(ProgramOrientedEncoder* encoder) {
 
 bool String::starts_with_vowel() {
   Bytes bytes(this);
-  int len = bytes.length();
+  word len = bytes.length();
   int pos = 0;
   while (pos < len && bytes.at(pos) == '_') pos++;
   if (pos == len) return false;
@@ -363,7 +363,7 @@ uint16 String::compute_hash_code_for(const char* str) {
 uint16 String::compute_hash_code_for(const char* str, int str_len) {
   // Trivial computation of hash code for string.
   uint16 hash = str_len;
-  for (int index = 0; index < str_len; index++) {
+  for (word index = 0; index < str_len; index++) {
     // The sign of 'char' is implementation dependent.
     // Force the value to be unsigned to have a deterministic hash.
     hash = 31 * hash + static_cast<uint8>(str[index]);
@@ -380,7 +380,7 @@ uint16 String::_assign_hash_code() {
 
 char* String::cstr_dup() {
   Bytes bytes(this);
-  int len = bytes.length();
+  word len = bytes.length();
   char* buffer = unvoid_cast<char*>(malloc(len + 1));
   if (!buffer) return null;
   memcpy(buffer, bytes.address(), len + 1);
@@ -430,8 +430,8 @@ void PromotedTrack::zap() {
 #ifndef TOIT_FREERTOS
 
 void Array::write_content(SnapshotWriter* st) {
-  int len = length();
-  for (int index = 0; index < len; index++) st->write_object(at(index));
+  word len = length();
+  for (word index = 0; index < len; index++) st->write_object(at(index));
 }
 
 void ByteArray::write_content(SnapshotWriter* st) {
@@ -442,29 +442,29 @@ void ByteArray::write_content(SnapshotWriter* st) {
     }
     st->write_external_list_uint8(List<const uint8>(bytes.address(), bytes.length()));
   } else {
-    for (int index = 0; index < bytes.length(); index++) {
+    for (word index = 0; index < bytes.length(); index++) {
       st->write_cardinal(bytes.at(index));
     }
   }
 }
 
 void Instance::write_content(int instance_size, SnapshotWriter* st) {
-  int fields = fields_from_size(instance_size);
+  word fields = fields_from_size(instance_size);
   st->write_cardinal(fields);
-  for (int index = 0; index < fields; index++) {
+  for (word index = 0; index < fields; index++) {
     st->write_object(at(index));
   }
 }
 
 void String::write_content(SnapshotWriter* st) {
   Bytes bytes(this);
-  int len = bytes.length();
+  word len = bytes.length();
   if (len > String::SNAPSHOT_INTERNAL_SIZE_CUTOFF) {
     // TODO(florian): we should remove the '\0'.
     st->write_external_list_uint8(List<const uint8>(bytes.address(), bytes.length() + 1));
   } else {
     ASSERT(content_on_heap());
-    for (int index = 0; index < len; index++) st->write_byte(bytes.at(index));
+    for (word index = 0; index < len; index++) st->write_byte(bytes.at(index));
   }
 }
 
@@ -473,14 +473,14 @@ void Double::write_content(SnapshotWriter* st) {
 }
 
 void Instance::read_content(SnapshotReader* st) {
-  int len = st->read_cardinal();
-  for (int index = 0; index < len; index++) {
+  word len = st->read_cardinal();
+  for (word index = 0; index < len; index++) {
     // Only used to read snapshots onto the program heap, which has no write barrier.
     at_put_no_write_barrier(index, st->read_object());
   }
 }
 
-void String::read_content(SnapshotReader* st, int len) {
+void String::read_content(SnapshotReader* st, word len) {
   if (len > String::SNAPSHOT_INTERNAL_SIZE_CUTOFF) {
     _set_external_length(len);
     auto external_bytes = st->read_external_list_uint8();
@@ -490,7 +490,7 @@ void String::read_content(SnapshotReader* st, int len) {
   } else {
     _set_length(len);
     MutableBytes bytes(this);
-    for (int index = 0; index < len; index++) bytes._at_put(index, st->read_byte());
+    for (word index = 0; index < len; index++) bytes._at_put(index, st->read_byte());
     bytes._set_end();
     _assign_hash_code();
     ASSERT(content_on_heap());
@@ -501,13 +501,13 @@ void Double::read_content(SnapshotReader* st) {
   _set_value(st->read_double());
 }
 
-void Array::read_content(SnapshotReader* st, int len) {
+void Array::read_content(SnapshotReader* st, word len) {
   _set_length(len);
   // Only used to read snapshots onto the program heap, which has no write barrier.
-  for (int index = 0; index < len; index++) at_put_no_write_barrier(index, st->read_object());
+  for (word index = 0; index < len; index++) at_put_no_write_barrier(index, st->read_object());
 }
 
-void ByteArray::read_content(SnapshotReader* st, int len) {
+void ByteArray::read_content(SnapshotReader* st, word len) {
   if (len > SNAPSHOT_INTERNAL_SIZE_CUTOFF) {
     _set_external_length(len);
     auto external_bytes = st->read_external_list_uint8();
@@ -518,7 +518,7 @@ void ByteArray::read_content(SnapshotReader* st, int len) {
     _set_length(len);
     Bytes bytes(this);
 
-    for (int index = 0; index < len; index++)
+    for (word index = 0; index < len; index++)
       bytes.at_put(index, st->read_cardinal());
   }
 }

--- a/src/objects.h
+++ b/src/objects.h
@@ -77,7 +77,7 @@ class Object {
 
   // Primitive support that sets content and length iff receiver is String or ByteArray.
   // Returns whether the content and length are set.
-  bool byte_content(Program* program, const uint8** content, int* length, BlobKind strings_only) const;
+  bool byte_content(Program* program, const uint8** content, word* length, BlobKind strings_only) const;
 
   // Same as above, but with a blob.
   bool byte_content(Program* program, Blob* blob, BlobKind strings_only) const;
@@ -87,7 +87,7 @@ class Object {
   // 'error' indicates the reason.  Most likely this is either a type error or
   // the function tried to allocate a ByteArray (for making a CowByteArray
   // mutable), but failed due to out-of-memory.
-  bool mutable_byte_content(Process* process, uint8** content, int* length, Error** error);
+  bool mutable_byte_content(Process* process, uint8** content, word* length, Error** error);
 
   // Same as above, but with a blob.
   bool mutable_byte_content(Process* process, MutableBlob* blob, Error** error);
@@ -104,17 +104,17 @@ class Blob {
  public:
   inline Blob(uninitialized_t& u) {}
   inline Blob() : address_(null), length_(0) {}
-  Blob(const uint8* address, int length)
+  Blob(const uint8* address, word length)
       : address_(address), length_(length) {}
 
   const uint8* address() const { return address_; }
-  int length() const { return length_; }
+  word length() const { return length_; }
 
   bool slow_equals(const char* c_string) const;
 
  private:
   const uint8* address_;
-  int length_;
+  word length_;
 };
 
 // A class that combines a memory address with the size of it.
@@ -122,15 +122,15 @@ class Blob {
 class MutableBlob {
  public:
   MutableBlob() : address_(null), length_(0) {}
-  MutableBlob(uint8* address, int length)
+  MutableBlob(uint8* address, word length)
       : address_(address), length_(length) {}
 
   uint8* address() { return address_; }
-  int length() { return length_; }
+  word length() { return length_; }
 
  private:
   uint8* address_;
-  int length_;
+  word length_;
 };
 
 // An error is a temporary object (a tagged string) only used for signaling a primitive has failed.
@@ -195,7 +195,7 @@ class Smi : public Object {
 class RootCallback {
  public:
   void do_root(Object** root) { do_roots(root, 1); }
-  virtual void do_roots(Object** roots, int length) = 0;
+  virtual void do_roots(Object** roots, word length) = 0;
   virtual bool shrink_stacks() const { return false; }
   virtual bool skip_marking(HeapObject* object) const { return false; }
 };
@@ -277,7 +277,7 @@ class HeapObject : public Object {
   bool in_remembered_set() const;
 
   // Pseudo virtual member functions.
-  int size(Program* program) const;  // Returns the byte size of this object.
+  word size(Program* program) const;  // Returns the byte size of this object.
   void roots_do(Program* program, RootCallback* cb);  // For GC.
   void do_pointers(Program* program, PointerCallback* cb);  // For snapshots.
 
@@ -370,28 +370,28 @@ class HeapObject : public Object {
 
   INLINE uword _raw() const { return reinterpret_cast<uword>(this) - HEAP_TAG; }
   INLINE uword* _raw_at() { return reinterpret_cast<uword*>(reinterpret_cast<uword>(this) - HEAP_TAG); }
-  INLINE uword* _raw_at(int offset) { return reinterpret_cast<uword*>(reinterpret_cast<uword>(this) - HEAP_TAG + offset); }
+  INLINE uword* _raw_at(word offset) { return reinterpret_cast<uword*>(reinterpret_cast<uword>(this) - HEAP_TAG + offset); }
   INLINE const uword* _raw_at() const { return reinterpret_cast<const uword*>(reinterpret_cast<uword>(this) - HEAP_TAG); }
-  INLINE const uword* _raw_at(int offset) const { return reinterpret_cast<const uword*>(reinterpret_cast<uword>(this) - HEAP_TAG + offset); }
+  INLINE const uword* _raw_at(word offset) const { return reinterpret_cast<const uword*>(reinterpret_cast<uword>(this) - HEAP_TAG + offset); }
 
-  INLINE Object* _at(int offset) const { return reinterpret_cast<Object* const*>(_raw_at())[offset / WORD_SIZE]; }
-  INLINE void _at_put(int offset, Object* value) { reinterpret_cast<Object**>(_raw_at())[offset / WORD_SIZE] = value; }
-  INLINE Object** _root_at(int offset) { return reinterpret_cast<Object**>(_raw_at()) + offset / WORD_SIZE; }
+  INLINE Object* _at(word offset) const { return reinterpret_cast<Object* const*>(_raw_at())[offset / WORD_SIZE]; }
+  INLINE void _at_put(word offset, Object* value) { reinterpret_cast<Object**>(_raw_at())[offset / WORD_SIZE] = value; }
+  INLINE Object** _root_at(word offset) { return reinterpret_cast<Object**>(_raw_at()) + offset / WORD_SIZE; }
 
-  INLINE uword _word_at(int offset) const { return _raw_at()[offset / WORD_SIZE]; }
-  INLINE void _word_at_put(int offset, uword value) { _raw_at()[offset / WORD_SIZE] = value; }
+  INLINE uword _word_at(word offset) const { return _raw_at()[offset / WORD_SIZE]; }
+  INLINE void _word_at_put(word offset, uword value) { _raw_at()[offset / WORD_SIZE] = value; }
 
-  INLINE uint8 _byte_at(int offset) const { return reinterpret_cast<const uint8*>(_raw_at())[offset]; }
-  INLINE void _byte_at_put(int offset, uint8 value) { reinterpret_cast<uint8*>(_raw_at())[offset] = value; }
+  INLINE uint8 _byte_at(word offset) const { return reinterpret_cast<const uint8*>(_raw_at())[offset]; }
+  INLINE void _byte_at_put(word offset, uint8 value) { reinterpret_cast<uint8*>(_raw_at())[offset] = value; }
 
-  INLINE uhalf_word _half_word_at(int offset) const { return *reinterpret_cast<const uhalf_word*>(_raw_at(offset)); }
-  INLINE void _half_word_at_put(int offset, uhalf_word value) { *reinterpret_cast<uhalf_word*>(_raw_at(offset)) = value; }
+  INLINE uhalf_word _half_word_at(word offset) const { return *reinterpret_cast<const uhalf_word*>(_raw_at(offset)); }
+  INLINE void _half_word_at_put(word offset, uhalf_word value) { *reinterpret_cast<uhalf_word*>(_raw_at(offset)) = value; }
 
-  INLINE double _double_at(int offset) const { return bit_cast<double>(_int64_at(offset)); }
-  INLINE void _double_at_put(int offset, double value) { _int64_at_put(offset, bit_cast<int64>(value)); }
+  INLINE double _double_at(word offset) const { return bit_cast<double>(_int64_at(offset)); }
+  INLINE void _double_at_put(word offset, double value) { _int64_at_put(offset, bit_cast<int64>(value)); }
 
-  INLINE int64 _int64_at(int offset) const { return *reinterpret_cast<const int64*>(_raw_at(offset)); }
-  INLINE void _int64_at_put(int offset, int64 value) { *reinterpret_cast<int64*>(_raw_at(offset)) = value; }
+  INLINE int64 _int64_at(word offset) const { return *reinterpret_cast<const int64*>(_raw_at(offset)); }
+  INLINE void _int64_at_put(word offset, int64 value) { *reinterpret_cast<int64*>(_raw_at(offset)) = value; }
 
   static int _align(int byte_size) { return (byte_size + (WORD_SIZE - 1)) & ~(WORD_SIZE - 1); }
 
@@ -415,44 +415,44 @@ class HeapObject : public Object {
 
 class Array : public HeapObject {
  public:
-  int length() const { return _word_at(LENGTH_OFFSET); }
+  word length() const { return _word_at(LENGTH_OFFSET); }
 
-  static INLINE int max_length_in_process();
-  static INLINE int max_length_in_program();
+  static INLINE word max_length_in_process();
+  static INLINE word max_length_in_program();
 
   // Must match collections.toit.
   static const int ARRAYLET_SIZE = 500;
 
-  INLINE Object* at(int index) const {
+  INLINE Object* at(word index) const {
     ASSERT(index >= 0 && index < length());
     return _at(_offset_from(index));
   }
 
-  INLINE void at_put(int index, Smi* value) {
+  INLINE void at_put(word index, Smi* value) {
     ASSERT(index >= 0 && index < length());
     _at_put(_offset_from(index), value);
   }
 
-  INLINE void at_put(int index, Object* value);
+  INLINE void at_put(word index, Object* value);
 
-  INLINE void at_put_no_write_barrier(int index, Object* value) {
+  INLINE void at_put_no_write_barrier(word index, Object* value) {
     ASSERT(index >= 0 && index < length());
     _at_put(_offset_from(index), value);
   }
 
-  void copy_from(Array* other, int length) {
+  void copy_from(Array* other, word length) {
     memcpy(content(), other->content(), length * WORD_SIZE);
   }
 
   uint8* content() { return reinterpret_cast<uint8*>(_raw() + _offset_from(0)); }
 
-  int size() const { return allocation_size(length()); }
+  word size() const { return allocation_size(length()); }
 
   void roots_do(RootCallback* cb);
 
 #ifndef TOIT_FREERTOS
   void write_content(SnapshotWriter* st);
-  void read_content(SnapshotReader* st, int length);
+  void read_content(SnapshotReader* st, word length);
 #endif
 
   static Array* cast(Object* array) {
@@ -467,17 +467,17 @@ class Array : public HeapObject {
 
   Object** base() { return reinterpret_cast<Object**>(_raw_at(_offset_from(0))); }
 
-  static int allocation_size(int length) { return  _align(_offset_from(length)); }
+  static int allocation_size(word length) { return  _align(_offset_from(length)); }
 
-  static void allocation_size(int length, int* word_count, int* extra_bytes) {
+  static void allocation_size(word length, int* word_count, int* extra_bytes) {
     *word_count = HEADER_SIZE / WORD_SIZE + length;
     *extra_bytes = 0;
   }
 
-  void fill(int from, Object* filler);
+  void fill(word from, Object* filler);
 
  private:
-  static const int LENGTH_OFFSET = HeapObject::SIZE;
+  static const word LENGTH_OFFSET = HeapObject::SIZE;
   static const int HEADER_SIZE = LENGTH_OFFSET + WORD_SIZE;
 
   void _set_length(int value) { _word_at_put(LENGTH_OFFSET, value); }
@@ -485,14 +485,14 @@ class Array : public HeapObject {
   // Can only be called on newly allocated objects that will be either
   // in new-space or were added to the remembered set on creation.
   // Is also called from the compiler, where there are no write barriers.
-  void _initialize_no_write_barrier(int length, Object* filler) {
+  void _initialize_no_write_barrier(word length, Object* filler) {
     _set_length(length);
-    for (int index = 0; index < length; index++) {
+    for (word index = 0; index < length; index++) {
       at_put_no_write_barrier(index, filler);
     }
   }
 
-  void _initialize(int length) {
+  void _initialize(word length) {
     _set_length(length);
   }
 
@@ -500,7 +500,7 @@ class Array : public HeapObject {
   friend class ProgramHeap;
 
  protected:
-  static int _offset_from(int index) { return HEADER_SIZE + index * WORD_SIZE; }
+  static int _offset_from(word index) { return HEADER_SIZE + index * WORD_SIZE; }
 };
 
 
@@ -521,28 +521,28 @@ class ByteArray : public HeapObject {
       }
       ASSERT(length() >= 0);
     }
-    Bytes(uint8* address, const int length) : address_(address), length_(length) {}
+    Bytes(uint8* address, const word length) : address_(address), length_(length) {}
 
     uint8* address() { return address_; }
-    int length() { return length_; }
+    word length() { return length_; }
 
-    uint8 at(int index) {
+    uint8 at(word index) {
       ASSERT(index >= 0 && index < length());
       return *(address() + index);
     }
 
-    void at_put(int index, uint8 value) {
+    void at_put(word index, uint8 value) {
       ASSERT(index >= 0 && index < length());
       *(address() + index) = value;
     }
 
-    bool is_valid_index(int index) {
+    bool is_valid_index(word index) {
       return index >= 0 && index < length();
     }
 
    private:
     uint8* address_;
-    int length_;
+    word length_;
   };
 
   class ConstBytes {
@@ -558,14 +558,14 @@ class ByteArray : public HeapObject {
       }
       ASSERT(length() >= 0);
     }
-    ConstBytes(const uint8* address, const int length) : address_(address), length_(length) {}
+    ConstBytes(const uint8* address, const word length) : address_(address), length_(length) {}
 
     const uint8* address() { return address_; }
-    int length() { return length_; }
+    word length() { return length_; }
 
    private:
     const uint8* address_;
-    int length_;
+    word length_;
   };
 
 
@@ -589,7 +589,7 @@ class ByteArray : public HeapObject {
     return 0;
   }
 
-  int size() const {
+  word size() const {
     return has_external_address()
          ? external_allocation_size()
          : internal_allocation_size(raw_length());
@@ -615,7 +615,7 @@ class ByteArray : public HeapObject {
   }
 
 #ifndef TOIT_FREERTOS
-  static void snapshot_allocation_size(int length, int* word_count, int* extra_bytes) {
+  static void snapshot_allocation_size(word length, int* word_count, int* extra_bytes) {
     if (length > SNAPSHOT_INTERNAL_SIZE_CUTOFF) {
       return external_allocation_size(word_count, extra_bytes);
     } else {
@@ -624,7 +624,7 @@ class ByteArray : public HeapObject {
   }
 
   void write_content(SnapshotWriter* st);
-  void read_content(SnapshotReader* st, int byte_length);
+  void read_content(SnapshotReader* st, word byte_length);
 #endif
 
   static ByteArray* cast(Object* byte_array) {
@@ -648,7 +648,7 @@ class ByteArray : public HeapObject {
     _set_external_tag(T::tag);
   }
 
-  void set_external_address(int length, uint8* value) {
+  void set_external_address(word length, uint8* value) {
     _initialize_external_memory(length, value, false);
   }
 
@@ -670,7 +670,7 @@ class ByteArray : public HeapObject {
   uint8* content() { return reinterpret_cast<uint8*>(_raw() + _offset_from(0)); }
   const uint8* content() const { return reinterpret_cast<const uint8*>(_raw() + _offset_from(0)); }
 
-  static const int LENGTH_OFFSET = HeapObject::SIZE;
+  static const word LENGTH_OFFSET = HeapObject::SIZE;
   static const int HEADER_SIZE = LENGTH_OFFSET + WORD_SIZE;
 
   // Constants for external representation.
@@ -699,7 +699,7 @@ class ByteArray : public HeapObject {
 
   void _set_length(int value) { _word_at_put(LENGTH_OFFSET, value); }
 
-  void _set_external_length(int length) { _set_length(-1 - length); }
+  void _set_external_length(word length) { _set_length(-1 - length); }
 
   int _external_length() {
     ASSERT(has_external_address());
@@ -711,12 +711,12 @@ class ByteArray : public HeapObject {
     memset(bytes.address(), 0, bytes.length());
   }
 
-  void _initialize(int length) {
+  void _initialize(word length) {
     _set_length(length);
     _clear();
   }
 
-  void _initialize_external_memory(int length, uint8* external_address, bool clear_content = true) {
+  void _initialize_external_memory(word length, uint8* external_address, bool clear_content = true) {
     ASSERT(length >= 0);
     _set_external_length(length);
     _set_external_address(external_address);
@@ -734,7 +734,7 @@ class ByteArray : public HeapObject {
   friend class VmFinalizerNode;
 
  protected:
-  static int _offset_from(int index) {
+  static int _offset_from(word index) {
     ASSERT(index >= 0);
     ASSERT(index <= max_internal_size());
     return HEADER_SIZE + index;
@@ -791,7 +791,7 @@ class FrameCallback {
 
 class Method {
  public:
-  Method(List<uint8> all_bytes, int offset) : Method(&all_bytes[offset]) {}
+  Method(List<uint8> all_bytes, word offset) : Method(&all_bytes[offset]) {}
   explicit Method(uint8* bytes) : bytes_(bytes) {}
 
   static Method invalid() { return Method(null); }
@@ -869,13 +869,13 @@ class Method {
     ASSERT(this->value_() == value);
   }
 
-  int _int16_at(int offset) const {
+  int _int16_at(word offset) const {
     int16 result;
     memcpy(&result, &bytes_[offset], 2);
     return result;
   }
 
-  void _set_int16_at(int offset, int value) {
+  void _set_int16_at(word offset, int value) {
     int16 source = value;
     memcpy(&bytes_[offset], &source, 2);
   }
@@ -911,7 +911,7 @@ class Method {
 
 class Stack : public HeapObject {
  public:
-  int length() const { return _word_at(LENGTH_OFFSET); }
+  word length() const { return _word_at(LENGTH_OFFSET); }
   int top() const { return _word_at(TOP_OFFSET); }
   int try_top() const { return _word_at(TRY_TOP_OFFSET); }
   int absolute_bci_at_preemption(Program* program);
@@ -935,7 +935,7 @@ class Stack : public HeapObject {
   void transfer_to_interpreter(Interpreter* interpreter);
   void transfer_from_interpreter(Interpreter* interpreter);
 
-  int size() const { return allocation_size(length()); }
+  word size() const { return allocation_size(length()); }
 
   void copy_to(Stack* other);
 
@@ -944,8 +944,8 @@ class Stack : public HeapObject {
   // Iterates over all frames on this stack and returns the number of frames.
   int frames_do(Program* program, FrameCallback* cb);
 
-  static INLINE int initial_length() { return 64; }
-  static INLINE int max_length();
+  static INLINE word initial_length() { return 64; }
+  static INLINE word max_length();
 
   static Stack* cast(Object* stack) {
     ASSERT(is_stack(stack));
@@ -957,8 +957,8 @@ class Stack : public HeapObject {
     return static_cast<const Stack*>(stack);
   }
 
-  static int allocation_size(int length) { return  _align(HEADER_SIZE + length * WORD_SIZE); }
-  static void allocation_size(int length, int* word_count, int* extra_bytes) {
+  static int allocation_size(word length) { return  _align(HEADER_SIZE + length * WORD_SIZE); }
+  static void allocation_size(word length, int* word_count, int* extra_bytes) {
     ASSERT(length > 0);
     *word_count = HEADER_SIZE / WORD_SIZE + length;
     *extra_bytes = 0;
@@ -984,7 +984,7 @@ class Stack : public HeapObject {
 #endif
   static const int GUARD_ZONE_SIZE = GUARD_ZONE_WORDS * WORD_SIZE;
 
-  static const int LENGTH_OFFSET = HeapObject::SIZE + WORD_SIZE;
+  static const word LENGTH_OFFSET = HeapObject::SIZE + WORD_SIZE;
   static const int TOP_OFFSET = LENGTH_OFFSET + WORD_SIZE;
   static const int TRY_TOP_OFFSET = TOP_OFFSET + WORD_SIZE;
   static const int PENDING_STACK_CHECK_METHOD_OFFSET = TRY_TOP_OFFSET + WORD_SIZE;
@@ -995,7 +995,7 @@ class Stack : public HeapObject {
   void _set_top(int value) { _word_at_put(TOP_OFFSET, value); }
   void _set_try_top(int value) { _word_at_put(TRY_TOP_OFFSET, value); }
 
-  void _initialize(int length) {
+  void _initialize(word length) {
     _set_length(length);
     _set_top(length);
     _set_try_top(length);
@@ -1012,7 +1012,7 @@ class Stack : public HeapObject {
     return false;
   }
 
-  uword* guard_zone_address(int index) {
+  uword* guard_zone_address(word index) {
     ASSERT(index >= 0 && index < GUARD_ZONE_WORDS);
     return _raw_at(GUARD_ZONE_OFFSET + index * WORD_SIZE);
   }
@@ -1022,7 +1022,7 @@ class Stack : public HeapObject {
   Object** _stack_sp_addr() { return reinterpret_cast<Object**>(_raw_at(_array_offset_from(top()))); }
   Object** _stack_try_sp_addr() { return reinterpret_cast<Object**>(_raw_at(_array_offset_from(try_top()))); }
 
-  Object* at(int index) {
+  Object* at(word index) {
     ASSERT((_stack_sp_addr() + index) < _stack_base_addr());
     return *(_stack_sp_addr() + index);
   }
@@ -1039,8 +1039,8 @@ class Stack : public HeapObject {
     return (_stack_base_addr() > value) && (value >= _stack_sp_addr());
   }
 
-  uword* _array_address(int index) { return _raw_at(_array_offset_from(index)); }
-  static int _array_offset_from(int index) { return HEADER_SIZE + index  * WORD_SIZE; }
+  uword* _array_address(word index) { return _raw_at(_array_offset_from(index)); }
+  static int _array_offset_from(word index) { return HEADER_SIZE + index  * WORD_SIZE; }
 
   friend class ObjectHeap;
   friend class ProgramHeap;
@@ -1082,25 +1082,25 @@ class Double : public HeapObject {
 class String : public HeapObject {
  public:
   uint16 hash_code() {
-    int result = _raw_hash_code();
+    word result = _raw_hash_code();
     return result != NO_HASH_CODE ? result : _assign_hash_code();
   }
 
-  int length() const {
-     int result = _internal_length();
+  word length() const {
+     word result = _internal_length();
      return result != SENTINEL ? result : _external_length();
   }
 
   // Tells whether the string content is on the heap or external.
   bool content_on_heap() const { return _internal_length() != SENTINEL; }
 
-  static INLINE int max_length_in_process();
-  static INLINE int max_length_in_program();
+  static INLINE word max_length_in_process();
+  static INLINE word max_length_in_program();
 
   bool is_empty() { return length() == 0; }
 
-  int size() const {
-    int len = _internal_length();
+  word size() const {
+    word len = _internal_length();
     if (len != SENTINEL) return internal_allocation_size(length());
     return external_allocation_size();
   }
@@ -1108,10 +1108,10 @@ class String : public HeapObject {
   bool equals(Object* other);
   bool slow_equals(const char* string, int string_length);
   bool slow_equals(const char* string);
-  static bool slow_equals(const char* string_a, int length_a, const char* string_b, int length_b) {
+  static bool slow_equals(const char* string_a, word length_a, const char* string_b, word length_b) {
     return length_a == length_b && memcmp(string_a, string_b, length_a) == 0;
   }
-  static bool slow_equals(const uint8* bytes_a, int length_a, const uint8* bytes_b, int length_b) {
+  static bool slow_equals(const uint8* bytes_a, word length_a, const uint8* bytes_b, word length_b) {
     return length_a == length_b && memcmp(bytes_a, bytes_b, length_a) == 0;
   }
 
@@ -1119,7 +1119,7 @@ class String : public HeapObject {
 
   // Returns -1, 0, or 1.
   int compare(String* other);
-  static int compare(const char* string_a, int length_a, const char* string_b, int length_b) {
+  static int compare(const char* string_a, word length_a, const char* string_b, word length_b) {
     int min_len;
     int equal_result;
     // We don't just use strcmp, in case one of the strings contains a '\0'.
@@ -1138,7 +1138,7 @@ class String : public HeapObject {
     if (comp < 0) return -1;
     return 1;
   }
-  static int compare(const uint8* bytes_a, int length_a, const uint8* bytes_b, int length_b) {
+  static int compare(const uint8* bytes_a, word length_a, const uint8* bytes_b, word length_b) {
     return compare(reinterpret_cast<const char*>(bytes_a),
                    length_a,
                    reinterpret_cast<const char*>(bytes_b),
@@ -1151,7 +1151,7 @@ class String : public HeapObject {
 
 #ifndef TOIT_FREERTOS
   void write_content(SnapshotWriter* st);
-  void read_content(SnapshotReader* st, int length);
+  void read_content(SnapshotReader* st, word length);
 #endif
 
   // Returns a derived pointer that can be used as a null terminated c string.
@@ -1178,10 +1178,10 @@ class String : public HeapObject {
   static inline word max_internal_size_in_program();
   static word max_internal_size();
 
-  static int internal_allocation_size(int length) {
+  static int internal_allocation_size(word length) {
     return _align(_offset_from(length+1));
   }
-  static void internal_allocation_size(int length, int* word_count, int* extra_bytes) {
+  static void internal_allocation_size(word length, int* word_count, int* extra_bytes) {
     ASSERT(length <= max_internal_size());
     // The length and hash-code are stored as half-word sizes.
     static_assert(INTERNAL_HEADER_SIZE == HeapObject::SIZE + 2 * HALF_WORD_SIZE,
@@ -1197,7 +1197,7 @@ class String : public HeapObject {
   }
 
 #ifndef TOIT_FREERTOS
-  static void snapshot_allocation_size(int length, int* word_count, int* extra_bytes) {
+  static void snapshot_allocation_size(word length, int* word_count, int* extra_bytes) {
     if (length > SNAPSHOT_INTERNAL_SIZE_CUTOFF) {
       return external_allocation_size(word_count, extra_bytes);
     } else {
@@ -1213,7 +1213,7 @@ class String : public HeapObject {
   class Bytes {
    public:
     explicit Bytes(const String* string) {
-      int len = string->_internal_length();
+      word len = string->_internal_length();
       if (len != SENTINEL) {
         address_ = string->_as_utf8bytes();
         length_ = len;
@@ -1223,29 +1223,29 @@ class String : public HeapObject {
       }
       ASSERT(length() >= 0);
     }
-    Bytes(const uint8* address, const int length) : address_(address), length_(length) {}
+    Bytes(const uint8* address, const word length) : address_(address), length_(length) {}
 
     const uint8* address() { return address_; }
-    int length() { return length_; }
+    word length() { return length_; }
 
-    uint8 at(int index) {
+    uint8 at(word index) {
       ASSERT(index >= 0 && index < length());
       return *(address() + index);
     }
 
-    bool is_valid_index(int index) {
+    bool is_valid_index(word index) {
       return index >= 0 && index < length();
     }
 
    private:
     const uint8* address_;
-    int length_;
+    word length_;
   };
 
   class MutableBytes {
    public:
     explicit MutableBytes(String* string) {
-      int len = string->_internal_length();
+      word len = string->_internal_length();
       if (len != SENTINEL) {
         address_ = string->_as_utf8bytes();
         length_ = len;
@@ -1257,22 +1257,22 @@ class String : public HeapObject {
     }
 
     uint8* address() { return address_; }
-    int length() { return length_; }
+    word length() { return length_; }
 
     void _initialize(const char* str) {
       memcpy(address(), str, length());
     }
 
-    void _initialize(int index, String* other, int start, int length) {
+    void _initialize(word index, String* other, int start, word length) {
       Bytes ot(other);
       memcpy(address() + index, ot.address() + start, length);
     }
 
-    void _initialize(int index, const uint8* chars, int start, int length) {
+    void _initialize(word index, const uint8* chars, int start, word length) {
       memcpy(address() + index, chars + start, length);
     }
 
-    void _at_put(int index, uint8 value) {
+    void _at_put(word index, uint8 value) {
       ASSERT(index >= 0 && index < length());
       *(address() + index) = value;
     }
@@ -1282,13 +1282,13 @@ class String : public HeapObject {
       *(address() + length()) = 0;
     }
 
-    bool is_valid_index(int index) {
+    bool is_valid_index(word index) {
       return index >= 0 && index < length();
     }
 
    private:
     uint8* address_;
-    int length_;
+    word length_;
   };
 
  private:
@@ -1317,7 +1317,7 @@ class String : public HeapObject {
   void _raw_set_hash_code(uint16 value) { _half_word_at_put(HASH_CODE_OFFSET, value); }
   void _set_length(int value) { _half_word_at_put(INTERNAL_LENGTH_OFFSET, value); }
 
-  static int _offset_from(int index) {
+  static int _offset_from(word index) {
     ASSERT(index >= 0);
     // We allow _offset_from of the null at the end of an internal string, so
     // add one to the limit here.
@@ -1387,25 +1387,25 @@ class String : public HeapObject {
 
 class Instance : public HeapObject {
  public:
-  Object* at(int index) const {
+  Object* at(word index) const {
     return _at(_offset_from(index));
   }
 
-  INLINE void at_put(int index, Smi* value) {
+  INLINE void at_put(word index, Smi* value) {
     _at_put(_offset_from(index), value);
   }
 
-  INLINE Object** root_at(int index) {
+  INLINE Object** root_at(word index) {
     return _root_at(_offset_from(index));
   }
 
-  void at_put_no_write_barrier(int index, Object* value) {
+  void at_put_no_write_barrier(word index, Object* value) {
     _at_put(_offset_from(index), value);
   }
 
   // Using this from the compiler will cause link errors.  Use
   // at_put_no_write_barrier in the compiler instead.
-  void at_put(int index, Object* value);
+  void at_put(word index, Object* value);
 
   void instance_roots_do(int instance_size, RootCallback* cb);
 
@@ -1429,8 +1429,8 @@ class Instance : public HeapObject {
     return static_cast<const Instance*>(value);
   }
 
-  static int allocation_size(int length) { return  _align(_offset_from(length)); }
-  static void allocation_size(int length, int* word_count, int* extra_bytes) {
+  static int allocation_size(word length) { return  _align(_offset_from(length)); }
+  static void allocation_size(word length, int* word_count, int* extra_bytes) {
     *word_count = HEADER_SIZE / WORD_SIZE + length;
     *extra_bytes = 0;
   }
@@ -1473,7 +1473,7 @@ class Instance : public HeapObject {
  private:
   static const int HEADER_SIZE = HeapObject::SIZE;
 
-  static int _offset_from(int index) { return HEADER_SIZE + index  * WORD_SIZE; }
+  static int _offset_from(word index) { return HEADER_SIZE + index  * WORD_SIZE; }
 
   friend class ObjectHeap;
   friend class ProgramHeap;

--- a/src/objects_inline.h
+++ b/src/objects_inline.h
@@ -24,15 +24,15 @@
 
 namespace toit {
 
-int Array::max_length_in_process() {
+word Array::max_length_in_process() {
   return (ObjectHeap::max_allocation_size() - HEADER_SIZE) / WORD_SIZE;
 }
 
-int Array::max_length_in_program() {
+word Array::max_length_in_program() {
   return (ProgramHeap::max_allocation_size() - HEADER_SIZE) / WORD_SIZE;
 }
 
-int Stack::max_length() {
+word Stack::max_length() {
   return (ObjectHeap::max_allocation_size() - HEADER_SIZE) / WORD_SIZE;
 }
 
@@ -70,21 +70,21 @@ inline bool HeapObject::on_program_heap(Process* process) const {
   return process->on_program_heap(this);
 }
 
-inline void Array::at_put(int index, Object* value) {
+inline void Array::at_put(word index, Object* value) {
   ASSERT(index >= 0 && index < length());
   GcMetadata::insert_into_remembered_set(this);
   _at_put(_offset_from(index), value);
 }
 
-inline void Array::fill(int from, Object* filler) {
+inline void Array::fill(word from, Object* filler) {
   GcMetadata::insert_into_remembered_set(this);
-  int len = length();
-  for (int index = from; index < len; index++) {
+  word len = length();
+  for (word index = from; index < len; index++) {
     at_put_no_write_barrier(index, filler);
   }
 }
 
-inline void Instance::at_put(int index, Object* value) {
+inline void Instance::at_put(word index, Object* value) {
   GcMetadata::insert_into_remembered_set(this);
   _at_put(_offset_from(index), value);
 }

--- a/src/objects_runtime.cc
+++ b/src/objects_runtime.cc
@@ -21,7 +21,7 @@
 
 namespace toit {
 
-bool Object::mutable_byte_content(Process* process, uint8** content, int* length, Error** error) {
+bool Object::mutable_byte_content(Process* process, uint8** content, word* length, Error** error) {
   *error = Error::from(process->program()->wrong_object_type());  // Default error if we return false.
   if (is_byte_array(this)) {
     auto byte_array = ByteArray::cast(this);
@@ -46,7 +46,7 @@ bool Object::mutable_byte_content(Process* process, uint8** content, int* length
     ASSERT(is_mutable == process->false_object());
 
     const uint8* immutable_content;
-    int immutable_length;
+    word immutable_length;
     if (!backing->byte_content(program, &immutable_content, &immutable_length, STRINGS_OR_BYTE_ARRAYS)) {
       return false;
     }
@@ -89,7 +89,7 @@ bool Object::mutable_byte_content(Process* process, uint8** content, int* length
 
 bool Object::mutable_byte_content(Process* process, MutableBlob* blob, Error** error) {
   uint8* content = null;
-  int length = 0;
+  word length = 0;
   auto result = mutable_byte_content(process, &content, &length, error);
   *blob = MutableBlob(content, length);
   return result;

--- a/src/os.cc
+++ b/src/os.cc
@@ -195,7 +195,7 @@ void* OS::allocate_pages(uword size) {
 
 void OS::free_pages(void* address, uword size) {
   Locker locker(OS::resource_mutex());
-  int size_in_pages = size >> TOIT_PAGE_SIZE_LOG2;
+  word size_in_pages = size >> TOIT_PAGE_SIZE_LOG2;
   uword page_number = Utils::void_sub(address, toit_heap_range) >> TOIT_PAGE_SIZE_LOG2;
   uword index = page_number >> BITS_PER_UINT64_LOG_2;
   ASSERT(size_in_pages <= 64);  // 64 bits per bitmap, since we use uint64.

--- a/src/os_darwin.cc
+++ b/src/os_darwin.cc
@@ -112,7 +112,7 @@ const char* OS::get_platform() {
 
 int OS::read_entire_file(char* name, uint8** buffer) {
   FILE* file;
-  int length;
+  word length;
   file = fopen(name, "rb");
   if (!file) return -1;
   fseek(file, 0, SEEK_END);

--- a/src/os_esp32.cc
+++ b/src/os_esp32.cc
@@ -663,7 +663,7 @@ class HeapSummaryPage {
 
 class HeapSummaryCollector {
  public:
-  HeapSummaryCollector(int max_pages, Process* current_process)
+  HeapSummaryCollector(word max_pages, Process* current_process)
       : current_process_(current_process)
       , max_pages_(max_pages) {
     if (max_pages > 0) {
@@ -748,8 +748,8 @@ class HeapSummaryCollector {
     printf("  │   Bytes   │  Count   │  Type                                               │\n");
     printf("  ├───────────┼──────────┼─────────────────────────────────────────────────────┤\n");
 
-    int size = 0;
-    int count = 0;
+    word size = 0;
+    word count = 0;
     uword metadata_location, metadata_size;
     GcMetadata::get_metadata_extent(&metadata_location, &metadata_size);
     for (int i = 0; i < NUMBER_OF_MALLOC_TAGS; i++) {
@@ -799,21 +799,23 @@ class HeapSummaryCollector {
     multi_heap_info_t info;
     int caps = OS::toit_heap_caps_flags_for_heap();
     heap_caps_get_info(&info, caps);
-    int capacity_bytes = info.total_allocated_bytes + info.total_free_bytes;
-    int used_bytes = size * 100 / capacity_bytes;
+    word capacity_bytes = info.total_allocated_bytes + info.total_free_bytes;
+    word used_bytes = size * 100 / capacity_bytes;
     printf("  └───────────┴──────────┴─────────────────────────────────────────────────────┘\n");
     printf("  Total: %d bytes in %d allocations (%d%%), largest free %dk, total free %dk\n",
-        size, count, used_bytes,
+        static_cast<int>(size),
+        static_cast<int>(count),
+        static_cast<int>(used_bytes),
         static_cast<int>(info.largest_free_block >> 10),
         static_cast<int>(info.total_free_bytes >> 10));
 
-    int page_count = 0;
-    for (int i = 0; i < max_pages_; i++) {
+    word page_count = 0;
+    for (word i = 0; i < max_pages_; i++) {
       if (!pages_[i].unused()) page_count++;
     }
     if (page_count == 0) return;
 
-    for (int i = 0; i < max_pages_; i++) {
+    for (word i = 0; i < max_pages_; i++) {
       pages_[i].print();
     }
     if (dropped_pages_ > 0) {
@@ -830,8 +832,8 @@ class HeapSummaryCollector {
   uword toit_memory_[MAX_PROCESSES];
   Process* processes_[MAX_PROCESSES];
   Process* current_process_;
-  const int max_pages_;
-  int dropped_pages_ = 0;
+  const word max_pages_;
+  word dropped_pages_ = 0;
   bool out_of_memory_ = false;
 };
 

--- a/src/os_linux.cc
+++ b/src/os_linux.cc
@@ -109,7 +109,7 @@ const char* OS::get_platform() {
 
 int OS::read_entire_file(char* name, uint8** buffer) {
   FILE* file;
-  int length;
+  word length;
   file = fopen(name, "rb");
   if (!file) return -1;
   fseek(file, 0, SEEK_END);

--- a/src/primitive.cc
+++ b/src/primitive.cc
@@ -59,7 +59,7 @@ Object* Primitive::allocate_large_integer(int64 value, Process* process) {
   return mark_as_error(process->program()->allocation_failed());
 }
 
-Object* Primitive::allocate_array(int length, Object* filler, Process* process) {
+Object* Primitive::allocate_array(word length, Object* filler, Process* process) {
   ASSERT(length <= Array::max_length_in_process());
   if (length > Array::max_length_in_process()) return null;
   Object* result = length == 0 ? process->program()->empty_array() :process->object_heap()->allocate_array(length, filler);

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -1226,7 +1226,7 @@ class Primitive {
   // Allocates or returns allocation failure.
   static Object* allocate_double(double value, Process* process);
   static Object* allocate_large_integer(int64 value, Process* process);
-  static Object* allocate_array(int length, Object* filler, Process* process);
+  static Object* allocate_array(word length, Object* filler, Process* process);
 
   static Object* integer(int64 value, Process* process) {
     if (Smi::is_valid(value)) return Smi::from((word) value);

--- a/src/primitive_bitmap.cc
+++ b/src/primitive_bitmap.cc
@@ -573,7 +573,7 @@ PRIMITIVE(draw_text) {
   // the bottom, the least significant at the top.  Y coordinates are 0 at the
   // top.
   if (byte_array_width < 1) FAIL(OUT_OF_BOUNDS);
-  int byte_array_height = bytes.length() / byte_array_width;
+  word byte_array_height = bytes.length() / byte_array_width;
   if (byte_array_height * byte_array_width != bytes.length()) FAIL(OUT_OF_BOUNDS);
   byte_array_height <<= 3;  // Height in pixels, not bytes.
   if (!(0 <= orientation && orientation <= 3)) FAIL(INVALID_ARGUMENT);
@@ -719,7 +719,7 @@ PRIMITIVE(draw_bitmap) {
   // Bytewise output:
   //   The byte array is arranged as n rows, each byte_array_width long.
   if (byte_array_width < 1) FAIL(OUT_OF_BOUNDS);
-  int byte_array_height = bytes.length() / byte_array_width;
+  word byte_array_height = bytes.length() / byte_array_width;
   if (byte_array_height * byte_array_width != bytes.length()) FAIL(OUT_OF_BOUNDS);
   if (!bytewise_output) {
     byte_array_height <<= 3;  // Height in pixels, not bytes.
@@ -730,7 +730,7 @@ PRIMITIVE(draw_bitmap) {
   int bytes_per_line = (bitmap_width + 7) >> 3;
   if (bitmap_offset < 0) FAIL(OUT_OF_BOUNDS);
   if (bitmap_width < 1 || bitmap_stride < 1) FAIL(OUT_OF_BOUNDS);
-  int bitmap_height = (in_bytes.length() - bitmap_offset + bitmap_stride - bytes_per_line) / bitmap_stride;
+  word bitmap_height = (in_bytes.length() - bitmap_offset + bitmap_stride - bytes_per_line) / bitmap_stride;
   if (bitmap_height * bitmap_stride - bitmap_stride + bytes_per_line > in_bytes.length() - bitmap_offset) FAIL(OUT_OF_BOUNDS);
 
   if (!(0 <= orientation && orientation <= 3)) FAIL(INVALID_ARGUMENT);
@@ -791,14 +791,14 @@ PRIMITIVE(draw_bytemap) {
   // Both the input and output byte arrays are arranged as n rows, each byte_array_width long.
   if (byte_array_width < 1) FAIL(OUT_OF_BOUNDS);
 
-  int byte_array_height = bytes.length() / byte_array_width;
+  word byte_array_height = bytes.length() / byte_array_width;
   if (byte_array_height * byte_array_width != bytes.length()) FAIL(OUT_OF_BOUNDS);
 
   uint8* output_contents = bytes.address();
 
   if (pixels_per_line < 1) FAIL(OUT_OF_BOUNDS);
   if (source_line_stride < pixels_per_line) FAIL(OUT_OF_BOUNDS);
-  int bitmap_height = (in_bytes.length() + source_line_stride - pixels_per_line) / source_line_stride;
+  word bitmap_height = (in_bytes.length() + source_line_stride - pixels_per_line) / source_line_stride;
   if (bitmap_height * source_line_stride - source_line_stride + pixels_per_line > in_bytes.length()) FAIL(OUT_OF_BOUNDS);
 
   if (!(0 <= orientation && orientation <= 3)) FAIL(INVALID_ARGUMENT);
@@ -808,7 +808,7 @@ PRIMITIVE(draw_bytemap) {
   const uint8* alpha_map;
   word alpha_length;
   if (is_smi(transparent_color)) {
-    int index = Smi::value(transparent_color);
+    word index = Smi::value(transparent_color);
     if (!(-1 <= index && index < 256)) FAIL(INVALID_ARGUMENT);
     memset(stack_alpha_map, 0xff, sizeof(stack_alpha_map));
     if (index != -1) stack_alpha_map[index] = 0;
@@ -874,7 +874,7 @@ PRIMITIVE(byte_draw_text) {
   ARGS(int, x_base, int, y_base, int, color, int, orientation, StringOrSlice, string, Font, font, MutableBlob, bytes, int, byte_array_width);
   // The byte array is arranged as n columns, each byte_array_width long.
   if (byte_array_width < 1) FAIL(OUT_OF_BOUNDS);
-  int byte_array_height = bytes.length() / byte_array_width;
+  word byte_array_height = bytes.length() / byte_array_width;
   if (byte_array_height * byte_array_width != bytes.length()) FAIL(OUT_OF_BOUNDS);
 
   if (!(0 <= orientation && orientation <= 3)) FAIL(INVALID_ARGUMENT);
@@ -901,7 +901,7 @@ PRIMITIVE(rectangle) {
 #else
   ARGS(int, x_base, int, y_base, int, color, int, width, int, height, MutableBlob, bytes, int, byte_array_width);
   if (byte_array_width < 1) FAIL(OUT_OF_BOUNDS);
-  int byte_array_height = bytes.length() / byte_array_width;
+  word byte_array_height = bytes.length() / byte_array_width;
   if (byte_array_height * byte_array_width != bytes.length()) FAIL(OUT_OF_BOUNDS);
   byte_array_height <<= 3;  // Height in pixels, not bytes.
   if (width < 0 || height < 0) FAIL(OUT_OF_RANGE);
@@ -963,7 +963,7 @@ PRIMITIVE(byte_rectangle) {
 #else
   ARGS(int, x_base, int, y_base, int, color, int, width, int, height, MutableBlob, bytes, int, byte_array_width);
   if (byte_array_width < 1) FAIL(OUT_OF_BOUNDS);
-  int byte_array_height = bytes.length() / byte_array_width;
+  word byte_array_height = bytes.length() / byte_array_width;
   if (byte_array_height * byte_array_width != bytes.length()) FAIL(OUT_OF_BOUNDS);
   if (width < 0 || height < 0) FAIL(OUT_OF_RANGE);
   static const int TOO_BIG = 0x8000000;
@@ -1024,7 +1024,7 @@ PRIMITIVE(bytemap_blur) {
   ARGS(MutableBlob, bytes, int, width, int, x_blur_radius, int, y_blur_radius);
   uint8* image = bytes.address();
   if (width < 1) FAIL(OUT_OF_BOUNDS);
-  int height = bytes.length() / width;
+  word height = bytes.length() / width;
   if (height * width != bytes.length()) FAIL(OUT_OF_BOUNDS);
   if (x_blur_radius < 2 && y_blur_radius < 2) return process->null_object();
   if (x_blur_radius < 0 || y_blur_radius < 0) FAIL(INVALID_ARGUMENT);
@@ -1085,7 +1085,8 @@ PRIMITIVE(bytemap_blur) {
         if (y - BUFFER_SIZE >= 0) image[x + (y - BUFFER_SIZE) * width] = buffer[y & BUFFER_MASK];
         buffer[y & BUFFER_MASK] = sum;
       }
-      int y = Utils::max(0, height + 1 - y_blur_radius - BUFFER_SIZE);
+      word zero = 0;
+      word y = Utils::max(zero, height + 1 - y_blur_radius - BUFFER_SIZE);
       for (int image_index = x + y * width; y <= height - y_blur_radius; y++) {
         image[image_index] = buffer[y & BUFFER_MASK];
         image_index += width;
@@ -1113,13 +1114,13 @@ PRIMITIVE(composit) {
 #endif
 
   uint8* dest_address = dest_bytes.address();
-  int dest_length = dest_bytes.length();
+  word dest_length = dest_bytes.length();
 
   // The frame opacity/transparency can be either an alpha map or a single opacity value.
   bool frame_opacity_lookup;
   int frame_opacity = 0;
   const uint8* frame_opacity_bytes = frame_opacity_object.address();
-  int frame_opacity_length = frame_opacity_object.length();
+  word frame_opacity_length = frame_opacity_object.length();
   if (frame_opacity_length == 1) {
     frame_opacity_lookup = false;
     frame_opacity = frame_opacity_bytes[0];
@@ -1132,7 +1133,7 @@ PRIMITIVE(composit) {
   bool painting_opacity_lookup;
   int painting_opacity = 0;
   const uint8* painting_opacity_bytes = painting_opacity_byte_array.address();
-  int painting_opacity_length = painting_opacity_byte_array.length();
+  word painting_opacity_length = painting_opacity_byte_array.length();
   if (painting_opacity_length == 1) {
     painting_opacity_lookup = false;
     painting_opacity = painting_opacity_bytes[0];
@@ -1144,7 +1145,7 @@ PRIMITIVE(composit) {
   // Unless the frame is totally transparent (opacity 0) we need some frame
   // pixels to mix in.
   const uint8* frame_pixels;
-  int frame_length;
+  word frame_length;
   if (!frame->byte_content(process->program(), &frame_pixels, &frame_length, STRINGS_OR_BYTE_ARRAYS)) {
     if (frame_opacity != 0) FAIL(WRONG_OBJECT_TYPE);
   } else {
@@ -1152,13 +1153,13 @@ PRIMITIVE(composit) {
   }
 
   const uint8* painting_pixels = painting.address();
-  int painting_length = painting.length();
+  word painting_length = painting.length();
   // The painting (window contents) must always be in the form of pixels.
   if (painting_length != dest_length) FAIL(OUT_OF_BOUNDS);
 
   if (bit) {
     // Bit version.  The images and opacities are all in a 1-bit-per-pixel format.
-    for (int i = 0; i < dest_length; i++) {
+    for (word i = 0; i < dest_length; i++) {
       int frame_mask = frame_opacity_lookup ? frame_opacity_bytes[i] : frame_opacity;
       int painting_mask = painting_opacity_lookup ? painting_opacity_bytes[i] : painting_opacity;
       if (painting_mask == 0xff) {
@@ -1177,7 +1178,7 @@ PRIMITIVE(composit) {
     }
   } else {
     // Byte version.  Opacities are 0-255 and pixels are also bytes.
-    for (int i = 0; i < dest_length; i++) {
+    for (word i = 0; i < dest_length; i++) {
       int frame_factor = frame_opacity_lookup ? frame_opacity_bytes[i] : frame_opacity;
       int painting_factor = painting_opacity_lookup ? painting_opacity_bytes[i] : painting_opacity;
       if (painting_factor == 0xff) {

--- a/src/primitive_core.cc
+++ b/src/primitive_core.cc
@@ -285,7 +285,7 @@ PRIMITIVE(byte_array_convert_to_string) {
 }
 
 PRIMITIVE(blob_index_of) {
-  ARGS(Blob, bytes, int, byte, int, from, int, to);
+  ARGS(Blob, bytes, int, byte, word, from, word, to);
   if (!(0 <= from && from <= to && to <= bytes.length())) FAIL(OUT_OF_BOUNDS);
 #if defined(__x86_64__) && !defined(__SANITIZE_THREAD__)
   const uint8* address = bytes.address();
@@ -323,7 +323,7 @@ PRIMITIVE(blob_index_of) {
   return Smi::from(-1);
 #else
   const uint8* from_address = bytes.address() + from;
-  int len = to - from;
+  word len = to - from;
   const uint8* value = reinterpret_cast<const uint8*>(memchr(from_address, byte, len));
   return Smi::from(value != null ? value - bytes.address() : -1);
 #endif
@@ -346,7 +346,7 @@ static Array* get_array_from_list(Object* object, Process* process) {
 }
 
 PRIMITIVE(crc) {
-  ARGS(int64, accumulator, int, width, Blob, data, int, from, int, to, Object, table_object);
+  ARGS(int64, accumulator, word, width, Blob, data, word, from, word, to, Object, table_object);
   if ((width != 0 && width < 8) || width > 64) FAIL(INVALID_ARGUMENT);
   bool big_endian = width != 0;
   if (to == from) return _raw_accumulator;
@@ -426,7 +426,7 @@ PRIMITIVE(string_from_rune) {
 }
 
 PRIMITIVE(string_write_to_byte_array) {
-  ARGS(Blob, source_bytes, MutableBlob, dest, int, from, int, to, int, dest_index);
+  ARGS(Blob, source_bytes, MutableBlob, dest, word, from, word, to, word, dest_index);
   if (to == from) return _raw_dest;
   if (from < 0 || to > source_bytes.length() || from > to) FAIL(OUT_OF_BOUNDS);
   if (dest_index + to - from > dest.length()) FAIL(OUT_OF_BOUNDS);
@@ -435,11 +435,11 @@ PRIMITIVE(string_write_to_byte_array) {
 }
 
 PRIMITIVE(put_uint_big_endian) {
-  ARGS(Object, unused, MutableBlob, dest, int, width, int, offset, int64, value);
+  ARGS(Object, unused, MutableBlob, dest, int, width, word, offset, int64, value);
   USE(unused);
   unsigned unsigned_width = width;
-  unsigned unsigned_offset = offset;
-  unsigned length = dest.length();
+  uword unsigned_offset = offset;
+  uword length = dest.length();
   // We don't need to check for <0 on unsigned values.  Can't have integer
   // overflow when they are both constrained in size (assuming the byte
   // array can't be close to 4Gbytes large).
@@ -454,18 +454,18 @@ PRIMITIVE(put_uint_big_endian) {
 }
 
 PRIMITIVE(put_uint_little_endian) {
-  ARGS(Object, unused, MutableBlob, dest, int, width, int, offset, int64, value);
+  ARGS(Object, unused, MutableBlob, dest, int, width, word, offset, int64, value);
   USE(unused);
   unsigned width_minus_1 = width - 1;  // This means width 0 is rejected.
-  unsigned unsigned_offset = offset;
-  unsigned length = dest.length();
+  uword unsigned_offset = offset;
+  uword length = dest.length();
   // We don't need to check for <0 on unsigned values.  Can't have integer
   // overflow when they are both constrained in size (assuming the byte
   // array can't be close to 4Gbytes large).
   if (unsigned_offset > length || width_minus_1 >= 8 || unsigned_offset + width_minus_1 >= length) {
     FAIL(OUT_OF_BOUNDS);
   }
-  for (unsigned i = 0; i <= width_minus_1; i++) {
+  for (uword i = 0; i <= width_minus_1; i++) {
     dest.address()[offset + i] = value;
     value >>= 8;
   }
@@ -473,10 +473,10 @@ PRIMITIVE(put_uint_little_endian) {
 }
 
 PRIMITIVE(put_float_32_little_endian) {
-  ARGS(Object, unused, MutableBlob, dest, int, offset, double, value);
+  ARGS(Object, unused, MutableBlob, dest, word, offset, double, value);
   USE(unused);
-  unsigned unsigned_offset = offset;
-  unsigned length = dest.length();
+  uword unsigned_offset = offset;
+  uword length = dest.length();
   // We don't need to check for <0 on unsigned values.  Can't have integer
   // overflow when they are both constrained in size (assuming the byte
   // array can't be close to 4Gbytes large).
@@ -489,10 +489,10 @@ PRIMITIVE(put_float_32_little_endian) {
 }
 
 PRIMITIVE(put_float_64_little_endian) {
-  ARGS(Object, unused, MutableBlob, dest, int, offset, double, value);
+  ARGS(Object, unused, MutableBlob, dest, word, offset, double, value);
   USE(unused);
-  unsigned unsigned_offset = offset;
-  unsigned length = dest.length();
+  uword unsigned_offset = offset;
+  uword length = dest.length();
   // We don't need to check for <0 on unsigned values.  Can't have integer
   // overflow when they are both constrained in size (assuming the byte
   // array can't be close to 4Gbytes large).
@@ -504,11 +504,11 @@ PRIMITIVE(put_float_64_little_endian) {
 }
 
 PRIMITIVE(read_uint_big_endian) {
-  ARGS(Object, unused, Blob, source, int, width, int, offset);
+  ARGS(Object, unused, Blob, source, int, width, word, offset);
   USE(unused);
   unsigned unsigned_width = width;
-  unsigned unsigned_offset = offset;
-  unsigned length = source.length();
+  uword unsigned_offset = offset;
+  uword length = source.length();
   // We don't need to check for <0 on unsigned values.  Can't have integer
   // overflow when they are both constrained in size (assuming the byte
   // array can't be close to 4Gbytes large).
@@ -524,11 +524,11 @@ PRIMITIVE(read_uint_big_endian) {
 }
 
 PRIMITIVE(read_uint_little_endian) {
-  ARGS(Object, unused, Blob, source, int, width, int, offset);
+  ARGS(Object, unused, Blob, source, int, width, word, offset);
   USE(unused);
   unsigned unsigned_width = width;
-  unsigned unsigned_offset = offset;
-  unsigned length = source.length();
+  uword unsigned_offset = offset;
+  uword length = source.length();
   // We don't need to check for <0 on unsigned values.  Can't have integer
   // overflow when they are both constrained in size (assuming the byte
   // array can't be close to 4Gbytes large).
@@ -536,7 +536,7 @@ PRIMITIVE(read_uint_little_endian) {
     FAIL(OUT_OF_BOUNDS);
   }
   uint64 value = 0;
-  for (int i = width - 1; i >= 0; i--) {
+  for (word i = width - 1; i >= 0; i--) {
     value <<= 8;
     value |= source.address()[offset + i];
   }
@@ -544,11 +544,11 @@ PRIMITIVE(read_uint_little_endian) {
 }
 
 PRIMITIVE(read_int_big_endian) {
-  ARGS(Object, unused, Blob, source, int, width, int, offset);
+  ARGS(Object, unused, Blob, source, int, width, word, offset);
   USE(unused);
   unsigned width_minus_1 = width - 1;  // This means size 0 is rejected.
-  unsigned unsigned_offset = offset;
-  unsigned length = source.length();
+  uword unsigned_offset = offset;
+  uword length = source.length();
   // We don't need to check for <0 on unsigned values.  Can't have integer
   // overflow when they are both constrained in size (assuming the byte
   // array can't be close to 4Gbytes large).
@@ -556,7 +556,7 @@ PRIMITIVE(read_int_big_endian) {
     FAIL(OUT_OF_BOUNDS);
   }
   int64 value = static_cast<int8>(source.address()[offset]);  // Sign extend.
-  for (unsigned i = 1; i <= width_minus_1; i++) {
+  for (uword i = 1; i <= width_minus_1; i++) {
     value <<= 8;
     value |= source.address()[offset + i];
   }
@@ -564,11 +564,11 @@ PRIMITIVE(read_int_big_endian) {
 }
 
 PRIMITIVE(read_int_little_endian) {
-  ARGS(Object, unused, Blob, source, int, width, int, offset);
+  ARGS(Object, unused, Blob, source, int, width, word, offset);
   USE(unused);
   unsigned width_minus_1 = width - 1;  // This means size 0 is rejected.
-  unsigned unsigned_offset = offset;
-  unsigned length = source.length();
+  uword unsigned_offset = offset;
+  uword length = source.length();
   // We don't need to check for <0 on unsigned values.  Can't have integer
   // overflow when they are both constrained in size (assuming the byte
   // array can't be close to 4Gbytes large).
@@ -576,7 +576,7 @@ PRIMITIVE(read_int_little_endian) {
     FAIL(OUT_OF_BOUNDS);
   }
   int64 value = static_cast<int8>(source.address()[offset + width_minus_1]);  // Sign extend.
-  for (unsigned i = width_minus_1; i != 0; i--) {
+  for (uword i = width_minus_1; i != 0; i--) {
     value <<= 8;
     value |= source.address()[offset + i - 1];
   }
@@ -881,23 +881,23 @@ PRIMITIVE(float_mod) {
 }
 
 PRIMITIVE(float_round) {
-  ARGS(double, receiver, int, precission);
-  if (precission < 0 || precission > 15) FAIL(INVALID_ARGUMENT);
+  ARGS(double, receiver, int, precision);
+  if (precision < 0 || precision > 15) FAIL(INVALID_ARGUMENT);
   if (isnan(receiver)) FAIL(OUT_OF_RANGE);
   if (receiver > pow(10,54)) return _raw_receiver;
-  int factor = pow(10, precission);
+  int factor = pow(10, precision);
   return Primitive::allocate_double(round(receiver * factor) / factor, process);
 }
 
 PRIMITIVE(int_parse) {
-  ARGS(Blob, input, int, from, int, to, int, block_arg_dont_use_this);
+  ARGS(Blob, input, word, from, word, to, int, block_arg_dont_use_this);
   if (!(0 <= from && from < to && to <= input.length())) FAIL(OUT_OF_RANGE);
   // Difficult cases, handled by Toit code.  If the ASCII length is always less
   // than 18 we don't have to worry about 64 bit overflow.
   if (to - from > 18) FAIL(OUT_OF_RANGE);
   uint64 result = 0;
   bool negative = false;
-  int index = from;
+  word index = from;
   const uint8* in = input.address();
   if (in[index] == '-') {
     negative = true;
@@ -919,7 +919,7 @@ PRIMITIVE(int_parse) {
 }
 
 PRIMITIVE(float_parse) {
-  ARGS(Blob, input, int, from, int, to);
+  ARGS(Blob, input, word, from, word, to);
   if (!(0 <= from && from < to && to <= input.length())) FAIL(OUT_OF_RANGE);
   const char* from_ptr = char_cast(input.address() + from);
   // strtod removes leading whitespace, but float.parse doesn't accept it.
@@ -1172,7 +1172,7 @@ PRIMITIVE(blob_hash_code) {
 }
 
 PRIMITIVE(hash_simple_json_string) {
-  ARGS(Blob, bytes, int, offset);
+  ARGS(Blob, bytes, word, offset);
   if (offset < 0) FAIL(INVALID_ARGUMENT);
   for (word i = offset; i < bytes.length(); i++) {
     uint8 c = bytes.address()[i];
@@ -1187,7 +1187,7 @@ PRIMITIVE(hash_simple_json_string) {
 }
 
 PRIMITIVE(json_skip_whitespace) {
-  ARGS(Blob, bytes, int, offset);
+  ARGS(Blob, bytes, word, offset);
   if (offset < 0) FAIL(INVALID_ARGUMENT);
   word i = offset;
   for ( ; i < bytes.length(); i++) {
@@ -1198,7 +1198,7 @@ PRIMITIVE(json_skip_whitespace) {
 }
 
 PRIMITIVE(compare_simple_json_string) {
-  ARGS(Blob, bytes, int, offset, StringOrSlice, string);
+  ARGS(Blob, bytes, word, offset, StringOrSlice, string);
   if (offset < 0) FAIL(INVALID_ARGUMENT);
   if (string.length() >= bytes.length() - offset) {
     return BOOL(false);
@@ -1211,7 +1211,7 @@ PRIMITIVE(compare_simple_json_string) {
 }
 
 PRIMITIVE(size_of_json_number) {
-  ARGS(Blob, bytes, int, offset);
+  ARGS(Blob, bytes, word, offset);
   if (offset < 0 || offset >= bytes.length() - 1) FAIL(INVALID_ARGUMENT);
   int is_float = 0;
   const uint8_t* p = bytes.address() + offset;
@@ -1291,12 +1291,12 @@ PRIMITIVE(string_rune_count) {
   word count = 0;
   const uword WORD_MASK = WORD_SIZE - 1;
   const uint8* address = bytes.address();
-  int len = bytes.length();
+  word len = bytes.length();
   // This algorithm counts the runes in word-sized chunks of UTF-8.
   // We have to ensure that the memory reads are word aligned to avoid memory
   // faults.
   // The first mask will make sure we skip over the bytes we don't need.
-  int skipped_start_bytes = reinterpret_cast<uword>(address) & WORD_MASK;
+  word skipped_start_bytes = reinterpret_cast<uword>(address) & WORD_MASK;
   address -= skipped_start_bytes;  // Align the address
   len += skipped_start_bytes;
 
@@ -1496,8 +1496,8 @@ static bool is_validated_string(Program* program, Object* object) {
 }
 
 static String* concat_strings(Process* process,
-                              const uint8* bytes_a, int len_a,
-                              const uint8* bytes_b, int len_b) {
+                              const uint8* bytes_a, word len_a,
+                              const uint8* bytes_b, word len_b) {
   String* result = process->allocate_string(len_a + len_b);
   if (result == null) return null;
   // Initialize object.
@@ -1532,9 +1532,9 @@ static inline bool utf_8_continuation_byte(int c) {
 }
 
 PRIMITIVE(string_slice) {
-  ARGS(String, receiver, int, from, int, to);
+  ARGS(String, receiver, word, from, word, to);
   String::Bytes bytes(receiver);
-  int length = bytes.length();
+  word length = bytes.length();
   if (from == 0 && to == length) return receiver;
   if (from < 0 || to > length || from > to) FAIL(OUT_OF_BOUNDS);
   if (from != length) {
@@ -1556,7 +1556,7 @@ PRIMITIVE(string_slice) {
   ASSERT(from >= 0);
   ASSERT(to <= receiver->length());  // Checked above.
   ASSERT(from < to);
-  int result_len = to - from;
+  word result_len = to - from;
   String* result = process->allocate_string(result_len);
   if (result == null) FAIL(ALLOCATION_FAILED);
   // Initialize object.
@@ -1569,11 +1569,11 @@ PRIMITIVE(concat_strings) {
   ARGS(Array, array);
   Program* program = process->program();
   // First make sure we have an array of strings.
-  for (int index = 0; index < array->length(); index++) {
+  for (word index = 0; index < array->length(); index++) {
     if (!is_validated_string(process->program(), array->at(index))) FAIL(WRONG_OBJECT_TYPE);
   }
-  int length = 0;
-  for (int index = 0; index < array->length(); index++) {
+  word length = 0;
+  for (word index = 0; index < array->length(); index++) {
     Blob blob;
     HeapObject::cast(array->at(index))->byte_content(program, &blob, STRINGS_ONLY);
     length += blob.length();
@@ -1581,11 +1581,11 @@ PRIMITIVE(concat_strings) {
   String* result = process->allocate_string(length);
   if (result == null) FAIL(ALLOCATION_FAILED);
   String::MutableBytes bytes(result);
-  int pos = 0;
-  for (int index = 0; index < array->length(); index++) {
+  word pos = 0;
+  for (word index = 0; index < array->length(); index++) {
     Blob blob;
     HeapObject::cast(array->at(index))->byte_content(program, &blob, STRINGS_ONLY);
-    int len = blob.length();
+    word len = blob.length();
     bytes._initialize(pos, blob.address(), 0, len);
     pos += len;
   }
@@ -1814,7 +1814,7 @@ PRIMITIVE(byte_array_new_external) {
 PRIMITIVE(byte_array_replace) {
   ARGS(MutableBlob, receiver, int, index, Blob, source_object, int, from, int, to);
   if (index < 0 || from < 0 || to < 0 || to > source_object.length()) FAIL(OUT_OF_BOUNDS);
-  int length = to - from;
+  word length = to - from;
   if (length < 0 || index + length > receiver.length()) FAIL(OUT_OF_BOUNDS);
 
   uint8* dest = receiver.address() + index;
@@ -2503,8 +2503,8 @@ PRIMITIVE(firmware_unmap) {
 
 PRIMITIVE(firmware_mapping_at) {
   ARGS(Instance, receiver, int, index);
-  int offset = Smi::value(receiver->at(1));
-  int size = Smi::value(receiver->at(2));
+  word offset = Smi::value(receiver->at(1));
+  word size = Smi::value(receiver->at(2));
   if (index < 0 || index >= size) FAIL(OUT_OF_BOUNDS);
 
   Blob input;
@@ -2522,10 +2522,10 @@ PRIMITIVE(firmware_mapping_at) {
 }
 
 PRIMITIVE(firmware_mapping_copy) {
-  ARGS(Instance, receiver, int, from, int, to, ByteArray, into, int, index);
+  ARGS(Instance, receiver, word, from, word, to, ByteArray, into, word, index);
   if (index < 0) FAIL(OUT_OF_BOUNDS);
-  int offset = Smi::value(receiver->at(1));
-  int size = Smi::value(receiver->at(2));
+  word offset = Smi::value(receiver->at(1));
+  word size = Smi::value(receiver->at(2));
   if (!Utils::is_aligned(from + offset, sizeof(uint32)) ||
       !Utils::is_aligned(to + offset, sizeof(uint32))) FAIL(INVALID_ARGUMENT);
   if (from > to || from < 0 || to > size) FAIL(OUT_OF_BOUNDS);
@@ -2539,7 +2539,7 @@ PRIMITIVE(firmware_mapping_copy) {
   // access. We use an IRAM safe memcpy alternative that guarantees
   // always reading whole words to avoid issues with this.
   ByteArray::Bytes output(into);
-  int bytes = to - from;
+  word bytes = to - from;
   if (index + bytes > output.length()) FAIL(OUT_OF_BOUNDS);
   iram_safe_memcpy(output.address() + index, input.address() + from + offset, bytes);
   return Smi::from(index + bytes);

--- a/src/primitive_encoding.cc
+++ b/src/primitive_encoding.cc
@@ -65,12 +65,12 @@ static int get_for_decode(const Blob& bytes, int index, bool url_mode) {
 
 PRIMITIVE(base64_decode)  {
   ARGS(Blob, input, bool, url_mode);
-  int length = input.length();
-  int out_len;
+  word length = input.length();
+  word out_len;
   if (url_mode) {
     // Padding = signs not required.
     out_len = (length >> 2) * 3;
-    int last_group_length = length & 3;  // Can be 0 if input length is a multiple of 4.
+    word last_group_length = length & 3;  // Can be 0 if input length is a multiple of 4.
     if (last_group_length == 1) {
       FAIL(OUT_OF_RANGE);  // 6 bits are not enough to encode another byte.
     } else if (last_group_length == 2) {
@@ -93,7 +93,7 @@ PRIMITIVE(base64_decode)  {
 
   uint8* buffer = ByteArray::Bytes(result).address();
   // Iterate over the groups of 3 output characters that have 4 regular input characters.
-  for (int i = 0, j = 0; i <= out_len - 3; i += 3, j += 4) {
+  for (word i = 0, j = 0; i <= out_len - 3; i += 3, j += 4) {
     uint32_t wrd =
       (get_for_decode(input, j + 0, url_mode) << 18) |
       (get_for_decode(input, j + 1, url_mode) << 12) |

--- a/src/primitive_file_non_win.cc
+++ b/src/primitive_file_non_win.cc
@@ -218,7 +218,7 @@ PRIMITIVE(readdir) {
   ByteArray* proxy = process->object_heap()->allocate_proxy(true);
   if (proxy == null) FAIL(ALLOCATION_FAILED);
 
-  const int MAX_VFAT = 260;  // Max filename length.
+  const word MAX_VFAT = 260;  // Max filename length.
   AllocationManager allocation(process);
   uint8* backing = allocation.alloc(MAX_VFAT);
   if (!backing) FAIL(ALLOCATION_FAILED);
@@ -231,7 +231,7 @@ PRIMITIVE(readdir) {
     return process->null_object();
   }
 
-  int len = strlen(entry->d_name);
+  word len = strlen(entry->d_name);
 
   if (len <= MAX_VFAT) {
     // Take ownership of the entire allocated backing array.

--- a/src/primitive_font.cc
+++ b/src/primitive_font.cc
@@ -493,7 +493,7 @@ PRIMITIVE(get_nonbuiltin) {
   for (int index = 0; index < arrays->length(); index++) {
     Object* block_array = arrays->at(index);
     const uint8* bytes;
-    int length;
+    word length;
     if (!is_heap_object(block_array)) FAIL(WRONG_OBJECT_TYPE);
     if (!block_array->byte_content(process->program(), &bytes, &length, STRINGS_OR_BYTE_ARRAYS)) FAIL(WRONG_OBJECT_TYPE);
     // TODO: We should perhaps avoid redoing this verification if the data is

--- a/src/primitive_programs_registry.cc
+++ b/src/primitive_programs_registry.cc
@@ -94,10 +94,10 @@ PRIMITIVE(kill) {
 PRIMITIVE(bundled_images) {
 #ifdef TOIT_ESP32
   const EmbeddedDataExtension* extension = EmbeddedData::extension();
-  int length = extension->images();
+  word length = extension->images();
   Array* result = process->object_heap()->allocate_array(length * 2, Smi::from(0));
   if (!result) FAIL(ALLOCATION_FAILED);
-  for (int i = 0; i < length; i++) {
+  for (word i = 0; i < length; i++) {
     // We store the distance from the start of the header to the image
     // because it naturally fits as a smi even if the virtual addresses
     // involved are large. We tag the entry so we can tell the difference
@@ -119,7 +119,7 @@ PRIMITIVE(bundled_images) {
 
 PRIMITIVE(assets) {
   Program* program = process->program();
-  int size;
+  word size;
   uint8* bytes;
   Object* result = null;
   if (program->program_assets_size(&bytes, &size) == 0) {

--- a/src/printing.cc
+++ b/src/printing.cc
@@ -56,7 +56,7 @@ static const int format_length[] { BYTECODE_FORMATS(THE_LENGTH) -1 };
 #undef THE_LENGTH
 
 void print_name(Printer* printer, String* string) {
-  const int MAX = 300;
+  const word MAX = 300;
   String::Bytes bytes(string);
   printer->print_buffer(bytes.address(), Utils::min(bytes.length(), MAX));
   if (MAX < string->length()) printer->printf("...");
@@ -299,17 +299,17 @@ class ShortPrintVisitor : public PrintVisitor {
   }
 
   void visit_byte_array(ByteArray* byte_array) {
-    int length = byte_array->raw_length();
+    word length = byte_array->raw_length();
     if (length < 0) length = -1 - length;
     if (byte_array->has_external_address()) {
-      printer_->printf("an external ByteArray (tag:%ld) [%d]", byte_array->external_tag(), length);
+      printer_->printf("an external ByteArray (tag:%ld) [%" PRIdPTR "]", byte_array->external_tag(), length);
     } else {
-      printer_->printf("a ByteArray [%d]", length);
+      printer_->printf("a ByteArray [%" PRIdPTR "]", length);
     }
   }
 
   void visit_stack(Stack* stack) {
-    printer_->printf("a Stack [%d, %d]", stack->top(), stack->length());
+    printer_->printf("a Stack [%" PRIdPTR ", %" PRIdPTR "]", stack->top(), stack->length());
   }
 
   void visit_instance(Instance* instance) {
@@ -449,10 +449,10 @@ void print_object_short(Printer* printer, Object* object, bool is_top_level) {
   p.accept(object);
 }
 
-void Printer::print_buffer(const uint8_t* s, int len) {
-  const int BUF_LEN = 16;
+void Printer::print_buffer(const uint8_t* s, word len) {
+  const word BUF_LEN = 16;
   char buf[BUF_LEN];
-  for (int i = 0; i < len; ) {
+  for (word i = 0; i < len; ) {
     unsigned chunk = Utils::min(len - i, BUF_LEN - 1);
     memcpy(buf, s + i, chunk);
     buf[chunk] = '\0';

--- a/src/printing.h
+++ b/src/printing.h
@@ -33,7 +33,7 @@ class Printer {
 
   // For printing strings.  %s relies on a terminating null, but for this
   // you get to specify the length.
-  void print_buffer(const uint8_t* buffer, int length);
+  void print_buffer(const uint8_t* buffer, word length);
 
   Program* program() { return program_; }
  private:
@@ -53,10 +53,10 @@ class ConsolePrinter : public Printer {
 
 class BufferPrinter : public Printer {
  public:
-  BufferPrinter(Program* program, char* buffer, int buffer_len)
+  BufferPrinter(Program* program, char* buffer, word buffer_len)
     : Printer(program), ptr_(buffer), buffer_(buffer), buffer_len_(buffer_len), remaining_(buffer_len) {}
 
-  int length() const {
+  word length() const {
     return ptr_ - buffer_;
   }
 
@@ -65,8 +65,8 @@ class BufferPrinter : public Printer {
  private:
   char* ptr_;
   char* buffer_;
-  int buffer_len_;
-  int remaining_;
+  word buffer_len_;
+  word remaining_;
 };
 
 void print_object(Printer* printer, Object* object);

--- a/src/process.cc
+++ b/src/process.cc
@@ -185,7 +185,7 @@ SystemMessage* Process::take_termination_message(uint8 result) {
 }
 
 
-String* Process::allocate_string(const char* content, int length) {
+String* Process::allocate_string(const char* content, word length) {
   String* result = allocate_string(length);
   if (result == null) return result;  // Allocation failure.
   // Initialize object.
@@ -194,14 +194,14 @@ String* Process::allocate_string(const char* content, int length) {
   return result;
 }
 
-String* Process::allocate_string(int length) {
+String* Process::allocate_string(word length) {
   ASSERT(length >= 0);
   bool can_fit_in_heap_block = length <= String::max_internal_size_in_process();
   if (can_fit_in_heap_block) {
     String* result = object_heap()->allocate_internal_string(length);
     if (result != null) return result;
 #ifdef TOIT_GC_LOGGING
-    printf("[gc @ %p%s | string allocation failed, length = %d (heap)]\n",
+    printf("[gc @ %p%s | string allocation failed, length = %" PRIdPTR " (heap)]\n",
         this, VM::current()->scheduler()->is_boot_process(this) ? "*" : " ",
         length);
 #endif
@@ -216,7 +216,7 @@ String* Process::allocate_string(int length) {
   }
   if (memory == null) {
 #ifdef TOIT_GC_LOGGING
-      printf("[gc @ %p%s | string allocation failed, length = %d (malloc)]\n",
+      printf("[gc @ %p%s | string allocation failed, length = %" PRIdPTR " (malloc)]\n",
           this, VM::current()->scheduler()->is_boot_process(this) ? "*" : " ",
           length);
 #endif
@@ -229,7 +229,7 @@ String* Process::allocate_string(int length) {
     return result;
   }
 #ifdef TOIT_GC_LOGGING
-    printf("[gc @ %p%s | string allocation failed, length = %d (after malloc)]\n",
+    printf("[gc @ %p%s | string allocation failed, length = %" PRIdPTR " (after malloc)]\n",
         this, VM::current()->scheduler()->is_boot_process(this) ? "*" : " ",
         length);
 #endif
@@ -240,7 +240,7 @@ Object* Process::allocate_string_or_error(const char* content) {
   return allocate_string_or_error(content, strlen(content));
 }
 
-Object* Process::allocate_string_or_error(const char* content, int length) {
+Object* Process::allocate_string_or_error(const char* content, word length) {
   String* result = allocate_string(content, length);
   if (result == null) return Error::from(program()->allocation_failed());
   return result;
@@ -250,7 +250,7 @@ String* Process::allocate_string(const char* content) {
   return allocate_string(content, strlen(content));
 }
 
-ByteArray* Process::allocate_byte_array(int length, bool force_external) {
+ByteArray* Process::allocate_byte_array(word length, bool force_external) {
   ASSERT(length >= 0);
   if (force_external || length > ByteArray::max_internal_size_in_process()) {
     // Byte array cannot fit within a heap block so place content in malloced space.
@@ -263,7 +263,7 @@ ByteArray* Process::allocate_byte_array(int length, bool force_external) {
     if (memory == null) {
       // Malloc failed, report it.
 #ifdef TOIT_GC_LOGGING
-      printf("[gc @ %p%s | byte array allocation failed, length = %d (malloc)]\n",
+      printf("[gc @ %p%s | byte array allocation failed, length = %" PRIdPTR " (malloc)]\n",
           this, VM::current()->scheduler()->is_boot_process(this) ? "*" : " ",
           length);
 #endif
@@ -274,7 +274,7 @@ ByteArray* Process::allocate_byte_array(int length, bool force_external) {
       return result;
     }
 #ifdef TOIT_GC_LOGGING
-    printf("[gc @ %p%s | byte array allocation failed, length = %d (after malloc)]\n",
+    printf("[gc @ %p%s | byte array allocation failed, length = %" PRIdPTR " (after malloc)]\n",
         this, VM::current()->scheduler()->is_boot_process(this) ? "*" : " ",
         length);
 #endif
@@ -282,7 +282,7 @@ ByteArray* Process::allocate_byte_array(int length, bool force_external) {
   }
   if (ByteArray* result = object_heap()->allocate_internal_byte_array(length)) return result;
 #ifdef TOIT_GC_LOGGING
-  printf("[gc @ %p%s | byte array allocation failed, length = %d (heap)]\n",
+  printf("[gc @ %p%s | byte array allocation failed, length = %" PRIdPTR " (heap)]\n",
       this, VM::current()->scheduler()->is_boot_process(this) ? "*" : " ",
       length);
 #endif

--- a/src/process.h
+++ b/src/process.h
@@ -184,15 +184,15 @@ class Process : public ProcessListFromProcessGroup::Element,
   int gc_count(GcType type) { return object_heap_.gc_count(type); }
 
   String* allocate_string(const char* content);
-  String* allocate_string(int length);
-  String* allocate_string(const char* content, int length);
+  String* allocate_string(word length);
+  String* allocate_string(const char* content, word length);
   Object* allocate_string_or_error(const char* content);
-  Object* allocate_string_or_error(const char* content, int length);
+  Object* allocate_string_or_error(const char* content, word length);
 #if defined(TOIT_WINDOWS)
   String* allocate_string(const wchar_t* content);
   String* allocate_string(const wchar_t* content, word length);
 #endif
-  ByteArray* allocate_byte_array(int length, bool force_external=false);
+  ByteArray* allocate_byte_array(word length, bool force_external=false);
 
   void set_max_heap_size(word bytes) {
     object_heap_.set_max_heap_size(bytes);

--- a/src/program.h
+++ b/src/program.h
@@ -147,7 +147,7 @@ class Program : public FlashAllocation {
   }
 
   // Implementation is located in interpreter_run.cc
-  inline Method find_method(Object* receiver, int offset);
+  inline Method find_method(Object* receiver, word offset);
 
   static const int CLASS_TAG_MASK = (1 << HeapObject::CLASS_TAG_BIT_SIZE) - 1;
   static const int INSTANCE_SIZE_BIT_SIZE = 16 - HeapObject::CLASS_ID_OFFSET;
@@ -330,7 +330,7 @@ class Program : public FlashAllocation {
     return (instance_byte_size << HeapObject::CLASS_ID_OFFSET) | tag;
   }
 
-  void set_invoke_bytecode_offset(Opcode opcode, int offset) {
+  void set_invoke_bytecode_offset(Opcode opcode, word offset) {
     ASSERT(opcode >= INVOKE_EQ && opcode <= INVOKE_SIZE);
     invoke_bytecode_offsets_[opcode - INVOKE_EQ] = offset;
   }

--- a/src/resources/espnow_esp32.cc
+++ b/src/resources/espnow_esp32.cc
@@ -54,7 +54,7 @@ class SpinLocker {
 };
 
 struct Datagram {
-  int len;
+  word len;
   uint8 mac[6];
   uint8 buffer[ESPNOW_RX_DATAGRAM_LEN_MAX];
 };

--- a/src/resources/i2c_esp32.cc
+++ b/src/resources/i2c_esp32.cc
@@ -128,7 +128,7 @@ PRIMITIVE(close) {
 static Object* write_i2c(Process* process, I2cResourceGroup* i2c, int i2c_address, const uint8* address, int address_length, Blob buffer) {
 
   const uint8* data = buffer.address();
-  int length = buffer.length();
+  word length = buffer.length();
   if (!esp_ptr_internal(data)) {
     // Copy buffer to malloc heap, if the buffer is not in memory.
     uint8* copy = unvoid_cast<uint8*>(malloc(length));
@@ -181,7 +181,7 @@ static Object* write_i2c(Process* process, I2cResourceGroup* i2c, int i2c_addres
   return process->null_object();
 }
 
-static Object* read_i2c(Process* process, I2cResourceGroup* i2c, int i2c_address, const uint8* address, int address_length, int length) {
+static Object* read_i2c(Process* process, I2cResourceGroup* i2c, int i2c_address, const uint8* address, int address_length, word length) {
   ByteArray* array = process->allocate_byte_array(length);
   if (array == null) FAIL(ALLOCATION_FAILED);
   uint8* data = ByteArray::Bytes(array).address();

--- a/src/resources/image.cc
+++ b/src/resources/image.cc
@@ -49,13 +49,13 @@ PRIMITIVE(writer_create) {
   return result;
 }
 
-static Object* write_image_chunk(Process* process, ImageOutputStream* output, const word* data, int length) {
+static Object* write_image_chunk(Process* process, ImageOutputStream* output, const word* data, word length) {
   // The first word is relocation bits, not part of the output.
-  int output_byte_size = (length - 1) * WORD_SIZE;
+  word output_byte_size = (length - 1) * WORD_SIZE;
   word buffer[WORD_BIT_SIZE];
 
   bool first = output->empty();
-  int offset = FlashRegistry::offset(output->cursor());
+  word offset = FlashRegistry::offset(output->cursor());
   if (offset < 0 || offset + output_byte_size > FlashRegistry::allocations_size()) FAIL(OUT_OF_BOUNDS);
   output->write(data, length, buffer);
 
@@ -66,9 +66,9 @@ static Object* write_image_chunk(Process* process, ImageOutputStream* output, co
     Program::Header* header = reinterpret_cast<Program::Header*>(&buffer[0]);
     output->set_program_id(header->id());
     output->set_program_size(header->size());
-    const int header_size = sizeof(Program::Header);
+    const word header_size = sizeof(Program::Header);
     ASSERT(Utils::is_aligned(header_size, WORD_SIZE));
-    const int header_words = header_size / WORD_SIZE;
+    const word header_words = header_size / WORD_SIZE;
     success = FlashRegistry::write_chunk(&buffer[header_words], offset + header_size, output_byte_size - header_size);
   } else {
     success = FlashRegistry::write_chunk(buffer, offset, output_byte_size);
@@ -78,11 +78,11 @@ static Object* write_image_chunk(Process* process, ImageOutputStream* output, co
 }
 
 PRIMITIVE(writer_write) {
-  ARGS(ImageOutputStream, output, Blob, content_bytes, int, from, int, to);
+  ARGS(ImageOutputStream, output, Blob, content_bytes, word, from, word, to);
   if (to < from || from < 0) FAIL(INVALID_ARGUMENT);
   if (to > content_bytes.length()) FAIL(OUT_OF_BOUNDS);
   const word* data = reinterpret_cast<const word*>(content_bytes.address() + from);
-  int length = (to - from) / WORD_SIZE;
+  word length = (to - from) / WORD_SIZE;
   Object* error = write_image_chunk(process, output, data, length);
   return error ? error : process->null_object();
 }

--- a/src/resources/pipe_posix.cc
+++ b/src/resources/pipe_posix.cc
@@ -394,7 +394,7 @@ static Object* fork_helper(
       if (!args->at(i)->byte_content(process->program(), &blob, STRINGS_ONLY)) {
         FAIL(WRONG_OBJECT_TYPE);
       }
-      int len = blob.length();
+      word len = blob.length();
       char* c_string = unvoid_cast<char*>(malloc(len + 1));
       memcpy(c_string, blob.address(), len);
       c_string[len] = '\0';

--- a/src/resources/pipe_win.cc
+++ b/src/resources/pipe_win.cc
@@ -151,7 +151,7 @@ class WritePipeResource : public HandlePipeResource {
   bool ready_for_write() const { return write_ready_; }
 
 
-  bool send(const uint8* buffer, int length) {
+  bool send(const uint8* buffer, word length) {
     if (write_buffer_ != null) free(write_buffer_);
 
     write_ready_ = false;

--- a/src/resources/tcp_esp32.cc
+++ b/src/resources/tcp_esp32.cc
@@ -144,7 +144,7 @@ void LwipSocket::on_read(pbuf* p, err_t err) {
   send_state();
 }
 
-void LwipSocket::on_wrote(int length) {
+void LwipSocket::on_wrote(word length) {
   send_pending_ -= length;
 
   if (send_closed_ && send_pending_ == 0) {
@@ -526,12 +526,12 @@ static Object* get_address(LwipSocket* socket, Process* process, bool peer) {
     ip_addr_get_ip4_u32(&socket->tpcb()->remote_ip) :
     ip_addr_get_ip4_u32(&socket->tpcb()->local_ip);
   char buffer[16];
-  int length = sprintf(buffer,
-                       "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32,
-                       (address >> 0) & 0xff,
-                       (address >> 8) & 0xff,
-                       (address >> 16) & 0xff,
-                       (address >> 24) & 0xff);
+  word length = sprintf(buffer,
+                        "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32,
+                        (address >> 0) & 0xff,
+                        (address >> 8) & 0xff,
+                        (address >> 16) & 0xff,
+                        (address >> 24) & 0xff);
   return  process->allocate_string_or_error(buffer, length);
 }
 

--- a/src/resources/tcp_esp32.h
+++ b/src/resources/tcp_esp32.h
@@ -66,7 +66,7 @@ class LwipSocket : public Resource, public BacklogSocketList::Element {
     unvoid_cast<LwipSocket*>(arg)->on_wrote(length);
     return ERR_OK;
   }
-  void on_wrote(int length);
+  void on_wrote(word length);
 
   static void on_error(void* arg, err_t err) {
     // Ignore if already deleted.

--- a/src/resources/tcp_win.cc
+++ b/src/resources/tcp_win.cc
@@ -173,7 +173,7 @@ class TcpSocketResource : public TcpSocketBaseResource {
     return overlapped_result;
   }
 
-  bool send(const uint8* buffer, int length) {
+  bool send(const uint8* buffer, word length) {
     if (write_buffer_.buf != null) {
       free(write_buffer_.buf);
       write_buffer_.buf = null;

--- a/src/resources/tls.cc
+++ b/src/resources/tls.cc
@@ -106,10 +106,10 @@ int BaseMbedTlsSocket::add_root_certificate(X509Certificate* cert) {
   return 0;
 }
 
-uint32 BaseMbedTlsSocket::hash_subject(uint8* buffer, int length) {
+uint32 BaseMbedTlsSocket::hash_subject(uint8* buffer, word length) {
   // Matching should be case independent for ASCII strings, so lets just zap
   // all the 0x20 bits, since we are just doing a fuzzy match.
-  for (int i = 0; i < length; i++) buffer[i] |= 0x20;
+  for (word i = 0; i < length; i++) buffer[i] |= 0x20;
   return Utils::crc32(0xce77509, buffer, length);
 }
 

--- a/src/resources/tls.h
+++ b/src/resources/tls.h
@@ -82,7 +82,7 @@ class BaseMbedTlsSocket : public TlsSocket {
   void record_error_detail(const mbedtls_asn1_named_data* issuer, int flags, int index);
   // Hash a textual description of the issuer of a certificate, or the
   // subject of a root certificate. These should match.
-  static uint32 hash_subject(uint8* buffer, int length);
+  static uint32 hash_subject(uint8* buffer, word length);
   uint32_t error_flags() const { return error_flags_; }
   char* error_detail(int index) const { return error_details_[index]; }
   void clear_error_data();

--- a/src/resources/uart_win.cc
+++ b/src/resources/uart_win.cc
@@ -111,7 +111,7 @@ public:
     return overlapped_result;
   }
 
-  bool send(const uint8* buffer, int length) {
+  bool send(const uint8* buffer, word length) {
     if (write_buffer_ != null) free(write_buffer_);
 
     write_ready_ = false;

--- a/src/resources/udp_esp32.cc
+++ b/src/resources/udp_esp32.cc
@@ -428,12 +428,12 @@ static Object* get_address_or_error(UdpSocket* socket, Process* process, bool pe
     ip_addr_get_ip4_u32(&socket->upcb()->remote_ip) :
     ip_addr_get_ip4_u32(&socket->upcb()->local_ip);
   char buffer[16];
-  int length = sprintf(buffer,
-                       "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32,
-                       (address >> 0) & 0xff,
-                       (address >> 8) & 0xff,
-                       (address >> 16) & 0xff,
-                       (address >> 24) & 0xff);
+  word length = sprintf(buffer,
+                        "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32,
+                        (address >> 0) & 0xff,
+                        (address >> 8) & 0xff,
+                        (address >> 16) & 0xff,
+                        (address >> 24) & 0xff);
   return process->allocate_string_or_error(buffer, length);
 }
 

--- a/src/resources/udp_win.cc
+++ b/src/resources/udp_win.cc
@@ -119,7 +119,7 @@ class UdpSocketResource : public WindowsResource {
     return overlapped_result;
   }
 
-  bool send(const uint8* buffer, int length, ToitSocketAddress* socket_address) {
+  bool send(const uint8* buffer, word length, ToitSocketAddress* socket_address) {
     // We need to copy the buffer out to a long-lived heap object
     if (write_buffer_.buf != null) {
       free(write_buffer_.buf);

--- a/src/third_party/dartino/gc_metadata.h
+++ b/src/third_party/dartino/gc_metadata.h
@@ -39,8 +39,8 @@ class GcMetadata {
   static const int CARD_SIZE_IN_BITS_LOG_2 = CARD_SIZE_LOG_2 + 3;
 
   // There is a byte per card, and any two byte values would work here.
-  static const int NO_NEW_SPACE_POINTERS = 0;
-  static const int NEW_SPACE_POINTERS = 1;  // Actually any non-zero value.
+  static const uint8 NO_NEW_SPACE_POINTERS = 0;
+  static const uint8 NEW_SPACE_POINTERS = 1;  // Actually any non-zero value.
 
   // One bit per word of heap, so the size in bytes is 1/8th of that.
   static const int MARK_BITS_SHIFT = 3 + WORD_SHIFT;
@@ -403,10 +403,6 @@ class GcMetadata {
     return base + (Utils::popcount(bits) << WORD_SHIFT);
   }
 
-  static int heap_allocation_arena() {
-    return singleton_.heap_allocation_arena_;
-  }
-
   static uword lowest_old_space_address() { return singleton_.lowest_address_; }
 
   static uword heap_extent() { return singleton_.heap_extent_; }
@@ -494,7 +490,6 @@ class GcMetadata {
   uword heap_extent_munged_;
   uword number_of_cards_;
   uword metadata_size_;
-  int heap_allocation_arena_;
   uint8* metadata_;
   uint8* remembered_set_;
   uint8* object_starts_;

--- a/src/third_party/dartino/mark_sweep.h
+++ b/src/third_party/dartino/mark_sweep.h
@@ -53,7 +53,7 @@ class MarkingVisitor : public RootCallback {
         new_space_size_(new_space->size()),
         marking_stack_(marking_stack) {}
 
-  virtual void do_roots(Object** start, int length) override {
+  virtual void do_roots(Object** start, word length) override {
     Object** end = start + length;
     // Mark live all HeapObjects pointed to by pointers in [start, end)
     for (Object** p = start; p < end; p++) mark_pointer(*p);
@@ -89,7 +89,7 @@ class FixPointersVisitor : public RootCallback {
  public:
   FixPointersVisitor() {}
 
-  virtual void do_roots(Object** start, int length);
+  virtual void do_roots(Object** start, word length);
 };
 
 class CompactingVisitor : public HeapObjectVisitor {

--- a/src/third_party/dartino/object_memory.cc
+++ b/src/third_party/dartino/object_memory.cc
@@ -168,8 +168,8 @@ bool Space::includes(uword address) {
 class InSpaceVisitor : public RootCallback {
  public:
   explicit InSpaceVisitor(Space* space) : space(space) {}
-  void do_roots(Object** p, int length) {
-    for (int i = 0; i < length; i++) {
+  void do_roots(Object** p, word length) {
+    for (word i = 0; i < length; i++) {
       Object* object = p[i];
       if (is_smi(object)) continue;
       if (space->includes(reinterpret_cast<uword>(object))) {

--- a/src/third_party/dartino/object_memory.h
+++ b/src/third_party/dartino/object_memory.h
@@ -31,7 +31,7 @@ class Smi;
 class Space;
 class TwoSpaceHeap;
 
-static const int SENTINEL_SIZE = sizeof(void*);
+static const uword SENTINEL_SIZE = sizeof(void*);
 
 // In oldspace, the sentinel marks the end of each chunk, and never moves or is
 // overwritten.
@@ -498,7 +498,6 @@ class OldSpace : public Space {
   // Actually new space garbage found since last compacting GC. Used to
   // evaluate whether we are out of memory.
   uword new_space_garbage_found_since_last_gc_ = 0;
-  int successive_pointless_gcs_ = 0;
   uword used_after_last_gc_ = 0;
   uword used_ = 0;               // Allocated bytes.
   // Record whether a promotion failed during a scavenge, so we can save time

--- a/src/third_party/dartino/object_memory_mark_sweep.cc
+++ b/src/third_party/dartino/object_memory_mark_sweep.cc
@@ -226,8 +226,8 @@ void OldSpace::zap_object_starts() {
 
 class RememberedSetRebuilder2 : public RootCallback {
  public:
-  virtual void do_roots(Object** pointers, int length) override {
-    for (int i = 0; i < length; i++) {
+  virtual void do_roots(Object** pointers, word length) override {
+    for (word i = 0; i < length; i++) {
       Object* object = pointers[i];
       if (GcMetadata::get_page_type(object) == NEW_SPACE_PAGE) {
         found = true;
@@ -406,7 +406,7 @@ void OldSpace::mark_chunk_ends_free() {
   });
 }
 
-void FixPointersVisitor::do_roots(Object** start, int length) {
+void FixPointersVisitor::do_roots(Object** start, word length) {
   Object** end = start + length;
   for (Object** current = start; current < end; current++) {
     Object* object = *current;

--- a/src/third_party/dartino/two_space_heap.cc
+++ b/src/third_party/dartino/two_space_heap.cc
@@ -107,7 +107,7 @@ HeapObject* ScavengeVisitor::clone_into_space(Program* program, HeapObject* orig
   return target;
 }
 
-void ScavengeVisitor::do_roots(Object** start, int count) {
+void ScavengeVisitor::do_roots(Object** start, word count) {
   Object** end = start + count;
   for (Object** p = start; p < end; p++) {
     if (!in_from_space(*p)) continue;

--- a/src/third_party/dartino/two_space_heap.h
+++ b/src/third_party/dartino/two_space_heap.h
@@ -92,7 +92,7 @@ class TwoSpaceHeap {
   }
 
   // Returns the number of bytes allocated in the space.
-  int used() const { return old_space_.used() + semi_space_.used(); }
+  word used() const { return old_space_.used() + semi_space_.used(); }
 
   HeapObject* new_space_allocation_failure(uword size);
 
@@ -168,7 +168,7 @@ class ScavengeVisitor : public RootCallback {
     return reinterpret_cast<uword>(object) - to_start_ < to_size_;
   }
 
-  virtual void do_roots(Object** start, int count);
+  virtual void do_roots(Object** start, word count);
 
   bool trigger_old_space_gc() { return trigger_old_space_gc_; }
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -295,7 +295,7 @@ static const uint32 HIGH_BIT_OF_EACH_BYTE = 0x80808080;
 
 #endif
 
-bool Utils::is_valid_utf_8(const uint8* buffer, int length) {
+bool Utils::is_valid_utf_8(const uint8* buffer, word length) {
   // Align.
   while (length != 0 && !is_aligned(buffer, WORD_SIZE) && (buffer[0] & 0xff) <= MAX_ASCII) {
     length--;
@@ -312,7 +312,7 @@ bool Utils::is_valid_utf_8(const uint8* buffer, int length) {
   // Thanks to Per Vognsen.  Explanation at
   // https://gist.github.com/pervognsen/218ea17743e1442e59bb60d29b1aa725
   uint64 state = UTF_BASE;
-  for (int i = 0; i < length; i++) {
+  for (word i = 0; i < length; i++) {
     unsigned char c = buffer[i];
     state = UTF_8_STATE_TABLE[c] >> (state & UTF_MASK);  // The '&' is optimized out.
   }
@@ -320,7 +320,7 @@ bool Utils::is_valid_utf_8(const uint8* buffer, int length) {
 #else
   int32 state = UTF_BASE;
   int allowed_nibbles = START;
-  for (int i = 0; i < length; i++) {
+  for (word i = 0; i < length; i++) {
     unsigned char c = buffer[i];
     int high_nibble = c >> 4;
     if ((allowed_nibbles & (1 << high_nibble)) == 0) return false;
@@ -486,7 +486,7 @@ uint16* Utils::create_new_environment(Process* process, uint16* previous_environ
       bool in_new_environment = false;
       // Environment variable key  from p to p + utf_16_key_value_length.
       // Environment variable name from p to p + utf_16_key_length.
-      for (int i = 0; i < environment->length(); i += 2) {
+      for (word i = 0; i < environment->length(); i += 2) {
         Blob key;
         environment->at(i)->byte_content(process->program(), &key, STRINGS_ONLY);
         if (utf_8_equals_utf_16(key.address(), key.length(), p, utf_16_key_length)) {
@@ -505,7 +505,7 @@ uint16* Utils::create_new_environment(Process* process, uint16* previous_environ
     }
     // Now that we have inherited the environment variables that were not
     // mentioned in the new environment map, add the new variables.
-    for (int i = 0; i < environment->length(); i += 2) {
+    for (word i = 0; i < environment->length(); i += 2) {
       Blob key;
       if (environment->at(i + 1) != process->null_object()) {
         Blob key, value;

--- a/src/utils.h
+++ b/src/utils.h
@@ -43,13 +43,13 @@ class Utils {
   }
 
   template<typename T>
-  static inline bool is_aligned(T x, int n) {
+  static inline bool is_aligned(T x, uword n) {
     ASSERT(is_power_of_two(n));
     return ((x - static_cast<T>(0)) & (n - 1)) == 0;
   }
 
   template<typename T>
-  static inline T round_down(T x, int n) {
+  static inline T round_down(T x, uword n) {
     ASSERT(is_power_of_two(n));
     return (T)((uintptr_t)(x) & -n);
   }
@@ -91,8 +91,8 @@ class Utils {
   static inline int popcount(T x) {
     typename std::make_unsigned<T>::type u = x;
 #ifdef __XTENSA__
-    int result = 0;
-    for (int i = 0; i < sizeof(u); i++) {
+    word result = 0;
+    for (word i = 0; i < sizeof(u); i++) {
       uint8 b = u & 0xff;
       result += popcount_table[b];
       u >>= 8;
@@ -111,7 +111,7 @@ class Utils {
   }
 
   template<typename T>
-  static inline T address_at(T base, int byte_offset) {
+  static inline T address_at(T base, word byte_offset) {
     return reinterpret_cast<T>(((uword) base) + byte_offset);
   }
 
@@ -121,11 +121,11 @@ class Utils {
   }
 
   template<typename T>
-  static inline T round_up(T x, int n) {
+  static inline T round_up(T x, word n) {
     return round_down(x + n - 1, n);
   }
 
-  static inline void* round_up(void* p, int n) {
+  static inline void* round_up(void* p, word n) {
     return reinterpret_cast<void*>(round_up(reinterpret_cast<uword>(p), n));
   }
 
@@ -322,10 +322,10 @@ class Utils {
 
   // The number of leading ones in the prefix byte determines the length of a
   // UTF-8 sequence.
-  static int bytes_in_utf_8_sequence(unsigned char prefix) {
+  static word bytes_in_utf_8_sequence(unsigned char prefix) {
     if (prefix <= MAX_ASCII) return 1;
-    int count = 0;
-    int mask = 0x80;
+    word count = 0;
+    word mask = 0x80;
     while ((prefix & mask) != 0) {
       count++;
       mask >>= 1;
@@ -333,12 +333,12 @@ class Utils {
     return count;
   }
 
-  static int payload_from_prefix(unsigned char prefix) {
-    int n_byte_sequence = bytes_in_utf_8_sequence(prefix);
+  static word payload_from_prefix(unsigned char prefix) {
+    word n_byte_sequence = bytes_in_utf_8_sequence(prefix);
     return prefix & ((1 << (7 - n_byte_sequence)) - 1);
   }
 
-  static bool is_valid_utf_8(const uint8* buffer, int length);
+  static bool is_valid_utf_8(const uint8* buffer, word length);
 
  private:
   static const uint8 REVERSE_NIBBLE[16];
@@ -446,7 +446,7 @@ template<typename T>
 class List {
  public:
   List() : data_(null), length_(0) {}
-  List(T* data, int length) : data_(data), length_(length) {
+  List(T* data, word length) : data_(data), length_(length) {
     ASSERT(length >= 0);
   }
 
@@ -459,15 +459,15 @@ class List {
 
   T* data() const { return data_; }
   T*& data() { return data_; }
-  int length() const { return length_; }
+  word length() const { return length_; }
   bool is_empty() const { return length_ == 0; }
 
-  T& operator[](int index) {
+  T& operator[](word index) {
     ASSERT(index >= 0 && index < length_);
     return data_[index];
   }
 
-  const T& operator[](int index) const {
+  const T& operator[](word index) const {
     ASSERT(index >= 0 && index < length_);
     return data_[index];
   }
@@ -486,7 +486,7 @@ class List {
     return (pointer >= begin() && pointer < end());
   }
 
-  const List<T> sublist(int from, int to) const {
+  const List<T> sublist(word from, word to) const {
     ASSERT(0 <= from && from <= to && to <= length_);
     return List<T>(&data_[from], to - from);
   }
@@ -513,7 +513,7 @@ class List {
 
  private:
   T* data_;
-  int length_;
+  word length_;
 
   template <typename U>
   friend class List;


### PR DESCRIPTION
Anything that relates to the size of an array, an offset to a pointer, or the size of memory should be a word, not an int.  This avoids 64+32 add operations.

Anything extracted from a Smi should be word because int will silently overflow.

Many primitives changed from int (the smaller of int and Smi) to word (which actually means the argument must be Smi).