### PR TITLE
Fix install-range constraint.

### DIFF
--- a/tests/envelope/fail.cmake
+++ b/tests/envelope/fail.cmake
@@ -18,6 +18,12 @@ set(TOIT_FAILING_TESTS
 
 set(TOIT_SKIP_TESTS
 )
+if (DEFINED ENV{TOIT_CHECK_PROPAGATED_TYPES})
+  list(APPEND TOIT_SKIP_TESTS
+    # This test takes too long.
+    tests/envelope/boot-upgrade-test.toit
+  )
+endif()
 
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" OR "${CMAKE_SYSTEM_NAME}" STREQUAL "MSYS")
   list(APPEND TOIT_SKIP_TESTS

--- a/tests/pkg/constraint-test.toit
+++ b/tests/pkg/constraint-test.toit
@@ -8,13 +8,13 @@ import ...tools.pkg.constraints
 
 check-constraint v/string c/string:
   expect --message="$v $c"
-      (Constraint c).satisfies
-          SemanticVersion v
+      (Constraint.parse c).satisfies
+          SemanticVersion.parse v
 
 check-not-constraint v/string c/string:
   expect-not --message="not $v$c"
-      (Constraint c).satisfies
-          SemanticVersion v
+      (Constraint.parse c).satisfies
+          SemanticVersion.parse v
 
 main:
   check-constraint "2.1.2" "^2.1.1"

--- a/tests/pkg/constraint2-test.toit
+++ b/tests/pkg/constraint2-test.toit
@@ -1,0 +1,27 @@
+// Copyright (C) 2024 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+import ...tools.pkg.semantic-version
+import ...tools.pkg.constraints
+
+TESTS ::= [
+  ["0", ">=0.0.0,<1.0.0"],
+  ["1", ">=1.0.0,<2.0.0"],
+  ["0.5", ">=0.5.0,<0.6.0"],
+  ["1.5", ">=1.5.0,<1.6.0"],
+  ["0.5.3", "=0.5.3"],
+  ["1.5.3", "=1.5.3"],
+  ["1.5.3-alpha", "=1.5.3-alpha"],
+]
+
+main:
+  TESTS.do: | test/List |
+    input := test[0]
+    expected := test[1]
+
+    constraint := Constraint.parse-range input
+    simple-constraints := constraint.simple-constraints
+    str := (simple-constraints.map: it.stringify).join ","
+    expect-equals expected str

--- a/tests/pkg/package-test.toit
+++ b/tests/pkg/package-test.toit
@@ -30,7 +30,7 @@ main:
     config := ProjectConfiguration
       --project-root=PROJECT-DIR
       --cwd=directory.cwd
-      --sdk-version=(SemanticVersion system.vm-sdk-version)
+      --sdk-version=(SemanticVersion.parse system.vm-sdk-version)
       --auto-sync=false
 
     project := Project config --empty-lock-file

--- a/tests/pkg/registry-test.toit
+++ b/tests/pkg/registry-test.toit
@@ -22,9 +22,11 @@ test-git:
 
   expect-equals 558 registry.list-all-descriptions.size
 
-  morse-1-0-6 := registry.retrieve-description "github.com/toitware/toit-morse" (SemanticVersion "1.0.6")
+  morse-1-0-6 := registry.retrieve-description
+      "github.com/toitware/toit-morse"
+      SemanticVersion.parse "1.0.6"
   expect-equals "github.com/toitware/toit-morse" morse-1-0-6.url
-  expect-equals (SemanticVersion "1.0.6") morse-1-0-6.version
+  expect-equals (SemanticVersion.parse "1.0.6") morse-1-0-6.version
   expect-equals "morse" morse-1-0-6.name
   expect-equals "Functions for International (ITU) Morse code." morse-1-0-6.description
 
@@ -67,9 +69,11 @@ test-local:
 
   expect-equals 3 registry.list-all-descriptions.size
 
-  morse-1-0-6 := registry.retrieve-description "github.com/toitware/toit-morse-local" (SemanticVersion "1.0.6")
+  morse-1-0-6 := registry.retrieve-description
+      "github.com/toitware/toit-morse-local"
+      SemanticVersion.parse "1.0.6"
   expect-equals "github.com/toitware/toit-morse-local" morse-1-0-6.url
-  expect-equals (SemanticVersion "1.0.6") morse-1-0-6.version
+  expect-equals (SemanticVersion.parse "1.0.6") morse-1-0-6.version
   expect-equals "morse" morse-1-0-6.name
   expect-equals "Functions for International (ITU) Morse code." morse-1-0-6.description
 
@@ -157,9 +161,11 @@ test-registries:
   expect-equals 5 morse-versions.size
   expect-equals "[1.0.6, 1.0.5, 1.0.2, 1.0.1, 1.0.0]" morse-versions.stringify
 
-  morse-1-0-6 := test-registries.retrieve-description "github.com/toitware/toit-morse-local" (SemanticVersion "1.0.6")
+  morse-1-0-6 := test-registries.retrieve-description
+      "github.com/toitware/toit-morse-local"
+      SemanticVersion.parse "1.0.6"
   expect-equals "github.com/toitware/toit-morse-local" morse-1-0-6.url
-  expect-equals (SemanticVersion "1.0.6") morse-1-0-6.version
+  expect-equals (SemanticVersion.parse "1.0.6") morse-1-0-6.version
   expect-equals "morse" morse-1-0-6.name
   expect-equals "Functions for International (ITU) Morse code." morse-1-0-6.description
 

--- a/tests/pkg/semver-test.toit
+++ b/tests/pkg/semver-test.toit
@@ -6,15 +6,15 @@ import expect show *
 import ...tools.pkg.semantic-version
 
 is-less-than v1 v2:
-  return (SemanticVersion v1) < (SemanticVersion v2)
+  return (SemanticVersion.parse v1) < (SemanticVersion.parse v2)
 
 main:
-  v := SemanticVersion "0.1.0"
+  v := SemanticVersion.parse "0.1.0"
   expect-equals 0 v.major
   expect-equals 1 v.minor
   expect-equals 0 v.patch
 
-  v = SemanticVersion "1.2.4533321-alpha.2.2.2+BBA---34.0-3.0133k.42"
+  v = SemanticVersion.parse "1.2.4533321-alpha.2.2.2+BBA---34.0-3.0133k.42"
   expect-equals 1 v.major
   expect-equals 2 v.minor
   expect-equals 4533321 v.patch
@@ -32,9 +32,9 @@ main:
   expect-equals true (is-less-than "2.0.0-alpha.79" "2.0.0-alpha.121.31+pgk-in-toit.95591318")
   expect-equals true (is-less-than "2.0.0-alpha.121.31+pgk-in-toit.95591318" "3.0.0")
 
-  expect-throw "Parse error, expected a numeric value at position 0" : SemanticVersion "."
-  expect-throw "Parse error, expected a numeric value at position 4" : SemanticVersion "1.1."
-  expect-throw "Parse error, not all input was consumed" : SemanticVersion "1.1.02"
-  expect-throw "Parse error, expected . at position 3" : SemanticVersion "1.01.2"
-  expect-throw "Parse error in pre-release, expected an identifier or a number at position 6" : SemanticVersion "1.1.2-"
-  expect-throw "Parse error in build-number, expected an identifier or digits at position 6" : SemanticVersion "1.1.2+"
+  expect-throw "Parse error, expected a numeric value at position 0": SemanticVersion.parse "."
+  expect-throw "Parse error, expected a numeric value at position 4": SemanticVersion.parse "1.1."
+  expect-throw "Parse error, not all input was consumed": SemanticVersion.parse "1.1.02"
+  expect-throw "Parse error, expected . at position 3": SemanticVersion.parse "1.01.2"
+  expect-throw "Parse error in pre-release, expected an identifier or a number at position 6": SemanticVersion.parse "1.1.2-"
+  expect-throw "Parse error in build-number, expected an identifier or digits at position 6": SemanticVersion.parse "1.1.2+"

--- a/tests/pkg/setup.toit
+++ b/tests/pkg/setup.toit
@@ -10,7 +10,7 @@ TOIT-REGISTRY-MAP := {
 }
 
 with-test-registry [block]:
-  tmp-dir := directory.mkdtemp "test-"
+  tmp-dir := directory.mkdtemp "/tmp/test-"
   try:
     os.env["TOIT_PKG_CACHE_DIR"] = ".test-cache"
     directory.mkdir --recursive ".test-cache"

--- a/tools/pkg/commands/utils_.toit
+++ b/tools/pkg/commands/utils_.toit
@@ -9,6 +9,6 @@ project-configuration-from-cli parsed/cli.Parsed:
     return ProjectConfiguration
         --project-root=parsed[OPTION-PROJECT-ROOT]
         --cwd=directory.cwd
-        --sdk-version=SemanticVersion parsed[OPTION-SDK-VERSION]
+        --sdk-version=SemanticVersion.parse parsed[OPTION-SDK-VERSION]
         --auto-sync=parsed[OPTION-AUTO-SYNC]
 

--- a/tools/pkg/constraints.toit
+++ b/tools/pkg/constraints.toit
@@ -15,19 +15,28 @@
 
 import .semantic-version
 import .parsers.constraint-parser
+import .parsers.semantic-version-parser
 
 class Constraint:
-  constraints/List
+  simple-constraints/List
   source/string
 
-  constructor .source/string:
+  constructor --.simple-constraints --.source:
+
+  static parse source/string -> Constraint:
     parsed := (ConstraintParser source).constraints --consume-all
-    constraints = []
+    constraints := []
     parsed.do: | constraint/ConstraintParseResult |
       version := SemanticVersion.from-parse-result constraint.semantic-version
       if constraint.prefix == "^":
-        constraints.add (SimpleConstraint ">=" version)
-        constraints.add (SimpleConstraint "<" (SemanticVersion --major=version.major + 1))
+        // All versions compatible with the given version.
+        if version.major != 0:
+          constraints.add (SimpleConstraint ">=" version)
+          constraints.add (SimpleConstraint "<" (SemanticVersion --major=version.major + 1))
+        else:
+          // If the major version is 0, then the minor version may not be increased.
+          constraints.add (SimpleConstraint ">=" version)
+          constraints.add (SimpleConstraint "<" (SemanticVersion --major=version.major --minor=version.minor + 1))
       else if constraint.prefix == "~" or constraint.prefix == "~>":
         constraints.add (SimpleConstraint ">=" version)
         constraints.add (SimpleConstraint "<" (SemanticVersion --major=version.major --minor=version.minor + 1))
@@ -35,9 +44,31 @@ class Constraint:
         constraints.add (SimpleConstraint "=" version)
       else:
         constraints.add (SimpleConstraint constraint.prefix version)
+    return Constraint --simple-constraints=constraints --source=source
+
+  static parse-range source/string -> Constraint:
+    parser := SemanticVersionParser source --allow-missing-minor
+    parse-result := parser.semantic-version --consume-all
+    // triple/TripleParseResult
+    // pre-releases/List
+    // build-numbers/List
+    triple := parse-result.triple.triple
+    constraints := []
+    if not triple[1]:
+      // No minor.
+      constraints.add (SimpleConstraint ">=" (SemanticVersion --major=triple[0]))
+      constraints.add (SimpleConstraint "<" (SemanticVersion --major=triple[0] + 1))
+    else if not triple[2]:
+      // No patch.
+      constraints.add (SimpleConstraint ">=" (SemanticVersion --major=triple[0] --minor=triple[1]))
+      constraints.add (SimpleConstraint "<" (SemanticVersion --major=triple[0] --minor=triple[1] + 1))
+    else:
+      constraints.add (SimpleConstraint "=" (SemanticVersion.from-parse-result parse-result))
+
+    return Constraint --simple-constraints=constraints --source=source
 
   satisfies version/SemanticVersion -> bool:
-    constraints.do:
+    simple-constraints.do:
       if not it.satisfies version:
         return false
     return true

--- a/tools/pkg/constraints.toit
+++ b/tools/pkg/constraints.toit
@@ -49,9 +49,6 @@ class Constraint:
   static parse-range source/string -> Constraint:
     parser := SemanticVersionParser source --allow-missing-minor
     parse-result := parser.semantic-version --consume-all
-    // triple/TripleParseResult
-    // pre-releases/List
-    // build-numbers/List
     triple := parse-result.triple.triple
     constraints := []
     if not triple[1]:

--- a/tools/pkg/project/lock.toit
+++ b/tools/pkg/project/lock.toit
@@ -90,7 +90,7 @@ class LoadedRepositoryPackage extends PackageBase implements RepositoryPackage:
 
   constructor.from-map name prefixes project-package-file/ProjectPackageFile map/Map:
     url = map["url"]
-    version = SemanticVersion map["version"]
+    version = SemanticVersion.parse map["version"]
     ref-hash = map["hash"]
     super name prefixes project-package-file
 
@@ -222,7 +222,7 @@ class LockFile:
     if yaml-sdk-version:
       if not yaml-sdk-version.starts-with "^":
         throw "The sdk version ($yaml-sdk-version) specified in the lock file is not valid. It should start with a ^"
-      sdk-version = SemanticVersion contents[SDK-KEY_][1..]
+      sdk-version = SemanticVersion.parse contents[SDK-KEY_][1..]
 
     if contents.contains PREFIXES-KEY_:
       prefixes = contents[PREFIXES-KEY_]
@@ -466,7 +466,7 @@ class LockFileBuilder:
         if not sdk-version.source.starts-with "^":
           throw "Unexpected sdk-version constraint: $sdk-version"
 
-        version := SemanticVersion sdk-version.source[1..]
+        version := SemanticVersion.parse sdk-version.source[1..]
 
         if not min-sdk-version:
           min-sdk-version = version

--- a/tools/pkg/project/package.toit
+++ b/tools/pkg/project/package.toit
@@ -158,7 +158,7 @@ abstract class PackageFile:
   sdk-version -> Constraint?:
     if environment_ := environment:
       if environment_.contains SDK-KEY_:
-        return Constraint environment_[SDK-KEY_]
+        return Constraint.parse environment_[SDK-KEY_]
     return null
 
   has-package package-name/string:
@@ -196,7 +196,7 @@ class PackageDependency:
   constraint/Constraint
 
   constructor .url .constraint_:
-    constraint = Constraint constraint_
+    constraint = Constraint.parse constraint_
 
   filter versions/List -> List:
     return constraint.filter versions

--- a/tools/pkg/registry/cache.toit
+++ b/tools/pkg/registry/cache.toit
@@ -14,6 +14,7 @@
 // directory of this repository.
 
 import .description
+import ..constraints
 import ..file-system-view
 import ..semantic-version
 import encoding.yaml
@@ -46,14 +47,14 @@ class DescriptionUrlCache:
   /**
   Returns a map, mapping urls to lists of descriptions.
   */
-  search url-suffix/string version-prefix/string? -> Map:
+  search url-suffix/string version-constraint/Constraint? -> Map:
     result := {:}
     cache_.do: | url/string version-cache/DescriptionVersionCache |
       if url.ends-with url-suffix:
-        if not version-prefix:
+        if not version-constraint:
           result[url] = version-cache.all-descriptions
         else:
-          result[url] = version-cache.filter version-prefix
+          result[url] = version-cache.filter version-constraint
     return result
 
   recurse_ content/FileSystemView:
@@ -95,10 +96,10 @@ class DescriptionVersionCache:
   all-versions -> List?:
     return cache_.keys
 
-  filter version-prefix/string -> List:
+  filter version-constraint/Constraint -> List:
     result := []
     cache_.do: | version/SemanticVersion description |
-      if version.stringify.starts-with version-prefix:
+      if version-constraint.satisfies version:
         result.add description
     return result
 

--- a/tools/pkg/registry/description.toit
+++ b/tools/pkg/registry/description.toit
@@ -48,14 +48,14 @@ class Description:
 
   version -> SemanticVersion:
     if not cached_version_:
-      cached_version_ = SemanticVersion content[VERSION-KEY_]
+      cached_version_ = SemanticVersion.parse content[VERSION-KEY_]
     return cached_version_
 
   sdk-version -> Constraint?:
     if cached-sdk-version_.is-empty:
       if environment := content.get ENVIRONMENT-KEY_:
         if sdk-constraint := environment.get SDK-KEY_:
-          cached-sdk-version_.add (Constraint sdk-constraint)
+          cached-sdk-version_.add (Constraint.parse sdk-constraint)
           return cached-sdk-version_[0]
       cached-sdk-version_.add null
     return cached-sdk-version_[0]

--- a/tools/pkg/registry/registry.toit
+++ b/tools/pkg/registry/registry.toit
@@ -87,7 +87,7 @@ class Registries:
       error-reporter.call "Package '$search-string' not found $registry-info"
     else:
       if not registry-name:
-        // Test for the same package appearing in multiple registreis.
+        // Test for the same package appearing in multiple registries.
         urls := {}
         search-results.do:
           urls.add it[1].url
@@ -235,14 +235,15 @@ abstract class Registry:
     return description-cache.get-versions url
 
   search search-string/string -> List:
-    search-version := null
+    search-version-constraint/Constraint? := null
     if search-string.contains "@":
       split := search-string.split "@"
       search-string = split[0]
-      search-version = split[1]
+      search-version-str := split[1]
+      search-version-constraint = Constraint.parse-range search-version-str
 
     // Initially maps urls to list of descriptions.
-    search-result := description-cache.search search-string search-version
+    search-result := description-cache.search search-string search-version-constraint
 
     // Remove empty.
     search-result = search-result.filter: | _ descriptions/List | not descriptions.is-empty

--- a/tools/pkg/semantic-version.toit
+++ b/tools/pkg/semantic-version.toit
@@ -26,11 +26,11 @@ class SemanticVersion:
   pre-releases/List
   build-numbers/List
 
-  constructor --.major/int --.minor/int=0 --.patch/int=0 --.pre-releases/List=[] --.build-numbers/List=[]:
-
-  constructor version/string:
+  static parse version/string -> SemanticVersion:
     parsed := (SemanticVersionParser version).semantic-version --consume-all
     return SemanticVersion.from-parse-result parsed
+
+  constructor --.major/int --.minor/int=0 --.patch/int=0 --.pre-releases/List=[] --.build-numbers/List=[]:
 
   constructor.from-parse-result parsed/SemanticVersionParseResult:
     major = parsed.triple.triple[0]


### PR DESCRIPTION
Just using the given term as prefix doesn't work. For example, 'pkg install foo@1' would match 'v10.0.1'.

Also some refactorings to use conventions that are more in line with the rest of the repository.