### PR TITLE
Fix add_characteristic primitive.

### DIFF
--- a/src/resources/ble_esp32.cc
+++ b/src/resources/ble_esp32.cc
@@ -2971,7 +2971,7 @@ PRIMITIVE(add_service) {
 
 PRIMITIVE(add_characteristic) {
   ARGS(BleServiceResource, service_resource, Blob, raw_uuid, int, properties,
-       int, permissions, Object, value, int, read_timeout_ms)
+       int, permissions, Object, value)
 
   Locker locker(service_resource->group()->mutex());
 


### PR DESCRIPTION
It was taking one too many parameters which made it flaky.