### PR TITLE
Update dns tests.

### DIFF
--- a/tests/dns-test.toit
+++ b/tests/dns-test.toit
@@ -56,7 +56,7 @@ ipv6-dns-test:
 
   // A domain that has no IPv6 address, but that's the only thing we will
   // accept.
-  error := catch: dns-lookup "toitlang.org" --accept-ipv6 --no-accept-ipv4
+  error := catch: dns-lookup "v4.ipv6test.app" --accept-ipv6 --no-accept-ipv4
   print "IPv6: $error"
   expect
       error is DnsException

--- a/tests/dns-tools-test.toit
+++ b/tests/dns-tools-test.toit
@@ -20,7 +20,7 @@ txt-test:
       ]
   texts := client.get --record-type=RECORD-TXT "toit.io"
   expect
-      texts.contains "OSSRH-61647"
+      texts.size == 0
   ptr := client.get --record-type=RECORD-PTR "toit.io"
   expect
       ptr.size == 0
@@ -110,7 +110,7 @@ encode-decode-packets-test:
   ]
   packet-2 := dns.create-dns-packet queries resources --id=42 --is-response=true
   decoded-2 := dns.decode-packet packet-2
-  
+
   expect-equals 42 decoded-2.id
   expect-equals 1 decoded-2.questions.size
   expect-equals 1 decoded-2.resources.size


### PR DESCRIPTION
After switching toit.io's DNS server some records don't exist anymore.