### PR TITLE
Simplify toit-run image.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,6 +118,9 @@ set_source_files_properties(utils.cc PROPERTIES COMPILE_FLAGS "-DTOIT_MODEL=\"\\
 set(GEN_DIR "${PROJECT_BINARY_DIR}/generated")
 set(BOOT_SNAPSHOT ${GEN_DIR}/toit.run.snapshot)
 set(BOOT_SNAPSHOT_CC ${GEN_DIR}/toit.run.snapshot.cc)
+set(RUN_IMAGE_SNAPSHOT ${GEN_DIR}/run-image.snapshot)
+set(RUN_IMAGE_IMAGE ${GEN_DIR}/run-image.image)
+set(RUN_IMAGE_IMAGE_CC ${GEN_DIR}/run-image.image.cc)
 set(TOIT_SNAPSHOT ${GEN_DIR}/toit.snapshot)
 set(TOIT_SNAPSHOT_CC ${GEN_DIR}/toit.snapshot.cc)
 
@@ -139,6 +142,32 @@ add_custom_command(
   COMMAND xxd -i "toit.snapshot" "${TOIT_SNAPSHOT_CC}"
   DEPENDS "${TOIT_SNAPSHOT}"
   WORKING_DIRECTORY "${GEN_DIR}"
+)
+
+add_custom_command(
+  OUTPUT "${RUN_IMAGE_IMAGE_CC}"
+  # We can't use ${RUN_IMAGE_IMAGE} here, as that would include the full path.
+  # xxd just got a patch to change the name, but it's not really released/widely available yet.
+  COMMAND xxd -i "run-image.image" "${RUN_IMAGE_IMAGE_CC}"
+  DEPENDS "${RUN_IMAGE_IMAGE}"
+  WORKING_DIRECTORY "${GEN_DIR}"
+)
+
+# If the target architecture is 32-bit use -m32; otherwise -m64.
+if (CMAKE_SIZEOF_VOID_P EQUAL 4)
+  set(RUN_IMAGE_ARCH_FLAG "-m32")
+else()
+  set(RUN_IMAGE_ARCH_FLAG "-m64")
+endif()
+add_custom_command(
+  OUTPUT "${RUN_IMAGE_IMAGE}"
+  COMMAND "$<TARGET_FILE:toit.run>"
+      ${CMAKE_SOURCE_DIR}/tools/snapshot_to_image.toit
+      -o "${RUN_IMAGE_IMAGE}"
+      --format binary
+      "${RUN_IMAGE_ARCH_FLAG}"
+      "${RUN_IMAGE_SNAPSHOT}"
+  DEPENDS "$<TARGET_FILE:toit.run>" ${RUN_IMAGE_SNAPSHOT}
 )
 
 if (NOT "${TOIT_SYSTEM_NAME}" MATCHES "esp32")
@@ -164,9 +193,11 @@ if (NOT "${TOIT_SYSTEM_NAME}" MATCHES "esp32")
   add_executable(
     toit_run_image
     toit_run_image.cc
-    ${BOOT_SNAPSHOT_CC}
+    ${RUN_IMAGE_IMAGE_CC}
     run.cc
     )
+
+  add_dependencies(build_tools toit_run_image)
 
   set_target_properties(toit_run_image
     PROPERTIES
@@ -265,8 +296,7 @@ if (NOT "${TOIT_SYSTEM_NAME}" MATCHES "esp32")
     COMMAND ${HOST_TOIT} tool firmware create host
         -e "${ENVELOPE}"
         --run-image "$<TARGET_FILE:toit_run_image>"
-        --system.snapshot "${BOOT_SNAPSHOT}"
-    DEPENDS ${HOST_TOIT} toit_run_image ${BOOT_SNAPSHOT}
+    DEPENDS ${HOST_TOIT} toit_run_image
   )
   add_custom_target(
     build_envelope
@@ -322,6 +352,14 @@ if (NOT "${TOIT_SYSTEM_NAME}" MATCHES "esp32")
     ${TOIT_SNAPSHOT_SOURCE}
     ${TOIT_SNAPSHOT}
     ${CMAKE_CURRENT_BINARY_DIR}/toit.dep
+    ""
+  )
+
+  set(RUN_IMAGE_SNAPSHOT_SOURCE ${TOIT_SDK_SOURCE_DIR}/tools/run-image.toit)
+  ADD_TOIT_SNAPSHOT(
+    ${RUN_IMAGE_SNAPSHOT_SOURCE}
+    ${RUN_IMAGE_SNAPSHOT}
+    ${CMAKE_CURRENT_BINARY_DIR}/run-image.dep
     ""
   )
 

--- a/src/toit_run_image.cc
+++ b/src/toit_run_image.cc
@@ -28,21 +28,14 @@
 #include "snapshot.h"
 #include "third_party/dartino/gc_metadata.h"
 
+extern "C" {
+  extern unsigned char run_image_image[];
+  extern unsigned int run_image_image_len;
+};
+
 namespace toit {
 
-static void print_usage(int exit_code) {
-  // We don't expose the `--lsp` flag in the help. It's internal and not
-  // relevant for users.
-  printf("Usage:\n");
-  printf("vm\n");
-  printf("  [-h] [--help]                             // This help message\n");
-  printf("  [--version]                               // Prints version information\n");
-  printf("  [-X<flag>]*                               // Provide a compiler flag\n");
-  printf("  image_file                                // The image file to be run\n");
-  exit(exit_code);
-}
-
-static int run_program(Program* program) {
+static int run_program(Program* program, char** argv) {
   while (true) {
     Scheduler::ExitState exit;
     {
@@ -50,7 +43,7 @@ static int run_program(Program* program) {
       vm.load_platform_event_sources();
       create_and_start_external_message_handlers(&vm);
       int group_id = vm.scheduler()->next_group_id();
-      exit = vm.scheduler()->run_boot_program(program, null, group_id);
+      exit = vm.scheduler()->run_boot_program(program, argv, group_id);
     }
     switch (exit.reason) {
       case Scheduler::EXIT_NONE:
@@ -75,22 +68,11 @@ static int run_program(Program* program) {
 }
 
 int main(int argc, char **argv) {
-  Flags::process_args(&argc, argv);
-  if (argc < 2) print_usage(1);
-
   FlashRegistry::set_up();
   OS::set_up();
   ObjectMemory::set_up();
 
-  char* image_filename = argv[1];
-  Flags::program_name = image_filename;
-  FILE* file = fopen(image_filename, "rb");
-  if (file == null) {
-    FATAL("Couldn't open file");
-  }
-  fseek(file, 0, SEEK_END);
-  auto image_size = ftell(file);
-  fseek(file, 0, SEEK_SET);
+  auto image_size = run_image_image_len;
   ASSERT(image_size % (WORD_BIT_SIZE + 1) == 0);
   // We use one word for the following WORD_BIT_SIZE words as relocation bits.
   int relocated_size = (image_size / (WORD_BIT_SIZE + 1)) * WORD_BIT_SIZE;
@@ -101,18 +83,12 @@ int main(int argc, char **argv) {
   const int CHUNK_WORD_SIZE = WORD_BIT_SIZE + 1;
   int image_word_size = image_size / WORD_SIZE;
   for (int i = 0; i < image_word_size; i += CHUNK_WORD_SIZE) {
-    word buffer[CHUNK_WORD_SIZE];
     int end = std::min(i + CHUNK_WORD_SIZE, image_word_size);
     int chunk_word_size = end - i;
-    int read_words = fread(buffer, WORD_SIZE, chunk_word_size, file);
-    if (chunk_word_size != read_words) {
-      FATAL("Problems reading the image");
-    }
-    output.write(reinterpret_cast<word*>(buffer), chunk_word_size);
+    output.write(reinterpret_cast<word*>(&run_image_image[i * WORD_SIZE]), chunk_word_size);
   }
-  fclose(file);
 
-  int exit_state = run_program(reinterpret_cast<Program*>(relocated.program()));
+  int exit_state = run_program(reinterpret_cast<Program*>(relocated.program()), &argv[1]);
 
   GcMetadata::tear_down();
   OS::tear_down();

--- a/tests/image/CMakeLists.txt
+++ b/tests/image/CMakeLists.txt
@@ -18,9 +18,6 @@ file(GLOB INPUT RELATIVE "${TOIT_SDK_SOURCE_DIR}" "*-input.toit")
 
 set(S2I_TEST_DIR ${CMAKE_BINARY_DIR}/snapshot_to_image_test)
 
-add_custom_target(build_toit_run_image DEPENDS $<TARGET_FILE:toit_run_image>)
-add_dependencies(build_tools build_toit_run_image)
-
 include(fail.cmake)
 
 foreach(input ${INPUT})

--- a/tools/firmware.toit
+++ b/tools/firmware.toit
@@ -236,9 +236,6 @@ create-host-cmd -> cli.Command:
             --help="Path to the run-image executable."
             --type="file"
             --required,
-        cli.Option "system.snapshot"
-            --type="file"
-            --required,
       ]
       --run=:: create-envelope-host it
 
@@ -248,16 +245,15 @@ create-envelope-host parsed/cli.Parsed -> none:
   run-image-path := parsed["run-image"]
   run-image-bytes := read-file run-image-path
 
-  system-snapshot-content := read-file parsed["system.snapshot"]
-  system-snapshot := SnapshotBundle system-snapshot-content
-
   entries := {
     AR-ENTRY-HOST-RUN-IMAGE: run-image-bytes,
-    SYSTEM-CONTAINER-NAME: system-snapshot-content,
   }
 
+  // TODO(florian): we are using the sdk-version of the firmware-tool.
+  // That's almost always correct, but we should verify that the
+  // run-image has the same version.
   envelope := Envelope.create entries
-      --sdk-version=system-snapshot.sdk-version
+      --sdk-version=system.app-sdk-version
       --platform=Envelope.PLATFORM-HOST
   envelope.store output-path
 

--- a/tools/run-image.toit
+++ b/tools/run-image.toit
@@ -1,0 +1,18 @@
+// Copyright (C) 2024 Toitware ApS.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+main arguments:
+  print_ arguments
+  exit 0


### PR DESCRIPTION
Start an embedded image and let the Toit code execute the given image.