### PR TITLE
Make a Deque a List.

### DIFF
--- a/lib/core/collections.toit
+++ b/lib/core/collections.toit
@@ -302,22 +302,22 @@ abstract class List extends CollectionBase:
     collection.do: this[index++] = it
 
   /**
-  Insert a value at the given index.
+  Inserts the given $alue at the given index.
   It is valid to insert at the $size position, in which case this is
     equivalent to $add.
   If n is the distance to the end of the list, the operation
     runs in `O(n)` and is thus not efficient for insertions that are not near
     the end of the list.
   */
-  insert-at index/int value/any -> none:
+  insert --at/int value/any -> none:
     sz := size
-    if index == sz:
+    if at == sz:
       add value
       return
-    if not 0 <= index < sz: throw "OUT_OF_BOUNDS"
+    if not 0 <= at < sz: throw "OUT_OF_BOUNDS"
     add value  // Will soon be overwritten.
-    replace (index + 1) this index sz
-    this[index] = value
+    replace (at + 1) this at sz
+    this[at] = value
 
   /**
   Removes the last element of this instance.
@@ -342,10 +342,10 @@ abstract class List extends CollectionBase:
   remove needle -> none:
     i := 0
     while i < size and this[i] != needle: i++
-    if i != size: remove-at i
+    if i != size: remove --at=i
 
   /**
-  Remove a value at the given index.
+  Removes the value at the given index.
   It is valid to remove at the $size - 1 position, in which case this is
     equivalent to $remove-last.
   If n is the distance to the end of the list, the operation
@@ -353,10 +353,10 @@ abstract class List extends CollectionBase:
     the end of the list.
   Returns the value that was removed.
   */
-  remove-at index/int -> any:
-    result := this[index]
-    if index != size - 1:
-      replace index this (index + 1) size
+  remove --at/int -> any:
+    result := this[at]
+    if at != size - 1:
+      replace at this (at + 1) size
     resize size - 1
     return result
 
@@ -3369,7 +3369,7 @@ class Deque extends List implements Collection:
     return Deque.from backing_[first_ + from .. first_ + to]
 
   /**
-  Insert a value at the given index.
+  Inserts the given $value at the given index.
   It is valid to insert at the $size position, in which case this is
     equivalent to $add.  It is also valid to add at the zero position,
     in which case this is equivalent to $add-first.
@@ -3377,22 +3377,22 @@ class Deque extends List implements Collection:
     runs in `O(n)` and is thus not efficient for insertions that are not near
     the start or end of the deque.
   */
-  insert-at index/int value -> none:
+  insert --at/int value -> none:
     sz := size
-    if index < 0 or index > sz: throw "OUT_OF_BOUNDS"
-    if index >= sz >> 1:
-      backing_.insert-at (index + first_) value
+    if at < 0 or at > sz: throw "OUT_OF_BOUNDS"
+    if at >= sz >> 1:
+      backing_.insert --at=(at + first_) value
     else:
       add-first value
-      if index != 0:
+      if at != 0:
         // Need to move down the elements.
         first := first_  // This is the decremented value after the add.
-        index += first
-        backing_.replace first backing_ (first + 1) (index + 1)
-        backing_[index] = value
+        at += first
+        backing_.replace first backing_ (first + 1) (at + 1)
+        backing_[at] = value
 
   /**
-  Remove a value at the given index.
+  Removes the value at the given index.
   It is valid to remove at the $size - 1 position, in which case this is
     equivalent to $remove-last.  It is also valid to remove at the zero
     position, in which case this is equivalent to $remove-first.
@@ -3401,18 +3401,18 @@ class Deque extends List implements Collection:
     the start or end of the deque.
   Returns the value that was removed.
   */
-  remove-at index/int -> any:
+  remove --at/int -> any:
     last := size - 1
-    if index < 0 or index > last: throw "OUT_OF_BOUNDS"
-    if index >= last >> 1:
-      return backing_.remove-at (first_ + index)
+    if at < 0 or at > last: throw "OUT_OF_BOUNDS"
+    if at >= last >> 1:
+      return backing_.remove --at=(first_ + at)
     removed := remove-first
-    if index == 0: return removed
+    if at == 0: return removed
     // Need to move up the elements.
     first := first_  // This is the incremented value after the remove-first.
-    index += first
-    result := backing_[index - 1]
-    backing_.replace (first + 1) backing_ first (index - 1)
+    at += first
+    result := backing_[at - 1]
+    backing_.replace (first + 1) backing_ first (at - 1)
     backing_[first] = removed
     return result
 

--- a/lib/core/collections.toit
+++ b/lib/core/collections.toit
@@ -302,6 +302,24 @@ abstract class List extends CollectionBase:
     collection.do: this[index++] = it
 
   /**
+  Insert a value at the given index.
+  It is valid to insert at the $size position, in which case this is
+    equivalent to $add.
+  If n is the distance to the end of the list, the operation
+    runs in `O(n)` and is thus not efficient for insertions that are not near
+    the end of the list.
+  */
+  insert-at index/int value/any -> none:
+    sz := size
+    if index == sz:
+      add value
+      return
+    if not 0 <= index < sz: throw "OUT_OF_BOUNDS"
+    add value  // Will soon be overwritten.
+    replace (index + 1) this index sz
+    this[index] = value
+
+  /**
   Removes the last element of this instance.
   Returns the removed element.
 
@@ -324,12 +342,23 @@ abstract class List extends CollectionBase:
   remove needle -> none:
     i := 0
     while i < size and this[i] != needle: i++
-    if i == size: return
-    i++
-    while i < size:
-      this[i - 1] = this[i]
-      i++
+    if i != size: remove-at i
+
+  /**
+  Remove a value at the given index.
+  It is valid to remove at the $size - 1 position, in which case this is
+    equivalent to $remove-last.
+  If n is the distance to the end of the list, the operation
+    runs in `O(n)` and is thus not efficient for deletions that are not near
+    the end of the list.
+  Returns the value that was removed.
+  */
+  remove-at index/int -> any:
+    result := this[index]
+    if index != size - 1:
+      replace index this (index + 1) size
     resize size - 1
+    return result
 
   /**
   Removes all entries that are equal to the given $needle.
@@ -3222,7 +3251,7 @@ A collection of items, where new items can be added at the end. They can
 A deque is a generalization of a stack and a queue, and can be used for both
   purposes.
 */
-class Deque implements Collection:
+class Deque extends List implements Collection:
   // Traditionally we would have a head index, a tail index and an array
   // backing, used as a circular buffer.  Instead we have only the tail index
   // (called first_) and use a growable list as backing, copying down when
@@ -3235,10 +3264,18 @@ class Deque implements Collection:
   first_ := 0
   backing_/List := []
 
+  /**
+  Constructs an empty Deque.
+  */
   constructor:
+    super.from-subclass
 
+  /**
+  Constructs a new Deque that initially contains the elements of the collection.
+  */
   constructor.from collection/Collection:
     backing_ = List.from collection
+    super.from-subclass
 
   size -> int:
     return backing_.size - first_
@@ -3278,15 +3315,15 @@ class Deque implements Collection:
     first_ = 0
 
   first -> any:
-    if first_ == backing_.size: throw "OUT_OF_RANGE"
+    if first_ == backing_.size: throw "OUT_OF_BOUNDS"
     return backing_[first_]
 
   last -> any:
-    if first_ == backing_.size: throw "OUT_OF_RANGE"
+    if first_ == backing_.size: throw "OUT_OF_BOUNDS"
     return backing_.last
 
   remove-last -> any:
-    if first_ == backing_.size: throw "OUT_OF_RANGE"
+    if first_ == backing_.size: throw "OUT_OF_BOUNDS"
     result := backing_.remove-last
     shrink-if-needed_
     return result
@@ -3294,7 +3331,7 @@ class Deque implements Collection:
   remove-first -> any:
     backing := backing_
     first := first_
-    if first == backing.size: throw "OUT_OF_RANGE"
+    if first == backing.size: throw "OUT_OF_BOUNDS"
     result := backing[first]
     backing[first] = null
     first_++
@@ -3317,8 +3354,71 @@ class Deque implements Collection:
     first_ = first
 
   operator [] index/int:
-    if index < 0 or index > backing_.size - first_: throw "OUT_OF_RANGE"
+    if index < 0: throw "OUT_OF_BOUNDS"
     return backing_[first_ + index]
+
+  operator []= index/int value:
+    if index < 0: throw "OUT_OF_BOUNDS"
+    backing_[first_ + index] = value
+
+  /**
+  Returns a new Deque that contains the elements of this.
+  */
+  copy from/int=0 to/int=size -> Deque:
+    if from < 0: throw "OUT_OF_BOUNDS"
+    return Deque.from backing_[first_ + from .. first_ + to]
+
+  /**
+  Insert a value at the given index.
+  It is valid to insert at the $size position, in which case this is
+    equivalent to $add.  It is also valid to add at the zero position,
+    in which case this is equivalent to $add-first.
+  If n is the shortest distance to the start or end of the deque, the operation
+    runs in `O(n)` and is thus not efficient for insertions that are not near
+    the start or end of the deque.
+  */
+  insert-at index/int value -> none:
+    sz := size
+    if index < 0 or index > sz: throw "OUT_OF_BOUNDS"
+    if index >= sz >> 1:
+      backing_.insert-at (index + first_) value
+    else:
+      add-first value
+      if index != 0:
+        // Need to move down the elements.
+        first := first_  // This is the decremented value after the add.
+        index += first
+        backing_.replace first backing_ (first + 1) (index + 1)
+        backing_[index] = value
+
+  /**
+  Remove a value at the given index.
+  It is valid to remove at the $size - 1 position, in which case this is
+    equivalent to $remove-last.  It is also valid to remove at the zero
+    position, in which case this is equivalent to $remove-first.
+  If n is the shortest distance to the start or end of the deque, the operation
+    runs in `O(n)` and is thus not efficient for deletions that are not near
+    the start or end of the deque.
+  Returns the value that was removed.
+  */
+  remove-at index/int -> any:
+    last := size - 1
+    if index < 0 or index > last: throw "OUT_OF_BOUNDS"
+    if index >= last >> 1:
+      return backing_.remove-at (first_ + index)
+    removed := remove-first
+    if index == 0: return removed
+    // Need to move up the elements.
+    first := first_  // This is the incremented value after the remove-first.
+    index += first
+    result := backing_[index - 1]
+    backing_.replace (first + 1) backing_ first (index - 1)
+    backing_[first] = removed
+    return result
+
+  resize new-size/int:
+    if new-size < 0: throw "OUT_OF_BOUNDS"
+    backing_.resize first_ + new-size
 
   shrink-if-needed_ -> none:
     backing := backing_

