### PR TITLE
Fix compilation warning.

### DIFF
--- a/src/compiler/dispatch_table.cc
+++ b/src/compiler/dispatch_table.cc
@@ -534,7 +534,8 @@ void DispatchTableBuilder::print_table() {
            selector.shape().arity(),
            selector.shape().total_block_count(),
            selector.shape().named_block_count());
-    for (auto name : selector.shape().names()) {
+    auto names = selector.shape().names();
+    for (auto name : names) {
       printf(", %s", name.c_str());
     }
     auto id = selector_offsets().at(selector);

--- a/src/compiler/ir.cc
+++ b/src/compiler/ir.cc
@@ -791,7 +791,8 @@ class Printer : public Visitor {
            node->shape().arity(),
            node->shape().total_block_count(),
            node->shape().named_block_count());
-    for (auto name : node->shape().names()) {
+    auto names = node->shape().names();
+    for (auto name : names) {
       printf(", %s", name.c_str());
     }
     printf(") ");

--- a/src/compiler/no_such_method.cc
+++ b/src/compiler/no_such_method.cc
@@ -87,7 +87,8 @@ static void report_no_such_method(List<ir::Node*> candidates,
   Map<Symbol, int> call_site_names;  // The names that are used at the call site.
 
   int index = 0;
-  for (auto symbol : selector.shape().names()) {
+  auto names = selector.shape().names();
+  for (auto symbol : names) {
     call_site_names.set(symbol, selector.shape().is_block_name(index) ? BLOCK_NAME : NAME);
     index++;
   }


### PR DESCRIPTION
We had the following errors:
```
possibly dangling reference to a temporary [-Wdangling-reference]
 537 |     for (auto name : selector.shape().names()) {
     |                                             ^
```