### PR TITLE
Add `build-envelope` to Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,10 @@ test:
 build-test-assets: rebuild-cmake
 	(cd $(BUILD)/$(HOST) && ninja build_test_assets)
 
+.PHONY: build-envelope
+build-envelope: rebuild-cmake
+	(cd $(BUILD)/$(HOST) && ninja build_envelope)
+
 .PHONY: test-flaky
 test-flaky:
 	(cd $(BUILD)/$(HOST) && ninja check_flaky)


### PR DESCRIPTION
Will be used in the envelope repository.