### PR TITLE
Don't add the version to the released toitdoc file.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: toitdoc_${{ steps.constants.outputs.toit_version }}.json
+          asset_name: toitdoc.json
           tag: ${{ github.event.release.tag_name }}
           overwrite: true
 


### PR DESCRIPTION
By not using a version in the filename it's easier to just fetch the latest released file.