--- a/lib/core/collections.toit
+++ b/lib/core/collections.toit
@@ -302,7 +302,7 @@ abstract class List extends CollectionBase:
     collection.do: this[index++] = it
 
   /**
-  Inserts the given $alue at the given index.
+  Inserts the given $value at the given index.
   It is valid to insert at the $size position, in which case this is
     equivalent to $add.
   If n is the distance to the end of the list, the operation

--- a/tests/deque-test.toit
+++ b/tests/deque-test.toit
@@ -6,6 +6,9 @@ import expect show *
 
 main:
   test-deque
+  test-at Deque
+  test-at List
+  test-copy
 
 test-deque:
   deque := Deque
@@ -90,3 +93,126 @@ test-deque:
       first = false
     else:
       expect it == 99_998
+
+test-at list:
+  expect-equals 0 list.size
+  expect-equals "[]" list.stringify
+  expect-throws "OUT_OF_BOUNDS": list[0]
+  expect-throws "OUT_OF_BOUNDS": list.remove-last
+  expect-throws "OUT_OF_BOUNDS": list.remove-at 0
+  expect-throws "OUT_OF_BOUNDS": list.remove-at -1
+  expect-throws "OUT_OF_BOUNDS": list.remove-at 1
+  expect-throws "OUT_OF_BOUNDS": list.insert-at -1 "foo"
+  expect-throws "OUT_OF_BOUNDS": list.insert-at 1 "foo"
+  list.insert-at 0 "foo"
+  expect-equals 1 list.size
+  expect-equals "[foo]" list.stringify
+  expect-throws "OUT_OF_BOUNDS": list.remove-at -1
+  expect-throws "OUT_OF_BOUNDS": list.remove-at 1
+  expect-throws "OUT_OF_BOUNDS": list.insert-at -1 "bar"
+  expect-throws "OUT_OF_BOUNDS": list.insert-at 2 "bar"
+  expect-equals "foo" (list.remove-at 0)
+  expect-equals 0 list.size
+  expect-equals "[]" list.stringify
+  list.insert-at 0 "foo"
+  list.insert-at 0 "bar"
+  expect-equals "[bar, foo]" list.stringify
+  list.insert-at 2 "baz"
+  expect-equals 3 list.size
+  expect-equals "[bar, foo, baz]" list.stringify
+  expect-equals "foo" (list.remove-at 1)
+  expect-equals "[bar, baz]" list.stringify
+  expect-equals "bar" (list.remove-at 0)
+  expect-equals "[baz]" list.stringify
+  expect-equals 1 list.size
+  expect-equals "baz" (list.remove-at 0)
+
+  10.repeat: list.add it
+  expect-equals "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]" list.stringify
+  expect-equals 7 (list.remove-at 7)
+  expect-equals "[0, 1, 2, 3, 4, 5, 6, 8, 9]" list.stringify
+  expect-equals 1 (list.remove-at 1)
+  expect-equals "[0, 2, 3, 4, 5, 6, 8, 9]" list.stringify
+  expect-equals 3 (list.remove-at 2)
+  expect-equals "[0, 2, 4, 5, 6, 8, 9]" list.stringify
+  expect-equals 6 (list.remove-at 4)
+  expect-equals "[0, 2, 4, 5, 8, 9]" list.stringify
+  expect-equals 2 (list.remove-at 1)
+  expect-equals "[0, 4, 5, 8, 9]" list.stringify
+  expect-equals 8 (list.remove-at 3)
+  expect-equals "[0, 4, 5, 9]" list.stringify
+  expect-equals 4 (list.remove-at 1)
+  expect-equals "[0, 5, 9]" list.stringify
+  expect-equals 5 (list.remove-at 1)
+  expect-equals "[0, 9]" list.stringify
+  expect-equals 9 (list.remove-at 1)
+  expect-equals "[0]" list.stringify
+  expect-equals 0 (list.remove-at 0)
+  expect-equals "[]" list.stringify
+
+  10.repeat: list.insert-at list.size it
+  expect-equals 10 list.size
+  expect-equals "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]" list.stringify
+  list.insert-at 1 42
+  expect-equals 11 list.size
+  expect-equals "[0, 42, 1, 2, 3, 4, 5, 6, 7, 8, 9]" list.stringify
+  list.insert-at 9 103
+  expect-equals "[0, 42, 1, 2, 3, 4, 5, 6, 7, 103, 8, 9]" list.stringify
+  list.insert-at 8 102
+  expect-equals "[0, 42, 1, 2, 3, 4, 5, 6, 102, 7, 103, 8, 9]" list.stringify
+  list.insert-at (list.size - 1) 99
+  expect-equals "[0, 42, 1, 2, 3, 4, 5, 6, 102, 7, 103, 8, 99, 9]" list.stringify
+  list.insert-at 2 -1
+  expect-equals "[0, 42, -1, 1, 2, 3, 4, 5, 6, 102, 7, 103, 8, 99, 9]" list.stringify
+
+  expect-equals 0 (list.index-of 0)
+  expect-equals 1 (list.index-of 42)
+  list.clear
+  expect-equals 0 list.size
+  10.repeat: list.add it
+  expect-equals "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]" list.stringify
+  expect-equals 5 (list.index-of --binary 5)
+  r := list.index-of --binary 10 --if-absent=:
+    expect-equals 10 it
+    42
+  expect-equals 42 r
+  r = list.index-of --binary -1 --if-absent=:
+    expect-equals 0 it
+    42
+  expect-equals 42 r
+  expect-equals 0 (list.remove-at 0)
+  expect-equals 1 (list.remove-at 0)
+  r = list.index-of --binary 10 --if-absent=:
+    expect-equals 8 it
+    42
+  expect-equals 42 r
+  expect-equals "[2, 3, 4, 5, 6, 7, 8, 9]" list.stringify
+  r = list.index-of --binary 8 0 5 --if-absent=:
+    expect-equals 5 it
+    42
+  expect-equals 42 r
+  expect-equals "[2, 3, 4, 5, 6, 7, 8, 9]" list.stringify
+  r = list.index-of --binary 8 0 6 --if-absent=:
+    expect-equals 6 it
+    42
+  expect-equals 42 r
+  expect-equals 6 (list.index-of --binary 8 0 7)
+  expect-equals 42 r
+
+test-copy:
+  d := Deque
+  d.add-all [1, 2, 3]
+  d2/Deque := d.copy
+  d[1] = 42
+  d2[1] = 103
+  expect-equals "[1, 42, 3]" d.stringify
+  expect-equals "[1, 103, 3]" d2.stringify
+  d.remove-last
+  d2.remove-first
+  expect-equals "[1, 42]" d.stringify
+  expect-equals "[103, 3]" d2.stringify
+
+expect-throws name [code]:
+  expect-equals
+    name
+    catch code

--- a/tests/deque-test.toit
+++ b/tests/deque-test.toit
@@ -99,70 +99,70 @@ test-at list:
   expect-equals "[]" list.stringify
   expect-throw "OUT_OF_BOUNDS": list[0]
   expect-throw "OUT_OF_BOUNDS": list.remove-last
-  expect-throw "OUT_OF_BOUNDS": list.remove-at 0
-  expect-throw "OUT_OF_BOUNDS": list.remove-at -1
-  expect-throw "OUT_OF_BOUNDS": list.remove-at 1
-  expect-throw "OUT_OF_BOUNDS": list.insert-at -1 "foo"
-  expect-throw "OUT_OF_BOUNDS": list.insert-at 1 "foo"
-  list.insert-at 0 "foo"
+  expect-throw "OUT_OF_BOUNDS": list.remove --at=0
+  expect-throw "OUT_OF_BOUNDS": list.remove --at=-1
+  expect-throw "OUT_OF_BOUNDS": list.remove --at=1
+  expect-throw "OUT_OF_BOUNDS": list.insert --at=-1 "foo"
+  expect-throw "OUT_OF_BOUNDS": list.insert --at=1 "foo"
+  list.insert --at=0 "foo"
   expect-equals 1 list.size
   expect-equals "[foo]" list.stringify
-  expect-throw "OUT_OF_BOUNDS": list.remove-at -1
-  expect-throw "OUT_OF_BOUNDS": list.remove-at 1
-  expect-throw "OUT_OF_BOUNDS": list.insert-at -1 "bar"
-  expect-throw "OUT_OF_BOUNDS": list.insert-at 2 "bar"
-  expect-equals "foo" (list.remove-at 0)
+  expect-throw "OUT_OF_BOUNDS": list.remove --at=-1
+  expect-throw "OUT_OF_BOUNDS": list.remove --at=1
+  expect-throw "OUT_OF_BOUNDS": list.insert --at=-1 "bar"
+  expect-throw "OUT_OF_BOUNDS": list.insert --at=2 "bar"
+  expect-equals "foo" (list.remove --at=0)
   expect-equals 0 list.size
   expect-equals "[]" list.stringify
-  list.insert-at 0 "foo"
-  list.insert-at 0 "bar"
+  list.insert --at=0 "foo"
+  list.insert --at=0 "bar"
   expect-equals "[bar, foo]" list.stringify
-  list.insert-at 2 "baz"
+  list.insert --at=2 "baz"
   expect-equals 3 list.size
   expect-equals "[bar, foo, baz]" list.stringify
-  expect-equals "foo" (list.remove-at 1)
+  expect-equals "foo" (list.remove --at=1)
   expect-equals "[bar, baz]" list.stringify
-  expect-equals "bar" (list.remove-at 0)
+  expect-equals "bar" (list.remove --at=0)
   expect-equals "[baz]" list.stringify
   expect-equals 1 list.size
-  expect-equals "baz" (list.remove-at 0)
+  expect-equals "baz" (list.remove --at=0)
 
   10.repeat: list.add it
   expect-equals "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]" list.stringify
-  expect-equals 7 (list.remove-at 7)
+  expect-equals 7 (list.remove --at=7)
   expect-equals "[0, 1, 2, 3, 4, 5, 6, 8, 9]" list.stringify
-  expect-equals 1 (list.remove-at 1)
+  expect-equals 1 (list.remove --at=1)
   expect-equals "[0, 2, 3, 4, 5, 6, 8, 9]" list.stringify
-  expect-equals 3 (list.remove-at 2)
+  expect-equals 3 (list.remove --at=2)
   expect-equals "[0, 2, 4, 5, 6, 8, 9]" list.stringify
-  expect-equals 6 (list.remove-at 4)
+  expect-equals 6 (list.remove --at=4)
   expect-equals "[0, 2, 4, 5, 8, 9]" list.stringify
-  expect-equals 2 (list.remove-at 1)
+  expect-equals 2 (list.remove --at=1)
   expect-equals "[0, 4, 5, 8, 9]" list.stringify
-  expect-equals 8 (list.remove-at 3)
+  expect-equals 8 (list.remove --at=3)
   expect-equals "[0, 4, 5, 9]" list.stringify
-  expect-equals 4 (list.remove-at 1)
+  expect-equals 4 (list.remove --at=1)
   expect-equals "[0, 5, 9]" list.stringify
-  expect-equals 5 (list.remove-at 1)
+  expect-equals 5 (list.remove --at=1)
   expect-equals "[0, 9]" list.stringify
-  expect-equals 9 (list.remove-at 1)
+  expect-equals 9 (list.remove --at=1)
   expect-equals "[0]" list.stringify
-  expect-equals 0 (list.remove-at 0)
+  expect-equals 0 (list.remove --at=0)
   expect-equals "[]" list.stringify
 
-  10.repeat: list.insert-at list.size it
+  10.repeat: list.insert --at=list.size it
   expect-equals 10 list.size
   expect-equals "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]" list.stringify
-  list.insert-at 1 42
+  list.insert --at=1 42
   expect-equals 11 list.size
   expect-equals "[0, 42, 1, 2, 3, 4, 5, 6, 7, 8, 9]" list.stringify
-  list.insert-at 9 103
+  list.insert --at=9 103
   expect-equals "[0, 42, 1, 2, 3, 4, 5, 6, 7, 103, 8, 9]" list.stringify
-  list.insert-at 8 102
+  list.insert --at=8 102
   expect-equals "[0, 42, 1, 2, 3, 4, 5, 6, 102, 7, 103, 8, 9]" list.stringify
-  list.insert-at (list.size - 1) 99
+  list.insert --at=(list.size - 1) 99
   expect-equals "[0, 42, 1, 2, 3, 4, 5, 6, 102, 7, 103, 8, 99, 9]" list.stringify
-  list.insert-at 2 -1
+  list.insert --at=2 -1
   expect-equals "[0, 42, -1, 1, 2, 3, 4, 5, 6, 102, 7, 103, 8, 99, 9]" list.stringify
 
   expect-equals 0 (list.index-of 0)
@@ -180,8 +180,8 @@ test-at list:
     expect-equals 0 it
     42
   expect-equals 42 r
-  expect-equals 0 (list.remove-at 0)
-  expect-equals 1 (list.remove-at 0)
+  expect-equals 0 (list.remove --at=0)
+  expect-equals 1 (list.remove --at=0)
   r = list.index-of --binary 10 --if-absent=:
     expect-equals 8 it
     42

--- a/tests/deque-test.toit
+++ b/tests/deque-test.toit
@@ -97,20 +97,20 @@ test-deque:
 test-at list:
   expect-equals 0 list.size
   expect-equals "[]" list.stringify
-  expect-throws "OUT_OF_BOUNDS": list[0]
-  expect-throws "OUT_OF_BOUNDS": list.remove-last
-  expect-throws "OUT_OF_BOUNDS": list.remove-at 0
-  expect-throws "OUT_OF_BOUNDS": list.remove-at -1
-  expect-throws "OUT_OF_BOUNDS": list.remove-at 1
-  expect-throws "OUT_OF_BOUNDS": list.insert-at -1 "foo"
-  expect-throws "OUT_OF_BOUNDS": list.insert-at 1 "foo"
+  expect-throw "OUT_OF_BOUNDS": list[0]
+  expect-throw "OUT_OF_BOUNDS": list.remove-last
+  expect-throw "OUT_OF_BOUNDS": list.remove-at 0
+  expect-throw "OUT_OF_BOUNDS": list.remove-at -1
+  expect-throw "OUT_OF_BOUNDS": list.remove-at 1
+  expect-throw "OUT_OF_BOUNDS": list.insert-at -1 "foo"
+  expect-throw "OUT_OF_BOUNDS": list.insert-at 1 "foo"
   list.insert-at 0 "foo"
   expect-equals 1 list.size
   expect-equals "[foo]" list.stringify
-  expect-throws "OUT_OF_BOUNDS": list.remove-at -1
-  expect-throws "OUT_OF_BOUNDS": list.remove-at 1
-  expect-throws "OUT_OF_BOUNDS": list.insert-at -1 "bar"
-  expect-throws "OUT_OF_BOUNDS": list.insert-at 2 "bar"
+  expect-throw "OUT_OF_BOUNDS": list.remove-at -1
+  expect-throw "OUT_OF_BOUNDS": list.remove-at 1
+  expect-throw "OUT_OF_BOUNDS": list.insert-at -1 "bar"
+  expect-throw "OUT_OF_BOUNDS": list.insert-at 2 "bar"
   expect-equals "foo" (list.remove-at 0)
   expect-equals 0 list.size
   expect-equals "[]" list.stringify
@@ -211,8 +211,3 @@ test-copy:
   d2.remove-first
   expect-equals "[1, 42]" d.stringify
   expect-equals "[103, 3]" d2.stringify
-
-expect-throws name [code]:
-  expect-equals
-    name
-    catch code

--- a/tests/type_propagation/gold/deltablue-test.gold
+++ b/tests/type_propagation/gold/deltablue-test.gold
@@ -998,37 +998,37 @@ Planner.make-plan tests/type_propagation/deltablue-test.toit
   8[053] - invoke static Plan tests/type_propagation/deltablue-test.toit // [{Plan}] -> {Plan}
  11[018] - load local 4
  12[014] - load local 0
- 13[053] - invoke static CollectionBase.is-empty <sdk>/core/collections.toit // [{List_}] -> {True_|False_}
- 16[082] - branch if true T79
- 19[014] - load local 0
- 20[058] - invoke virtual remove-last // [{List_}] -> {*}
- 24[014] - load local 0
- 25[058] - invoke virtual output // [{*}] -> {Null_|Variable}
- 29[060] - invoke virtual get mark // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
- 32[018] - load local 4
- 33[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
- 34[082] - branch if true T73
- 37[014] - load local 0
- 38[018] - load local 4
- 39[058] - invoke virtual inputs-known // [{*}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
- 43[083] - branch if false T73
- 46[016] - load local 2
- 47[015] - load local 1
- 48[053] - invoke static Plan.add-constraint tests/type_propagation/deltablue-test.toit // [{Plan}, {*}] -> {Null_}
- 51[002] - pop, load local S0
- 53[058] - invoke virtual output // [{*}] -> {Null_|Variable}
- 57[018] - load local 4
- 58[061] - invoke virtual set mark // [{Null_|Variable}, {LargeInteger_|SmallInteger_}] -> {LargeInteger_|SmallInteger_}
- 61[002] - pop, load local S7
- 63[015] - load local 1
- 64[058] - invoke virtual output // [{*}] -> {Null_|Variable}
- 68[017] - load local 3
- 69[053] - invoke static Planner.add-constraints-consuming-to tests/type_propagation/deltablue-test.toit // [{Planner}, {Null_|Variable}, {List_}] -> {Null_}
- 72[041] - pop 1
+ 13[058] - invoke virtual is-empty // [{List_}] -> {True_|False_}
+ 17[082] - branch if true T80
+ 20[014] - load local 0
+ 21[058] - invoke virtual remove-last // [{List_}] -> {*}
+ 25[014] - load local 0
+ 26[058] - invoke virtual output // [{*}] -> {Null_|Variable}
+ 30[060] - invoke virtual get mark // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
+ 33[018] - load local 4
+ 34[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
+ 35[082] - branch if true T74
+ 38[014] - load local 0
+ 39[018] - load local 4
+ 40[058] - invoke virtual inputs-known // [{*}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
+ 44[083] - branch if false T74
+ 47[016] - load local 2
+ 48[015] - load local 1
+ 49[053] - invoke static Plan.add-constraint tests/type_propagation/deltablue-test.toit // [{Plan}, {*}] -> {Null_}
+ 52[002] - pop, load local S0
+ 54[058] - invoke virtual output // [{*}] -> {Null_|Variable}
+ 58[018] - load local 4
+ 59[061] - invoke virtual set mark // [{Null_|Variable}, {LargeInteger_|SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+ 62[002] - pop, load local S7
+ 64[015] - load local 1
+ 65[058] - invoke virtual output // [{*}] -> {Null_|Variable}
+ 69[017] - load local 3
+ 70[053] - invoke static Planner.add-constraints-consuming-to tests/type_propagation/deltablue-test.toit // [{Planner}, {Null_|Variable}, {List_}] -> {Null_}
  73[041] - pop 1
- 74[084] - branch back T12
- 79[015] - load local 1
- 80[089] - return S4 2
+ 74[041] - pop 1
+ 75[084] - branch back T12
+ 80[015] - load local 1
+ 81[089] - return S4 2
 
 Planner.extract-plan-from-constraints tests/type_propagation/deltablue-test.toit
  - argument 0: {Planner}
@@ -1056,15 +1056,15 @@ Planner.extract-plan-from-constraints tests/type_propagation/deltablue-test.toit
   0[022] - load null
   1[017] - load local 3
   2[058] - invoke virtual is-input // [{*}] -> {True_|False_}
-  6[083] - branch if false T24
+  6[083] - branch if false T25
   9[017] - load local 3
  10[060] - invoke virtual get is-satisfied // [{*}] -> {Null_|True_|False_}
- 13[083] - branch if false T24
+ 13[083] - branch if false T25
  16[002] - pop, load local S3
  18[005] - load outer S1 // {List_}
  20[017] - load local 3
- 21[053] - invoke static List.add <sdk>/core/collections.toit // [{List_}, {*}] -> {Null_}
- 24[089] - return S1 2
+ 21[058] - invoke virtual add // [{List_}, {*}] -> {Null_}
+ 25[089] - return S1 2
 
 Planner.add-propagate tests/type_propagation/deltablue-test.toit
  - argument 0: {Planner}
@@ -1076,35 +1076,35 @@ Planner.add-propagate tests/type_propagation/deltablue-test.toit
   5[053] - invoke static create-array_ <sdk>/core/collections.toit // [{EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {LargeArray_|SmallArray_}
   8[053] - invoke static create-list-literal-from-array_ <sdk>/core/collections.toit // [{LargeArray_|SmallArray_}] -> {List_}
  11[014] - load local 0
- 12[053] - invoke static CollectionBase.is-empty <sdk>/core/collections.toit // [{List_}] -> {True_|False_}
- 15[082] - branch if true T74
- 18[014] - load local 0
- 19[058] - invoke virtual remove-last // [{List_}] -> {*}
- 23[014] - load local 0
- 24[058] - invoke virtual output // [{*}] -> {Null_|Variable}
- 28[060] - invoke virtual get mark // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
- 31[019] - load local 5
- 32[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
- 33[083] - branch if false T51
- 36[000] - load local S6
- 38[000] - load local S6
- 40[053] - invoke static Planner.incremental-remove tests/type_propagation/deltablue-test.toit // [{Planner}, {EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {Null_}
- 43[041] - pop 1
- 44[020] - load literal false
- 46[048] - as class True_(21 - 23) // {True_}
- 48[089] - return S3 3
- 51[014] - load local 0
- 52[058] - invoke virtual recalculate // [{*}] -> {Null_}
- 56[002] - pop, load local S6
- 58[015] - load local 1
- 59[058] - invoke virtual output // [{*}] -> {Null_|Variable}
- 63[017] - load local 3
- 64[053] - invoke static Planner.add-constraints-consuming-to tests/type_propagation/deltablue-test.toit // [{Planner}, {Null_|Variable}, {List_}] -> {Null_}
- 67[040] - pop 2
- 69[084] - branch back T11
- 74[020] - load literal true
- 76[048] - as class True_(21 - 23) // {True_}
- 78[089] - return S2 3
+ 12[058] - invoke virtual is-empty // [{List_}] -> {True_|False_}
+ 16[082] - branch if true T75
+ 19[014] - load local 0
+ 20[058] - invoke virtual remove-last // [{List_}] -> {*}
+ 24[014] - load local 0
+ 25[058] - invoke virtual output // [{*}] -> {Null_|Variable}
+ 29[060] - invoke virtual get mark // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
+ 32[019] - load local 5
+ 33[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
+ 34[083] - branch if false T52
+ 37[000] - load local S6
+ 39[000] - load local S6
+ 41[053] - invoke static Planner.incremental-remove tests/type_propagation/deltablue-test.toit // [{Planner}, {EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {Null_}
+ 44[041] - pop 1
+ 45[020] - load literal false
+ 47[048] - as class True_(21 - 23) // {True_}
+ 49[089] - return S3 3
+ 52[014] - load local 0
+ 53[058] - invoke virtual recalculate // [{*}] -> {Null_}
+ 57[002] - pop, load local S6
+ 59[015] - load local 1
+ 60[058] - invoke virtual output // [{*}] -> {Null_|Variable}
+ 64[017] - load local 3
+ 65[053] - invoke static Planner.add-constraints-consuming-to tests/type_propagation/deltablue-test.toit // [{Planner}, {Null_|Variable}, {List_}] -> {Null_}
+ 68[040] - pop 2
+ 70[084] - branch back T11
+ 75[020] - load literal true
+ 77[048] - as class True_(21 - 23) // {True_}
+ 79[089] - return S2 3
 
 Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
  - argument 0: {Planner}
@@ -1129,27 +1129,27 @@ Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
  28[053] - invoke static create-array_ <sdk>/core/collections.toit // [{Variable}] -> {LargeArray_|SmallArray_}
  31[053] - invoke static create-list-literal-from-array_ <sdk>/core/collections.toit // [{LargeArray_|SmallArray_}] -> {List_}
  34[014] - load local 0
- 35[053] - invoke static CollectionBase.is-empty <sdk>/core/collections.toit // [{List_}] -> {True_|False_}
- 38[082] - branch if true T89
- 41[014] - load local 0
- 42[058] - invoke virtual remove-last // [{List_}] -> {*}
- 46[029] - load method [block] in Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
- 51[015] - load local 1
- 52[060] - invoke virtual get constraints // [{*}] -> {Null_|List_}
- 55[038] - load block 1
- 57[058] - invoke virtual do // [{Null_|List_}, [block]] -> {Null_}
- 61[041] - pop 1
- 62[002] - pop, load local S0
- 64[060] - invoke virtual get determined-by // [{*}] -> {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}
- 67[029] - load method [block] in Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
- 72[016] - load local 2
- 73[060] - invoke virtual get constraints // [{*}] -> {Null_|List_}
- 76[038] - load block 1
- 78[058] - invoke virtual do // [{Null_|List_}, [block]] -> {Null_}
- 82[040] - pop 4
- 84[084] - branch back T34
- 89[015] - load local 1
- 90[089] - return S3 2
+ 35[058] - invoke virtual is-empty // [{List_}] -> {True_|False_}
+ 39[082] - branch if true T90
+ 42[014] - load local 0
+ 43[058] - invoke virtual remove-last // [{List_}] -> {*}
+ 47[029] - load method [block] in Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
+ 52[015] - load local 1
+ 53[060] - invoke virtual get constraints // [{*}] -> {Null_|List_}
+ 56[038] - load block 1
+ 58[058] - invoke virtual do // [{Null_|List_}, [block]] -> {Null_}
+ 62[041] - pop 1
+ 63[002] - pop, load local S0
+ 65[060] - invoke virtual get determined-by // [{*}] -> {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}
+ 68[029] - load method [block] in Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
+ 73[016] - load local 2
+ 74[060] - invoke virtual get constraints // [{*}] -> {Null_|List_}
+ 77[038] - load block 1
+ 79[058] - invoke virtual do // [{Null_|List_}, [block]] -> {Null_}
+ 83[040] - pop 4
+ 85[084] - branch back T34
+ 90[015] - load local 1
+ 91[089] - return S3 2
 
 [block] in Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
  - argument 0: [block]
@@ -1157,12 +1157,12 @@ Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
   0[022] - load null
   1[017] - load local 3
   2[060] - invoke virtual get is-satisfied // [{*}] -> {Null_|True_|False_}
-  5[082] - branch if true T16
+  5[082] - branch if true T17
   8[002] - pop, load local S3
  10[005] - load outer S3 // {List_}
  12[017] - load local 3
- 13[053] - invoke static List.add <sdk>/core/collections.toit // [{List_}, {*}] -> {Null_}
- 16[089] - return S1 2
+ 13[058] - invoke virtual add // [{List_}, {*}] -> {Null_}
+ 17[089] - return S1 2
 
 [block] in Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
  - argument 0: [block]
@@ -1172,18 +1172,18 @@ Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
   2[019] - load local 5
   3[005] - load outer S1 // {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}
   5[062] - invoke eq // [{*}, {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {True_|False_}
-  6[082] - branch if true T34
+  6[082] - branch if true T35
   9[017] - load local 3
  10[060] - invoke virtual get is-satisfied // [{*}] -> {Null_|True_|False_}
- 13[083] - branch if false T34
+ 13[083] - branch if false T35
  16[002] - pop, load local S2
  18[058] - invoke virtual recalculate // [{*}] -> {Null_}
  22[002] - pop, load local S3
  24[005] - load outer S3 // {List_}
  26[017] - load local 3
  27[058] - invoke virtual output // [{*}] -> {Null_|Variable}
- 31[053] - invoke static List.add <sdk>/core/collections.toit // [{List_}, {Null_|Variable}] -> {Null_}
- 34[089] - return S1 2
+ 31[058] - invoke virtual add // [{List_}, {Null_|Variable}] -> {Null_}
+ 35[089] - return S1 2
 
 Planner.add-constraints-consuming-to tests/type_propagation/deltablue-test.toit
  - argument 0: {Planner}
@@ -1206,15 +1206,15 @@ Planner.add-constraints-consuming-to tests/type_propagation/deltablue-test.toit
   2[019] - load local 5
   3[005] - load outer S1 // {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}
   5[062] - invoke eq // [{*}, {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {True_|False_}
-  6[082] - branch if true T24
+  6[082] - branch if true T25
   9[017] - load local 3
  10[060] - invoke virtual get is-satisfied // [{*}] -> {Null_|True_|False_}
- 13[083] - branch if false T24
+ 13[083] - branch if false T25
  16[002] - pop, load local S3
  18[005] - load outer S4 // {List_}
  20[017] - load local 3
- 21[053] - invoke static List.add <sdk>/core/collections.toit // [{List_}, {*}] -> {Null_}
- 24[089] - return S1 2
+ 21[058] - invoke virtual add // [{List_}, {*}] -> {Null_}
+ 25[089] - return S1 2
 
 Plan tests/type_propagation/deltablue-test.toit
  - argument 0: {Plan}
@@ -1235,8 +1235,8 @@ Plan.add-constraint tests/type_propagation/deltablue-test.toit
   0[052] - load local, as class, pop 2 - EqualityConstraint(47 - 51) // {True_|False_}
   2[009] - load field local 3 // [{Plan}] -> {Null_|List_}
   4[017] - load local 3
-  5[053] - invoke static List.add <sdk>/core/collections.toit // [{Null_|List_}, {EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {Null_}
-  8[090] - return null S1 2
+  5[058] - invoke virtual add // [{Null_|List_}, {EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {Null_}
+  9[090] - return null S1 2
 
 Plan.execute tests/type_propagation/deltablue-test.toit
  - argument 0: {Plan}
@@ -1401,7 +1401,7 @@ projection-test tests/type_propagation/deltablue-test.toit
  43[014] - load local 0
  44[000] - load local S9
  46[063] - invoke lt // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
- 47[083] - branch if false T127
+ 47[083] - branch if false T128
  50[042] - allocate instance Variable
  52[020] - load literal src
  54[016] - load local 2
@@ -1422,115 +1422,115 @@ projection-test tests/type_propagation/deltablue-test.toit
  84[004] - store local, pop S3
  86[015] - load local 1
  87[017] - load local 3
- 88[053] - invoke static List.add <sdk>/core/collections.toit // [{List_}, {Variable}] -> {Null_}
- 91[041] - pop 1
- 92[042] - allocate instance StayConstraint
- 94[032] - load global var lazy G4 // {Strength}
- 96[019] - load local 5
- 97[053] - invoke static StayConstraint tests/type_propagation/deltablue-test.toit // [{StayConstraint}, {Strength}, {Variable}] -> {StayConstraint}
-100[041] - pop 1
-101[042] - allocate instance ScaleConstraint
-103[032] - load global var lazy G0 // {Strength}
-105[019] - load local 5
+ 88[058] - invoke virtual add // [{List_}, {Variable}] -> {Null_}
+ 92[041] - pop 1
+ 93[042] - allocate instance StayConstraint
+ 95[032] - load global var lazy G4 // {Strength}
+ 97[019] - load local 5
+ 98[053] - invoke static StayConstraint tests/type_propagation/deltablue-test.toit // [{StayConstraint}, {Strength}, {Variable}] -> {StayConstraint}
+101[041] - pop 1
+102[042] - allocate instance ScaleConstraint
+104[032] - load global var lazy G0 // {Strength}
 106[019] - load local 5
-107[000] - load local S9
-109[000] - load local S9
-111[053] - invoke static ScaleConstraint tests/type_propagation/deltablue-test.toit // [{ScaleConstraint}, {Strength}, {Variable}, {Variable}, {Variable}, {Variable}] -> {ScaleConstraint}
-114[041] - pop 1
-115[014] - load local 0
+107[019] - load local 5
+108[000] - load local S9
+110[000] - load local S9
+112[053] - invoke static ScaleConstraint tests/type_propagation/deltablue-test.toit // [{ScaleConstraint}, {Strength}, {Variable}, {Variable}, {Variable}, {Variable}] -> {ScaleConstraint}
+115[041] - pop 1
 116[014] - load local 0
-117[025] - load smi 1
-118[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-119[004] - store local, pop S2
-121[041] - pop 1
-122[084] - branch back T43
-127[002] - pop, load local S2
-129[026] - load smi 17
-131[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Null_|Variable}, {SmallInteger_}] -> {Null_}
-134[002] - pop, load local S1
-136[060] - invoke virtual get value // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
-139[027] - load smi 1170
-142[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
-143[082] - branch if true T152
-146[020] - load literal Projection 1 failed
-148[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
-151[041] - pop 1
-152[015] - load local 1
-153[027] - load smi 1050
-156[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Null_|Variable}, {SmallInteger_}] -> {Null_}
-159[002] - pop, load local S2
-161[060] - invoke virtual get value // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
-164[026] - load smi 5
-166[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
-167[082] - branch if true T176
-170[020] - load literal Projection 2 failed
-172[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
-175[041] - pop 1
-176[018] - load local 4
-177[026] - load smi 5
-179[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Variable}, {SmallInteger_}] -> {Null_}
-182[041] - pop 1
-183[023] - load smi 0
-184[014] - load local 0
-185[000] - load local S9
-187[025] - load smi 1
-188[074] - invoke sub // [{SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-189[063] - invoke lt // [{LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
-190[083] - branch if false T229
-193[015] - load local 1
+117[014] - load local 0
+118[025] - load smi 1
+119[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+120[004] - store local, pop S2
+122[041] - pop 1
+123[084] - branch back T43
+128[002] - pop, load local S2
+130[026] - load smi 17
+132[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Null_|Variable}, {SmallInteger_}] -> {Null_}
+135[002] - pop, load local S1
+137[060] - invoke virtual get value // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
+140[027] - load smi 1170
+143[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
+144[082] - branch if true T153
+147[020] - load literal Projection 1 failed
+149[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
+152[041] - pop 1
+153[015] - load local 1
+154[027] - load smi 1050
+157[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Null_|Variable}, {SmallInteger_}] -> {Null_}
+160[002] - pop, load local S2
+162[060] - invoke virtual get value // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
+165[026] - load smi 5
+167[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
+168[082] - branch if true T177
+171[020] - load literal Projection 2 failed
+173[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
+176[041] - pop 1
+177[018] - load local 4
+178[026] - load smi 5
+180[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Variable}, {SmallInteger_}] -> {Null_}
+183[041] - pop 1
+184[023] - load smi 0
+185[014] - load local 0
+186[000] - load local S9
+188[025] - load smi 1
+189[074] - invoke sub // [{SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+190[063] - invoke lt // [{LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
+191[083] - branch if false T230
 194[015] - load local 1
-195[078] - invoke at // [{List_}, {LargeInteger_|SmallInteger_}] -> {*}
-196[060] - invoke virtual get value // [{*}] -> {*}
-199[015] - load local 1
-200[026] - load smi 5
-202[075] - invoke mul // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-203[027] - load smi 1000
-206[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-207[062] - invoke eq // [{*}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
-208[082] - branch if true T217
-211[020] - load literal Projection 3 failed
-213[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
-216[041] - pop 1
-217[014] - load local 0
+195[015] - load local 1
+196[078] - invoke at // [{List_}, {LargeInteger_|SmallInteger_}] -> {*}
+197[060] - invoke virtual get value // [{*}] -> {*}
+200[015] - load local 1
+201[026] - load smi 5
+203[075] - invoke mul // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+204[027] - load smi 1000
+207[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+208[062] - invoke eq // [{*}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
+209[082] - branch if true T218
+212[020] - load literal Projection 3 failed
+214[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
+217[041] - pop 1
 218[014] - load local 0
-219[025] - load smi 1
-220[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-221[004] - store local, pop S2
-223[041] - pop 1
-224[084] - branch back T184
-229[002] - pop, load local S3
-231[027] - load smi 2000
-234[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Variable}, {SmallInteger_}] -> {Null_}
-237[041] - pop 1
-238[023] - load smi 0
-239[014] - load local 0
-240[000] - load local S9
-242[025] - load smi 1
-243[074] - invoke sub // [{SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-244[063] - invoke lt // [{LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
-245[083] - branch if false T284
-248[015] - load local 1
+219[014] - load local 0
+220[025] - load smi 1
+221[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+222[004] - store local, pop S2
+224[041] - pop 1
+225[084] - branch back T185
+230[002] - pop, load local S3
+232[027] - load smi 2000
+235[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Variable}, {SmallInteger_}] -> {Null_}
+238[041] - pop 1
+239[023] - load smi 0
+240[014] - load local 0
+241[000] - load local S9
+243[025] - load smi 1
+244[074] - invoke sub // [{SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+245[063] - invoke lt // [{LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
+246[083] - branch if false T285
 249[015] - load local 1
-250[078] - invoke at // [{List_}, {LargeInteger_|SmallInteger_}] -> {*}
-251[060] - invoke virtual get value // [{*}] -> {*}
-254[015] - load local 1
-255[026] - load smi 5
-257[075] - invoke mul // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-258[027] - load smi 2000
-261[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-262[062] - invoke eq // [{*}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
-263[082] - branch if true T272
-266[020] - load literal Projection 4 failed
-268[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
-271[041] - pop 1
-272[014] - load local 0
+250[015] - load local 1
+251[078] - invoke at // [{List_}, {LargeInteger_|SmallInteger_}] -> {*}
+252[060] - invoke virtual get value // [{*}] -> {*}
+255[015] - load local 1
+256[026] - load smi 5
+258[075] - invoke mul // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+259[027] - load smi 2000
+262[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+263[062] - invoke eq // [{*}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
+264[082] - branch if true T273
+267[020] - load literal Projection 4 failed
+269[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
+272[041] - pop 1
 273[014] - load local 0
-274[025] - load smi 1
-275[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-276[004] - store local, pop S2
-278[041] - pop 1
-279[084] - branch back T239
-284[090] - return null S6 1
+274[014] - load local 0
+275[025] - load smi 1
+276[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+277[004] - store local, pop S2
+279[041] - pop 1
+280[084] - branch back T240
+285[090] - return null S6 1
 
 change tests/type_propagation/deltablue-test.toit
  - argument 0: {Null_|Variable}

--- a/tests/type_propagation/gold/deltablue-test.gold-O2
+++ b/tests/type_propagation/gold/deltablue-test.gold-O2
@@ -935,37 +935,37 @@ Planner.make-plan tests/type_propagation/deltablue-test.toit
   6[053] - invoke static Plan tests/type_propagation/deltablue-test.toit // [{Plan}] -> {Plan}
   9[018] - load local 4
  10[014] - load local 0
- 11[053] - invoke static CollectionBase.is-empty <sdk>/core/collections.toit // [{List_}] -> {True_|False_}
- 14[082] - branch if true T77
- 17[014] - load local 0
- 18[058] - invoke virtual remove-last // [{List_}] -> {*}
- 22[014] - load local 0
- 23[058] - invoke virtual output // [{*}] -> {Null_|Variable}
- 27[060] - invoke virtual get mark // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
- 30[018] - load local 4
- 31[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
- 32[082] - branch if true T71
- 35[014] - load local 0
- 36[018] - load local 4
- 37[058] - invoke virtual inputs-known // [{*}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
- 41[083] - branch if false T71
- 44[016] - load local 2
- 45[015] - load local 1
- 46[053] - invoke static Plan.add-constraint tests/type_propagation/deltablue-test.toit // [{Plan}, {*}] -> {Null_}
- 49[002] - pop, load local S0
- 51[058] - invoke virtual output // [{*}] -> {Null_|Variable}
- 55[018] - load local 4
- 56[061] - invoke virtual set mark // [{Null_|Variable}, {LargeInteger_|SmallInteger_}] -> {LargeInteger_|SmallInteger_}
- 59[002] - pop, load local S7
- 61[015] - load local 1
- 62[058] - invoke virtual output // [{*}] -> {Null_|Variable}
- 66[017] - load local 3
- 67[053] - invoke static Planner.add-constraints-consuming-to tests/type_propagation/deltablue-test.toit // [{Planner}, {Null_|Variable}, {List_}] -> {Null_}
- 70[041] - pop 1
+ 11[058] - invoke virtual is-empty // [{List_}] -> {True_|False_}
+ 15[082] - branch if true T78
+ 18[014] - load local 0
+ 19[058] - invoke virtual remove-last // [{List_}] -> {*}
+ 23[014] - load local 0
+ 24[058] - invoke virtual output // [{*}] -> {Null_|Variable}
+ 28[060] - invoke virtual get mark // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
+ 31[018] - load local 4
+ 32[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
+ 33[082] - branch if true T72
+ 36[014] - load local 0
+ 37[018] - load local 4
+ 38[058] - invoke virtual inputs-known // [{*}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
+ 42[083] - branch if false T72
+ 45[016] - load local 2
+ 46[015] - load local 1
+ 47[053] - invoke static Plan.add-constraint tests/type_propagation/deltablue-test.toit // [{Plan}, {*}] -> {Null_}
+ 50[002] - pop, load local S0
+ 52[058] - invoke virtual output // [{*}] -> {Null_|Variable}
+ 56[018] - load local 4
+ 57[061] - invoke virtual set mark // [{Null_|Variable}, {LargeInteger_|SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+ 60[002] - pop, load local S7
+ 62[015] - load local 1
+ 63[058] - invoke virtual output // [{*}] -> {Null_|Variable}
+ 67[017] - load local 3
+ 68[053] - invoke static Planner.add-constraints-consuming-to tests/type_propagation/deltablue-test.toit // [{Planner}, {Null_|Variable}, {List_}] -> {Null_}
  71[041] - pop 1
- 72[084] - branch back T10
- 77[015] - load local 1
- 78[089] - return S4 2
+ 72[041] - pop 1
+ 73[084] - branch back T10
+ 78[015] - load local 1
+ 79[089] - return S4 2
 
 Planner.extract-plan-from-constraints tests/type_propagation/deltablue-test.toit
  - argument 0: {Planner}
@@ -992,15 +992,15 @@ Planner.extract-plan-from-constraints tests/type_propagation/deltablue-test.toit
   0[022] - load null
   1[017] - load local 3
   2[058] - invoke virtual is-input // [{*}] -> {True_|False_}
-  6[083] - branch if false T24
+  6[083] - branch if false T25
   9[017] - load local 3
  10[060] - invoke virtual get is-satisfied // [{*}] -> {Null_|True_|False_}
- 13[083] - branch if false T24
+ 13[083] - branch if false T25
  16[002] - pop, load local S3
  18[005] - load outer S1 // {List_}
  20[017] - load local 3
- 21[053] - invoke static List.add <sdk>/core/collections.toit // [{List_}, {*}] -> {Null_}
- 24[089] - return S1 2
+ 21[058] - invoke virtual add // [{List_}, {*}] -> {Null_}
+ 25[089] - return S1 2
 
 Planner.add-propagate tests/type_propagation/deltablue-test.toit
  - argument 0: {Planner}
@@ -1010,33 +1010,33 @@ Planner.add-propagate tests/type_propagation/deltablue-test.toit
   1[053] - invoke static create-array_ <sdk>/core/collections.toit // [{EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {LargeArray_|SmallArray_}
   4[053] - invoke static create-list-literal-from-array_ <sdk>/core/collections.toit // [{LargeArray_|SmallArray_}] -> {List_}
   7[014] - load local 0
-  8[053] - invoke static CollectionBase.is-empty <sdk>/core/collections.toit // [{List_}] -> {True_|False_}
- 11[082] - branch if true T68
- 14[014] - load local 0
- 15[058] - invoke virtual remove-last // [{List_}] -> {*}
- 19[014] - load local 0
- 20[058] - invoke virtual output // [{*}] -> {Null_|Variable}
- 24[060] - invoke virtual get mark // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
- 27[019] - load local 5
- 28[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
- 29[083] - branch if false T45
- 32[000] - load local S6
- 34[000] - load local S6
- 36[053] - invoke static Planner.incremental-remove tests/type_propagation/deltablue-test.toit // [{Planner}, {EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {Null_}
- 39[041] - pop 1
- 40[020] - load literal false
- 42[089] - return S3 3
- 45[014] - load local 0
- 46[058] - invoke virtual recalculate // [{*}] -> {Null_}
- 50[002] - pop, load local S6
- 52[015] - load local 1
- 53[058] - invoke virtual output // [{*}] -> {Null_|Variable}
- 57[017] - load local 3
- 58[053] - invoke static Planner.add-constraints-consuming-to tests/type_propagation/deltablue-test.toit // [{Planner}, {Null_|Variable}, {List_}] -> {Null_}
- 61[040] - pop 2
- 63[084] - branch back T7
- 68[020] - load literal true
- 70[089] - return S2 3
+  8[058] - invoke virtual is-empty // [{List_}] -> {True_|False_}
+ 12[082] - branch if true T69
+ 15[014] - load local 0
+ 16[058] - invoke virtual remove-last // [{List_}] -> {*}
+ 20[014] - load local 0
+ 21[058] - invoke virtual output // [{*}] -> {Null_|Variable}
+ 25[060] - invoke virtual get mark // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
+ 28[019] - load local 5
+ 29[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
+ 30[083] - branch if false T46
+ 33[000] - load local S6
+ 35[000] - load local S6
+ 37[053] - invoke static Planner.incremental-remove tests/type_propagation/deltablue-test.toit // [{Planner}, {EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {Null_}
+ 40[041] - pop 1
+ 41[020] - load literal false
+ 43[089] - return S3 3
+ 46[014] - load local 0
+ 47[058] - invoke virtual recalculate // [{*}] -> {Null_}
+ 51[002] - pop, load local S6
+ 53[015] - load local 1
+ 54[058] - invoke virtual output // [{*}] -> {Null_|Variable}
+ 58[017] - load local 3
+ 59[053] - invoke static Planner.add-constraints-consuming-to tests/type_propagation/deltablue-test.toit // [{Planner}, {Null_|Variable}, {List_}] -> {Null_}
+ 62[040] - pop 2
+ 64[084] - branch back T7
+ 69[020] - load literal true
+ 71[089] - return S2 3
 
 Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
  - argument 0: {Planner}
@@ -1061,27 +1061,27 @@ Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
  28[053] - invoke static create-array_ <sdk>/core/collections.toit // [{Variable}] -> {LargeArray_|SmallArray_}
  31[053] - invoke static create-list-literal-from-array_ <sdk>/core/collections.toit // [{LargeArray_|SmallArray_}] -> {List_}
  34[014] - load local 0
- 35[053] - invoke static CollectionBase.is-empty <sdk>/core/collections.toit // [{List_}] -> {True_|False_}
- 38[082] - branch if true T89
- 41[014] - load local 0
- 42[058] - invoke virtual remove-last // [{List_}] -> {*}
- 46[029] - load method [block] in Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
- 51[015] - load local 1
- 52[060] - invoke virtual get constraints // [{*}] -> {Null_|List_}
- 55[038] - load block 1
- 57[058] - invoke virtual do // [{Null_|List_}, [block]] -> {Null_}
- 61[041] - pop 1
- 62[002] - pop, load local S0
- 64[060] - invoke virtual get determined-by // [{*}] -> {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}
- 67[029] - load method [block] in Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
- 72[016] - load local 2
- 73[060] - invoke virtual get constraints // [{*}] -> {Null_|List_}
- 76[038] - load block 1
- 78[058] - invoke virtual do // [{Null_|List_}, [block]] -> {Null_}
- 82[040] - pop 4
- 84[084] - branch back T34
- 89[015] - load local 1
- 90[089] - return S3 2
+ 35[058] - invoke virtual is-empty // [{List_}] -> {True_|False_}
+ 39[082] - branch if true T90
+ 42[014] - load local 0
+ 43[058] - invoke virtual remove-last // [{List_}] -> {*}
+ 47[029] - load method [block] in Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
+ 52[015] - load local 1
+ 53[060] - invoke virtual get constraints // [{*}] -> {Null_|List_}
+ 56[038] - load block 1
+ 58[058] - invoke virtual do // [{Null_|List_}, [block]] -> {Null_}
+ 62[041] - pop 1
+ 63[002] - pop, load local S0
+ 65[060] - invoke virtual get determined-by // [{*}] -> {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}
+ 68[029] - load method [block] in Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
+ 73[016] - load local 2
+ 74[060] - invoke virtual get constraints // [{*}] -> {Null_|List_}
+ 77[038] - load block 1
+ 79[058] - invoke virtual do // [{Null_|List_}, [block]] -> {Null_}
+ 83[040] - pop 4
+ 85[084] - branch back T34
+ 90[015] - load local 1
+ 91[089] - return S3 2
 
 [block] in Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
  - argument 0: [block]
@@ -1089,12 +1089,12 @@ Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
   0[022] - load null
   1[017] - load local 3
   2[060] - invoke virtual get is-satisfied // [{*}] -> {Null_|True_|False_}
-  5[082] - branch if true T16
+  5[082] - branch if true T17
   8[002] - pop, load local S3
  10[005] - load outer S3 // {List_}
  12[017] - load local 3
- 13[053] - invoke static List.add <sdk>/core/collections.toit // [{List_}, {*}] -> {Null_}
- 16[089] - return S1 2
+ 13[058] - invoke virtual add // [{List_}, {*}] -> {Null_}
+ 17[089] - return S1 2
 
 [block] in Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
  - argument 0: [block]
@@ -1104,18 +1104,18 @@ Planner.remove-propagate-from tests/type_propagation/deltablue-test.toit
   2[019] - load local 5
   3[005] - load outer S1 // {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}
   5[062] - invoke eq // [{*}, {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {True_|False_}
-  6[082] - branch if true T34
+  6[082] - branch if true T35
   9[017] - load local 3
  10[060] - invoke virtual get is-satisfied // [{*}] -> {Null_|True_|False_}
- 13[083] - branch if false T34
+ 13[083] - branch if false T35
  16[002] - pop, load local S2
  18[058] - invoke virtual recalculate // [{*}] -> {Null_}
  22[002] - pop, load local S3
  24[005] - load outer S3 // {List_}
  26[017] - load local 3
  27[058] - invoke virtual output // [{*}] -> {Null_|Variable}
- 31[053] - invoke static List.add <sdk>/core/collections.toit // [{List_}, {Null_|Variable}] -> {Null_}
- 34[089] - return S1 2
+ 31[058] - invoke virtual add // [{List_}, {Null_|Variable}] -> {Null_}
+ 35[089] - return S1 2
 
 Planner.add-constraints-consuming-to tests/type_propagation/deltablue-test.toit
  - argument 0: {Planner}
@@ -1137,15 +1137,15 @@ Planner.add-constraints-consuming-to tests/type_propagation/deltablue-test.toit
   2[019] - load local 5
   3[005] - load outer S1 // {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}
   5[062] - invoke eq // [{*}, {Null_|EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {True_|False_}
-  6[082] - branch if true T24
+  6[082] - branch if true T25
   9[017] - load local 3
  10[060] - invoke virtual get is-satisfied // [{*}] -> {Null_|True_|False_}
- 13[083] - branch if false T24
+ 13[083] - branch if false T25
  16[002] - pop, load local S3
  18[005] - load outer S4 // {List_}
  20[017] - load local 3
- 21[053] - invoke static List.add <sdk>/core/collections.toit // [{List_}, {*}] -> {Null_}
- 24[089] - return S1 2
+ 21[058] - invoke virtual add // [{List_}, {*}] -> {Null_}
+ 25[089] - return S1 2
 
 Plan tests/type_propagation/deltablue-test.toit
  - argument 0: {Plan}
@@ -1166,8 +1166,8 @@ Plan.add-constraint tests/type_propagation/deltablue-test.toit
   0[052] - load local, as class, pop 2 - EqualityConstraint(42 - 46) // {True_|False_}
   2[009] - load field local 3 // [{Plan}] -> {Null_|List_}
   4[017] - load local 3
-  5[053] - invoke static List.add <sdk>/core/collections.toit // [{Null_|List_}, {EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {Null_}
-  8[090] - return null S1 2
+  5[058] - invoke virtual add // [{Null_|List_}, {EqualityConstraint|ScaleConstraint|EditConstraint|StayConstraint}] -> {Null_}
+  9[090] - return null S1 2
 
 Plan.execute tests/type_propagation/deltablue-test.toit
  - argument 0: {Plan}
@@ -1329,7 +1329,7 @@ projection-test tests/type_propagation/deltablue-test.toit
  41[014] - load local 0
  42[000] - load local S9
  44[063] - invoke lt // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
- 45[083] - branch if false T121
+ 45[083] - branch if false T122
  48[042] - allocate instance Variable
  50[020] - load literal src
  52[016] - load local 2
@@ -1348,115 +1348,115 @@ projection-test tests/type_propagation/deltablue-test.toit
  78[004] - store local, pop S3
  80[015] - load local 1
  81[017] - load local 3
- 82[053] - invoke static List.add <sdk>/core/collections.toit // [{List_}, {Variable}] -> {Null_}
- 85[041] - pop 1
- 86[042] - allocate instance StayConstraint
- 88[032] - load global var lazy G4 // {Strength}
- 90[019] - load local 5
- 91[053] - invoke static StayConstraint tests/type_propagation/deltablue-test.toit // [{StayConstraint}, {Strength}, {Variable}] -> {StayConstraint}
- 94[041] - pop 1
- 95[042] - allocate instance ScaleConstraint
- 97[032] - load global var lazy G0 // {Strength}
- 99[019] - load local 5
+ 82[058] - invoke virtual add // [{List_}, {Variable}] -> {Null_}
+ 86[041] - pop 1
+ 87[042] - allocate instance StayConstraint
+ 89[032] - load global var lazy G4 // {Strength}
+ 91[019] - load local 5
+ 92[053] - invoke static StayConstraint tests/type_propagation/deltablue-test.toit // [{StayConstraint}, {Strength}, {Variable}] -> {StayConstraint}
+ 95[041] - pop 1
+ 96[042] - allocate instance ScaleConstraint
+ 98[032] - load global var lazy G0 // {Strength}
 100[019] - load local 5
-101[000] - load local S9
-103[000] - load local S9
-105[053] - invoke static ScaleConstraint tests/type_propagation/deltablue-test.toit // [{ScaleConstraint}, {Strength}, {Variable}, {Variable}, {Variable}, {Variable}] -> {ScaleConstraint}
-108[041] - pop 1
-109[014] - load local 0
+101[019] - load local 5
+102[000] - load local S9
+104[000] - load local S9
+106[053] - invoke static ScaleConstraint tests/type_propagation/deltablue-test.toit // [{ScaleConstraint}, {Strength}, {Variable}, {Variable}, {Variable}, {Variable}] -> {ScaleConstraint}
+109[041] - pop 1
 110[014] - load local 0
-111[025] - load smi 1
-112[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-113[004] - store local, pop S2
-115[041] - pop 1
-116[084] - branch back T41
-121[002] - pop, load local S2
-123[026] - load smi 17
-125[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Null_|Variable}, {SmallInteger_}] -> {Null_}
-128[002] - pop, load local S1
-130[060] - invoke virtual get value // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
-133[027] - load smi 1170
-136[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
-137[082] - branch if true T146
-140[020] - load literal Projection 1 failed
-142[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
-145[041] - pop 1
-146[015] - load local 1
-147[027] - load smi 1050
-150[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Null_|Variable}, {SmallInteger_}] -> {Null_}
-153[002] - pop, load local S2
-155[060] - invoke virtual get value // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
-158[026] - load smi 5
-160[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
-161[082] - branch if true T170
-164[020] - load literal Projection 2 failed
-166[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
-169[041] - pop 1
-170[018] - load local 4
-171[026] - load smi 5
-173[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Variable}, {SmallInteger_}] -> {Null_}
-176[041] - pop 1
-177[023] - load smi 0
-178[014] - load local 0
-179[000] - load local S9
-181[025] - load smi 1
-182[074] - invoke sub // [{SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-183[063] - invoke lt // [{LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
-184[083] - branch if false T223
-187[015] - load local 1
+111[014] - load local 0
+112[025] - load smi 1
+113[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+114[004] - store local, pop S2
+116[041] - pop 1
+117[084] - branch back T41
+122[002] - pop, load local S2
+124[026] - load smi 17
+126[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Null_|Variable}, {SmallInteger_}] -> {Null_}
+129[002] - pop, load local S1
+131[060] - invoke virtual get value // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
+134[027] - load smi 1170
+137[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
+138[082] - branch if true T147
+141[020] - load literal Projection 1 failed
+143[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
+146[041] - pop 1
+147[015] - load local 1
+148[027] - load smi 1050
+151[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Null_|Variable}, {SmallInteger_}] -> {Null_}
+154[002] - pop, load local S2
+156[060] - invoke virtual get value // [{Null_|Variable}] -> {Null_|LargeInteger_|SmallInteger_}
+159[026] - load smi 5
+161[062] - invoke eq // [{Null_|LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
+162[082] - branch if true T171
+165[020] - load literal Projection 2 failed
+167[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
+170[041] - pop 1
+171[018] - load local 4
+172[026] - load smi 5
+174[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Variable}, {SmallInteger_}] -> {Null_}
+177[041] - pop 1
+178[023] - load smi 0
+179[014] - load local 0
+180[000] - load local S9
+182[025] - load smi 1
+183[074] - invoke sub // [{SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+184[063] - invoke lt // [{LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
+185[083] - branch if false T224
 188[015] - load local 1
-189[078] - invoke at // [{List_}, {LargeInteger_|SmallInteger_}] -> {*}
-190[060] - invoke virtual get value // [{*}] -> {*}
-193[015] - load local 1
-194[026] - load smi 5
-196[075] - invoke mul // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-197[027] - load smi 1000
-200[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-201[062] - invoke eq // [{*}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
-202[082] - branch if true T211
-205[020] - load literal Projection 3 failed
-207[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
-210[041] - pop 1
-211[014] - load local 0
+189[015] - load local 1
+190[078] - invoke at // [{List_}, {LargeInteger_|SmallInteger_}] -> {*}
+191[060] - invoke virtual get value // [{*}] -> {*}
+194[015] - load local 1
+195[026] - load smi 5
+197[075] - invoke mul // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+198[027] - load smi 1000
+201[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+202[062] - invoke eq // [{*}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
+203[082] - branch if true T212
+206[020] - load literal Projection 3 failed
+208[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
+211[041] - pop 1
 212[014] - load local 0
-213[025] - load smi 1
-214[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-215[004] - store local, pop S2
-217[041] - pop 1
-218[084] - branch back T178
-223[002] - pop, load local S3
-225[027] - load smi 2000
-228[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Variable}, {SmallInteger_}] -> {Null_}
-231[041] - pop 1
-232[023] - load smi 0
-233[014] - load local 0
-234[000] - load local S9
-236[025] - load smi 1
-237[074] - invoke sub // [{SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-238[063] - invoke lt // [{LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
-239[083] - branch if false T278
-242[015] - load local 1
+213[014] - load local 0
+214[025] - load smi 1
+215[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+216[004] - store local, pop S2
+218[041] - pop 1
+219[084] - branch back T179
+224[002] - pop, load local S3
+226[027] - load smi 2000
+229[053] - invoke static change tests/type_propagation/deltablue-test.toit // [{Variable}, {SmallInteger_}] -> {Null_}
+232[041] - pop 1
+233[023] - load smi 0
+234[014] - load local 0
+235[000] - load local S9
+237[025] - load smi 1
+238[074] - invoke sub // [{SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+239[063] - invoke lt // [{LargeInteger_|SmallInteger_}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
+240[083] - branch if false T279
 243[015] - load local 1
-244[078] - invoke at // [{List_}, {LargeInteger_|SmallInteger_}] -> {*}
-245[060] - invoke virtual get value // [{*}] -> {*}
-248[015] - load local 1
-249[026] - load smi 5
-251[075] - invoke mul // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-252[027] - load smi 2000
-255[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-256[062] - invoke eq // [{*}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
-257[082] - branch if true T266
-260[020] - load literal Projection 4 failed
-262[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
-265[041] - pop 1
-266[014] - load local 0
+244[015] - load local 1
+245[078] - invoke at // [{List_}, {LargeInteger_|SmallInteger_}] -> {*}
+246[060] - invoke virtual get value // [{*}] -> {*}
+249[015] - load local 1
+250[026] - load smi 5
+252[075] - invoke mul // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+253[027] - load smi 2000
+256[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+257[062] - invoke eq // [{*}, {LargeInteger_|SmallInteger_}] -> {True_|False_}
+258[082] - branch if true T267
+261[020] - load literal Projection 4 failed
+263[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
+266[041] - pop 1
 267[014] - load local 0
-268[025] - load smi 1
-269[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
-270[004] - store local, pop S2
-272[041] - pop 1
-273[084] - branch back T233
-278[090] - return null S6 1
+268[014] - load local 0
+269[025] - load smi 1
+270[073] - invoke add // [{LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {LargeInteger_|SmallInteger_}
+271[004] - store local, pop S2
+273[041] - pop 1
+274[084] - branch back T234
+279[090] - return null S6 1
 
 change tests/type_propagation/deltablue-test.toit
  - argument 0: {Null_|Variable}

--- a/tests/type_propagation/gold/loop-list-test.gold
+++ b/tests/type_propagation/gold/loop-list-test.gold
@@ -6,22 +6,22 @@ main tests/type_propagation/loop-list-test.toit
   8[080] - invoke size size // [{List_}] -> {Null_|LargeInteger_|SmallInteger_}
  11[026] - load smi 100
  13[063] - invoke lt // [{Null_|LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
- 14[083] - branch if false T36
+ 14[083] - branch if false T38
  17[014] - load local 0
  18[015] - load local 1
  19[080] - invoke size size // [{List_}] -> {Null_|LargeInteger_|SmallInteger_}
  22[016] - load local 2
- 23[053] - invoke static List.last <sdk>/core/collections.toit // [{List_}] -> {*}
- 26[073] - invoke add // [{Null_|LargeInteger_|SmallInteger_}, {*}] -> {float|LargeInteger_|SmallInteger_}
- 27[053] - invoke static List.add <sdk>/core/collections.toit // [{List_}, {float|LargeInteger_|SmallInteger_}] -> {Null_}
- 30[041] - pop 1
- 31[084] - branch back T7
- 36[027] - load smi 4950
- 39[015] - load local 1
- 40[053] - invoke static List.last <sdk>/core/collections.toit // [{List_}] -> {*}
- 43[062] - invoke eq // [{SmallInteger_}, {*}] -> {True_|False_}
- 44[082] - branch if true T53
- 47[020] - load literal Bad computation
- 49[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
- 52[041] - pop 1
- 53[090] - return null S1 0
+ 23[058] - invoke virtual last // [{List_}] -> {*}
+ 27[073] - invoke add // [{Null_|LargeInteger_|SmallInteger_}, {*}] -> {float|LargeInteger_|SmallInteger_}
+ 28[058] - invoke virtual add // [{List_}, {float|LargeInteger_|SmallInteger_}] -> {Null_}
+ 32[041] - pop 1
+ 33[084] - branch back T7
+ 38[027] - load smi 4950
+ 41[015] - load local 1
+ 42[058] - invoke virtual last // [{List_}] -> {*}
+ 46[062] - invoke eq // [{SmallInteger_}, {*}] -> {True_|False_}
+ 47[082] - branch if true T56
+ 50[020] - load literal Bad computation
+ 52[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
+ 55[041] - pop 1
+ 56[090] - return null S1 0

--- a/tests/type_propagation/gold/loop-list-test.gold-O2
+++ b/tests/type_propagation/gold/loop-list-test.gold-O2
@@ -6,22 +6,22 @@ main tests/type_propagation/loop-list-test.toit
   8[080] - invoke size size // [{List_}] -> {Null_|LargeInteger_|SmallInteger_}
  11[026] - load smi 100
  13[063] - invoke lt // [{Null_|LargeInteger_|SmallInteger_}, {SmallInteger_}] -> {True_|False_}
- 14[083] - branch if false T36
+ 14[083] - branch if false T38
  17[014] - load local 0
  18[015] - load local 1
  19[080] - invoke size size // [{List_}] -> {Null_|LargeInteger_|SmallInteger_}
  22[016] - load local 2
- 23[053] - invoke static List.last <sdk>/core/collections.toit // [{List_}] -> {*}
- 26[073] - invoke add // [{Null_|LargeInteger_|SmallInteger_}, {*}] -> {float|LargeInteger_|SmallInteger_}
- 27[053] - invoke static List.add <sdk>/core/collections.toit // [{List_}, {float|LargeInteger_|SmallInteger_}] -> {Null_}
- 30[041] - pop 1
- 31[084] - branch back T7
- 36[027] - load smi 4950
- 39[015] - load local 1
- 40[053] - invoke static List.last <sdk>/core/collections.toit // [{List_}] -> {*}
- 43[062] - invoke eq // [{SmallInteger_}, {*}] -> {True_|False_}
- 44[082] - branch if true T53
- 47[020] - load literal Bad computation
- 49[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
- 52[041] - pop 1
- 53[090] - return null S1 0
+ 23[058] - invoke virtual last // [{List_}] -> {*}
+ 27[073] - invoke add // [{Null_|LargeInteger_|SmallInteger_}, {*}] -> {float|LargeInteger_|SmallInteger_}
+ 28[058] - invoke virtual add // [{List_}, {float|LargeInteger_|SmallInteger_}] -> {Null_}
+ 32[041] - pop 1
+ 33[084] - branch back T7
+ 38[027] - load smi 4950
+ 41[015] - load local 1
+ 42[058] - invoke virtual last // [{List_}] -> {*}
+ 46[062] - invoke eq // [{SmallInteger_}, {*}] -> {True_|False_}
+ 47[082] - branch if true T56
+ 50[020] - load literal Bad computation
+ 52[053] - invoke static throw <sdk>/core/exceptions.toit // [{String_}] -> {}
+ 55[041] - pop 1
+ 56[090] - return null S1 0


### PR DESCRIPTION
With this change, a Deque is a subclass of the abstract subclass List, which means it has useful methods like []=, index-of, and index-of --binary.

In addition, we add methods remove-at and insert-at, which can be used to insert and remove items from the middle of a list or deque. If the insertion is near the ends of a deque, or near the end of a List_ then the operation is efficient.