### PR TITLE
Make url encoding|decoding more predictible.

### DIFF
--- a/lib/encoding/url.toit
+++ b/lib/encoding/url.toit
@@ -59,9 +59,6 @@ Decodes the given $data using URL-encoding, also known as percent encoding.
 The function is liberal, accepting unencoded characters that should be
   encoded, with the exception of '%'.
 
-Returns a string if the input is a string and no decoding is needed.
-Returns a byte array otherwise.
-
 Plus signs (+) are not decoded to spaces.
 
 # Example

--- a/lib/encoding/url.toit
+++ b/lib/encoding/url.toit
@@ -78,12 +78,12 @@ The encoded $data may contain characters that are not valid UTF-8.
 */
 decode-binary data/string -> ByteArray:
   count := 0
-  for i := 0; i < data.byte-size; i++:
+  data.size.repeat: | i/int |
     if (data.at --raw i) == '%': count++
 
   if count == 0: return data.to-byte-array
 
-  result := ByteArray data.byte-size - count * 2
+  result := ByteArray (data.size - count * 2)
 
   j := 0
   for i := 0; i < data.size; i++:

--- a/lib/encoding/url.toit
+++ b/lib/encoding/url.toit
@@ -2,30 +2,38 @@
 // Use of this source code is governed by an MIT-style license that can be
 // found in the lib/LICENSE file.
 
+import io
+
 NEEDS-ENCODING_ ::= ByteArray '~' - '-' + 1:
   c := it + '-'
   (c == '-' or c == '_' or c == '.' or c == '~' or '0' <= c <= '9' or 'A' <= c <= 'Z' or 'a' <= c <= 'z') ? 0 : 1
 
 // Takes an ASCII string or a byte array.
 // Counts the number of bytes that need escaping.
-count-escapes_ data -> int:
+count-escapes_ data/io.Data -> int:
   count := 0
   table := NEEDS-ENCODING_
-  data.do: | c |
+  data.byte-size.repeat: | i/int |
+    c := data.byte-at i
     if not '-' <= c <= '~':
       count++
     else if table[c - '-'] == 1:
       count++
   return count
 
-// Takes an ASCII string or a byte array.
-url-encode_ from -> any:
+url-encode_ from/io.Data -> string:
   escaped := count-escapes_ from
-  if escaped == 0: return from
-  result := ByteArray from.size + escaped * 2
+  if escaped == 0:
+    if from is string: return from as string
+    if from is not ByteArray:
+      from = ByteArray.from from
+    return (from as ByteArray).to-string
+
+  result := ByteArray from.byte-size + escaped * 2
   pos := 0
   table := NEEDS-ENCODING_
-  from.do: | c |
+  from.byte-size.repeat: | i/int |
+    c := from.byte-at i
     if not '-' <= c <= '~' or table[c - '-'] == 1:
       result[pos] = '%'
       result[pos + 1] = to-upper-case-hex c >> 4
@@ -37,55 +45,55 @@ url-encode_ from -> any:
 
 /**
 Encodes the given $data using URL-encoding, also known as percent encoding.
-The $data must be a string or byte array.  The value returned is a string or
-  a byte array.  It can only be a byte array if the input was a byte array
-  and in this case it can be the identical byte array that was passed in.
+
 The characters 0-9, A-Z, and a-z are unchanged by the encoding, as are the
   characters '-', '_', '.', and '~'.  All other characters are encoded in
   hexadecimal, using the percent sign.  Thus a space character is encoded
   as "%20", and the Unicode snowman (☃) is encoded as "%E2%98%83".
 */
-encode data -> any:
-  if data is string:
-    // If a string is ASCII only then the sizes match.
-    if data.size != (data.size --runes):
-      // Convert to something where do will iterate over UTF-8 bytes.
-      data = data.to-byte-array
-  else if data is not ByteArray:
-    throw "WRONG_OBJECT_TYPE"
+encode data/io.Data -> string:
   return url-encode_ data
 
 /**
 Decodes the given $data using URL-encoding, also known as percent encoding.
 The function is liberal, accepting unencoded characters that should be
   encoded, with the exception of '%'.
-Takes a string or a byte array, and may return a string or a ByteArray.
-  (Both string and ByteArray have a to-string method.)
-Does not check for malformed UTF-8, but calling to-string on the return
-  value will throw on malformed UTF-8.
+
+Returns a string if the input is a string and no decoding is needed.
+Returns a byte array otherwise.
+
 Plus signs (+) are not decoded to spaces.
 
 # Example
-  (url.decode "foo%20b%C3%A5r").to-string  // Returns "foo bår".
+```
+  url.decode "foo%20b%C3%A5r"  // Returns "foo bår".
+```
 */
-decode data -> any:
-  if data is string:
-    if not data.contains "%": return data
-    if data.size != (data.size --runes): data = data.to-byte-array
-  else if data is ByteArray:
-    if (data.index-of '%') == -1: return data
-  else:
-    throw "WRONG_OBJECT_TYPE"
+decode data/string -> string:
+  if not data.contains "%": return data
+  return (decode-binary data).to-string
+
+/**
+Variant of $decode.
+
+Decodes the given $data using URL-encoding and returns the result as a byte array.
+The encoded $data may contain characters that are not valid UTF-8.
+*/
+decode-binary data/string -> ByteArray:
   count := 0
