### PR TITLE
Enable asserts by default for -O0 and -O1 and add flag.

### DIFF
--- a/tests/toit/assert-test.toit
+++ b/tests/toit/assert-test.toit
@@ -1,0 +1,53 @@
+// Copyright (C) 2024 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+import host.directory
+import host.file
+import host.pipe
+import system
+
+import .utils
+
+main args:
+  toit-exe := ToitExecutable args
+
+  print "ASSERTION ERRORS ARE EXPECTED IN THIS TEST"
+
+  with-tmp-dir: | tmp-dir/string |
+    src-path := "$tmp-dir/assert.toit"
+    file.write-content --path=src-path """
+      main args:
+        // The assert will always fail.
+        assert: args.size > 100
+      """
+    exit-code := toit-exe.run ["run", src-path]
+    expect-equals 1 exit-code
+
+    exit-code = toit-exe.run ["run", "-O2", src-path]
+    expect-equals 0 exit-code
+
+    exit-code = toit-exe.run ["run", "--no-enable-asserts", "-O1", src-path]
+    expect-equals 0 exit-code
+
+    exit-code = toit-exe.run ["run", "--enable-asserts", "-O2", src-path]
+    expect-equals 1 exit-code
+
+    assert-executable := "$tmp-dir/assert"
+    toit-exe.backticks ["compile", "-o", assert-executable, src-path]
+    expect (file.is-file assert-executable)
+    exit-code = pipe.run-program assert-executable
+    expect-equals 1 exit-code
+
+    toit-exe.backticks ["compile", "-O2", "-o", assert-executable, src-path]
+    exit-code = pipe.run-program assert-executable
+    expect-equals 0 exit-code
+
+    toit-exe.backticks ["compile", "--no-enable-asserts", "-o", assert-executable, src-path]
+    exit-code = pipe.run-program assert-executable
+    expect-equals 0 exit-code
+
+    toit-exe.backticks ["compile", "--enable-asserts", "-O2", "-o", assert-executable, src-path]
+    exit-code = pipe.run-program assert-executable
+    expect-equals 1 exit-code

--- a/tools/toit.toit
+++ b/tools/toit.toit
@@ -519,7 +519,7 @@ compile-or-analyze-or-run --command/string parsed/cli.Parsed:
 
     enable-asserts := optimization < 2
     if parsed.was-provided "enable-asserts":
-      // An explicit --assert, or --no-assert, overrides the default.
+      // An explicit --enable-asserts, or --no-enable-asserts, overrides the default.
       if parsed["enable-asserts"]:
         enable-asserts = true
       else:

--- a/tools/toit.toit
+++ b/tools/toit.toit
@@ -512,10 +512,8 @@ compile-or-analyze-or-run --command/string parsed/cli.Parsed:
   if command == "analyze":
     args.add "--analyze"
   else:
-    optimization/int := 0
-    if parsed["optimization-level"]:
-      optimization = parsed["optimization-level"]
-      if not 0 <= optimization <= 2: error "Invalid optimization level"
+    optimization/int := parsed["optimization-level"]
+    if not 0 <= optimization <= 2: error "Invalid optimization level"
 
     args.add "-O$optimization"
 

--- a/tools/toit.toit
+++ b/tools/toit.toit
@@ -79,10 +79,12 @@ main args/List:
     cli.OptionInt "optimization-level" --short-name="O"
         --help="""
             Set the optimization level.
-            0 is no optimization,
-            1 is some optimization,
-            2 is more optimization."""
+            0: no optimizations,
+            1: some optimizations,
+            2: more optimizations."""
         --default=1,
+    cli.Flag "enable-asserts"
+        --help="Enable assertions. Enabled by default for -O0 and -O1.",
     cli.Flag "force" --short-name="f"
         --help="Force compilation even if there were errors (if possible).",
   ]
@@ -510,10 +512,21 @@ compile-or-analyze-or-run --command/string parsed/cli.Parsed:
   if command == "analyze":
     args.add "--analyze"
   else:
+    optimization/int := 0
     if parsed["optimization-level"]:
-      optimization/int := parsed["optimization-level"]
+      optimization = parsed["optimization-level"]
       if not 0 <= optimization <= 2: error "Invalid optimization level"
-      args.add "-O$optimization"
+
+    args.add "-O$optimization"
+
+    enable-asserts := optimization < 2
+    if parsed.was-provided "enable-asserts":
+      // An explicit --assert, or --no-assert, overrides the default.
+      if parsed["enable-asserts"]:
+        enable-asserts = true
+      else:
+        enable-asserts = false
+    args.add "-X$(enable-asserts ? "enable-asserts" : "no-enable-asserts")"
 
     if parsed["force"]: args.add "--force"
 

--- a/tools/toit.toit
+++ b/tools/toit.toit
@@ -526,7 +526,7 @@ compile-or-analyze-or-run --command/string parsed/cli.Parsed:
         enable-asserts = true
       else:
         enable-asserts = false
-    args.add "-X$(enable-asserts ? "enable-asserts" : "no-enable-asserts")"
+    args.add "-Xenable-asserts=$enable-asserts"
 
     if parsed["force"]: args.add "--force"
 


### PR DESCRIPTION
Partially fixes #2493.
We still need to expose it in Jaguar.