### PR TITLE
Don't emit the test-dir in the boot-output.

### DIFF
--- a/system/extensions/host/run-image-boot-sh.toit
+++ b/system/extensions/host/run-image-boot-sh.toit
@@ -104,12 +104,12 @@ for (( ; ; )); do
         else
           should_exit=true;
         fi' TERM INT
-  pushd \$PREFIX/\$current
+  cd \$PREFIX/\$current
   # Run the image in background mode.
   # The trap handlers are only active between commands, or when 'wait' is called.
   ./run-image \$PREFIX/\$current \$PREFIX/scratch &
   run_image_pid=\$!
-  popd
+  cd \$PREFIX
   if [ \$should_exit = true ]; then
     kill \$run_image_pid
     exit

--- a/tests/envelope/boot-hello-test.toit
+++ b/tests/envelope/boot-hello-test.toit
@@ -16,3 +16,4 @@ main args:
     test.extract-to-dir --dir-path=test.tmp-dir
     output := test.boot-backticks test.tmp-dir
     expect (output.contains "hello world")
+    expect-not (output.contains test.tmp-dir)


### PR DESCRIPTION
The pushd/popd commands were printing their paths.