-  data.do: | c |
-    if c == '%': count++
-  result := ByteArray data.size - count * 2
+  for i := 0; i < data.byte-size; i++:
+    if (data.at --raw i) == '%': count++
+
+  if count == 0: return data.to-byte-array
+
+  result := ByteArray data.byte-size - count * 2
+
   j := 0
   for i := 0; i < data.size; i++:
-    c := data[i]
+    c := data.at --raw i
     if c == '%':
-      c = (hex-char-to-value data[i + 1]) << 4
-      c += hex-char-to-value data[i + 2]
+      c = (hex-char-to-value (data.at --raw i + 1)) << 4
+      c += hex-char-to-value (data.at --raw i + 2)
       i += 2
     result[j++] = c
   return result
@@ -169,9 +177,9 @@ class QueryString:
           parameters[key] = value
 
     return QueryString.internal_
-        --resource=(decode resource).to-string
+        --resource=decode resource
         --parameters=parameters
-        --fragment=(decode fragment).to-string
+        --fragment=decode fragment
 
   /// Decodes the application/x-www-form-urlencoded $component string.
   static decode-form-urlencoded_ component/string -> string:

--- a/tests/encoding-test.toit
+++ b/tests/encoding-test.toit
@@ -13,16 +13,16 @@ main:
 test-url-encode:
   expect-equals "foo" (url.encode "foo")
   expect-equals "-_.~abcABC012" (url.encode "-_.~abcABC012")
-  expect-equals "%20" (url.encode " ").to-string
-  expect-equals "%25" (url.encode "%").to-string
-  expect-equals "%2B" (url.encode "+").to-string
-  expect-equals "%26" (url.encode "&").to-string
-  expect-equals "%3D" (url.encode "=").to-string
-  expect-equals "%00%01%02%03%04" (url.encode (ByteArray 5: it)).to-string
-  expect-equals "%F0%F1%F2%F3%F4" (url.encode (ByteArray 5: 0xf0 + it)).to-string
-  expect-equals "%F1sh" (url.encode #[0xf1, 's', 'h']).to-string
-  expect-equals "-%E2%98%83-" (url.encode "-☃-").to-string
-  expect-equals "%E2%82%AC25%2C-" (url.encode "€25,-").to-string
+  expect-equals "%20" (url.encode " ")
+  expect-equals "%25" (url.encode "%")
+  expect-equals "%2B" (url.encode "+")
+  expect-equals "%26" (url.encode "&")
+  expect-equals "%3D" (url.encode "=")
+  expect-equals "%00%01%02%03%04" (url.encode (ByteArray 5: it))
+  expect-equals "%F0%F1%F2%F3%F4" (url.encode (ByteArray 5: 0xf0 + it))
+  expect-equals "%F1sh" (url.encode #[0xf1, 's', 'h'])
+  expect-equals "-%E2%98%83-" (url.encode "-☃-")
+  expect-equals "%E2%82%AC25%2C-" (url.encode "€25,-")
 
 test-url-decode:
   expect-equals "foo" (url.decode "foo")
@@ -36,14 +36,13 @@ test-url-decode:
   expect-equals "+" (url.decode "%2B").to-string
   expect-equals "&" (url.decode "%26").to-string
   expect-equals "=" (url.decode "%3D").to-string
-  expect-equals #[0, 1, 2, 3, 4] (url.decode (ByteArray 5: it))
-  expect-equals #[0, 1, 2, 3, 4] (url.decode "%00%01%02%03%04")
-  expect-equals #[0xf0, 0xf1, 0xf2] (url.decode (ByteArray 3: 0xf0 + it))
-  expect-equals #[0xf0, 0xf1, 0xf2] (url.decode "%F0%F1%F2")
-  expect-equals #[0xf0, 0xf1, 0xf2] (url.decode "%f0%f1%f2")  // Lower case.
-  expect-equals "%F1sh" (url.encode #[0xf1, 's', 'h']).to-string
-  expect-equals "-☃-" (url.decode "-%E2%98%83-").to-string
-  expect-equals "€25,-" (url.decode "%E2%82%AC25%2C-").to-string
+  expect-equals #[0, 1, 2, 3, 4] (url.decode-binary (ByteArray 5: it).to-string)
+  expect-equals #[0, 1, 2, 3, 4] (url.decode-binary "%00%01%02%03%04")
+  expect-equals #[0xf0, 0xf1, 0xf2] (url.decode-binary "%F0%F1%F2")
+  expect-equals #[0xf0, 0xf1, 0xf2] (url.decode-binary "%f0%f1%f2")  // Lower case.
+  expect-equals #[0xf1, 's', 'h'] (url.decode-binary "%F1sh")
+  expect-equals "-☃-" (url.decode "-%E2%98%83-")
+  expect-equals "€25,-" (url.decode "%E2%82%AC25%2C-")
 
 test-query-string:
   qs := url.QueryString.parse "/foo?x"


### PR DESCRIPTION
This is a breaking change:
- `encode` now always returns a string.
- `decode` always returns a string, and `decode-binary` always returns a ByteArray.