### PR TITLE
Force comparisons to be boolean.

### DIFF
--- a/src/compiler/ir.h
+++ b/src/compiler/ir.h
@@ -634,6 +634,10 @@ class Method : public Node {
     ASSERT(!return_type_.is_valid());
     return_type_ = type;
   }
+  void replace_return_type(Type type) {
+    return_type_ = type;
+  }
+
   Expression* body() const { return body_; }
   void set_body(Expression* body) {
     ASSERT(body_ == null);

--- a/src/compiler/resolver_method.h
+++ b/src/compiler/resolver_method.h
@@ -74,7 +74,18 @@ class MethodResolver : public ast::Visitor {
       , block_has_direct_field_access_(true)
       , current_lambda_(null)
       , loop_status_(NO_LOOP)
-      , loop_block_depth_(0) {}
+      , loop_block_depth_(0) {
+    auto core_scope = core_module->scope();
+    auto entry = core_scope->lookup(Symbols::bool_).entry;
+    if (!entry.is_class()) FATAL("MISSING BOOL TYPE");
+    bool_type_ = ir::Type(entry.klass());
+    entry = core_scope->lookup(Symbols::True).entry;
+    if (!entry.is_class()) FATAL("MISSING TRUE TYPE");
+    true_type_ = ir::Type(entry.klass());
+    entry = core_scope->lookup(Symbols::False).entry;
+    if (!entry.is_class()) FATAL("MISSING FALSE TYPE");
+    false_type_ = ir::Type(entry.klass());
+  }
 
   void resolve_fill();
 
@@ -141,6 +152,10 @@ class MethodResolver : public ast::Visitor {
   std::vector<std::pair<Symbol, ast::Node*>> break_continue_label_stack_;
 
   std::vector<ir::AssignmentGlobal*> global_assignments_;
+
+  ir::Type bool_type_ = ir::Type::invalid();
+  ir::Type true_type_ = ir::Type::invalid();
+  ir::Type false_type_ = ir::Type::invalid();
 
   SourceManager* source_manager() const { return source_manager_; }
   Diagnostics* diagnostics() const { return diagnostics_; }

--- a/tests/abstract-test.toit
+++ b/tests/abstract-test.toit
@@ -34,13 +34,26 @@ test1:
 
 abstract class C2-0:
   abstract operator < other
+  abstract operator > other
 
 class C2-1 extends C2-0:
+  hit-lt := false
   operator < other:
-    return 42
+    hit-lt = true
+    return true
+
+  hit-gt := false
+  operator > other:
+    hit-gt = true
+    return false
 
 test2:
-  expect-equals 42 (C2-1 < 499)
+  c2-1 := C2-1
+  expect-equals true (c2-1 < 499)
+  expect c2-1.hit-lt
+
+  expect-equals false (c2-1 > 499)
+  expect c2-1.hit-gt
 
 main:
   test0

--- a/tests/lsp/toitdoc3-compiler-test.toit
+++ b/tests/lsp/toitdoc3-compiler-test.toit
@@ -736,11 +736,11 @@ test client/LspClient:
       \$([]= x y)
       */
       class A:
-        operator == other:
-        operator < other:
-        operator <= other:
-        operator >= other:
-        operator > other:
+        operator == other: return true
+        operator < other: return true
+        operator <= other: return true
+        operator >= other: return true
+        operator > other: return true
         operator + other:
         operator - other:  // Unary minus is tested elsewhere.
         operator * other:
@@ -757,11 +757,11 @@ test client/LspClient:
         operator []= i val:
 
       class B:
-        operator == other:
-        operator < other:
-        operator <= other:
-        operator >= other:
-        operator > other:
+        operator == other: return true
+        operator < other: return true
+        operator <= other: return true
+        operator >= other: return true
+        operator > other: return true
         operator + other:
         operator - other:  // Unary minus is tested elsewhere.
         operator * other:

--- a/tests/negative/comparison-type-test.toit
+++ b/tests/negative/comparison-type-test.toit
@@ -1,0 +1,25 @@
+// Copyright (C) 2024 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+class A:
+  operator == other -> string:
+    return "str"
+
+  operator <= other:
+
+  operator < other:
+    return "str"
+
+  operator >= other -> bool?:
+    return true
+
+class B:
+  operator == other -> any:
+    return false
+
+foo str/string:
+
+main:
+  b := B
+  foo (b == "foo")

--- a/tests/negative/comparison-type2-test.toit
+++ b/tests/negative/comparison-type2-test.toit
@@ -1,0 +1,14 @@
+// Copyright (C) 2024 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+foo -> any:
+  return "foo"
+
+class A:
+  operator == other -> any:
+    return foo
+
+main:
+  a := A
+  print (a == "foo")

--- a/tests/negative/gold/comparison-type-test.gold
+++ b/tests/negative/gold/comparison-type-test.gold
@@ -1,0 +1,19 @@
+tests/negative/comparison-type-test.toit:6:24: error: Return type of comparison must be a boolean
+  operator == other -> string:
+                       ^~~~~~
+tests/negative/comparison-type-test.toit:14:24: error: Comparison operators may not return null
+  operator >= other -> bool?:
+                       ^~~~~
+tests/negative/comparison-type-test.toit:7:5: error: Type mismatch. Expected 'bool'. Got 'string'
+    return "str"
+    ^~~~~~
+tests/negative/comparison-type-test.toit:12:5: error: Type mismatch. Expected 'bool'. Got 'string'
+    return "str"
+    ^~~~~~
+tests/negative/comparison-type-test.toit:25:10: error: Type mismatch. Expected 'string'. Got 'bool'
+  foo (b == "foo")
+         ^~
+tests/negative/comparison-type-test.toit:9:3: error: Method doesn't return a value
+  operator <= other:
+  ^~~~~~~~~~~
+Compilation failed

--- a/tests/negative/gold/comparison-type2-test.gold
+++ b/tests/negative/gold/comparison-type2-test.gold
@@ -1,0 +1,3 @@
+As check failed: a string ("foo") is not a bool.
+  0: A.==                      tests/negative/comparison-type2-test.toit:10:5
+  1: main                      tests/negative/comparison-type2-test.toit:14:12

--- a/tests/negative/gold/operator-test.gold
+++ b/tests/negative/gold/operator-test.gold
@@ -625,4 +625,94 @@ tests/negative/operator-test.toit:227:5: error: Unresolved identifier: 'unresolv
 tests/negative/operator-test.toit:229:5: error: Unresolved identifier: 'unresolved'
     unresolved
     ^~~~~~~~~~
+tests/negative/operator-test.toit:196:3: error: Method doesn't return a value
+  operator == other [--bad]:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:198:3: error: Method doesn't return a value
+  operator < other [--bad]:
+  ^~~~~~~~~~
+tests/negative/operator-test.toit:200:3: error: Method doesn't return a value
+  operator <= other [--bad]:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:202:3: error: Method doesn't return a value
+  operator >= other [--bad]:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:204:3: error: Method doesn't return a value
+  operator > other [--bad]:
+  ^~~~~~~~~~
+tests/negative/operator-test.toit:157:3: error: Method doesn't return a value
+  operator == other --bad:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:159:3: error: Method doesn't return a value
+  operator < other --bad:
+  ^~~~~~~~~~
+tests/negative/operator-test.toit:161:3: error: Method doesn't return a value
+  operator <= other --bad:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:163:3: error: Method doesn't return a value
+  operator >= other --bad:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:165:3: error: Method doesn't return a value
+  operator > other --bad:
+  ^~~~~~~~~~
+tests/negative/operator-test.toit:121:3: error: Method doesn't return a value
+  operator == other bad=null:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:123:3: error: Method doesn't return a value
+  operator < other bad=null:
+  ^~~~~~~~~~
+tests/negative/operator-test.toit:125:3: error: Method doesn't return a value
+  operator <= other bad=null:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:127:3: error: Method doesn't return a value
+  operator >= other bad=null:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:129:3: error: Method doesn't return a value
+  operator > other bad=null:
+  ^~~~~~~~~~
+tests/negative/operator-test.toit:85:3: error: Method doesn't return a value
+  operator == other [bad]:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:87:3: error: Method doesn't return a value
+  operator < other [bad]:
+  ^~~~~~~~~~
+tests/negative/operator-test.toit:89:3: error: Method doesn't return a value
+  operator <= other [bad]:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:91:3: error: Method doesn't return a value
+  operator >= other [bad]:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:93:3: error: Method doesn't return a value
+  operator > other [bad]:
+  ^~~~~~~~~~
+tests/negative/operator-test.toit:42:3: error: Method doesn't return a value
+  operator ==:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:44:3: error: Method doesn't return a value
+  operator <:
+  ^~~~~~~~~~
+tests/negative/operator-test.toit:46:3: error: Method doesn't return a value
+  operator <=:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:48:3: error: Method doesn't return a value
+  operator >=:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:50:3: error: Method doesn't return a value
+  operator >:
+  ^~~~~~~~~~
+tests/negative/operator-test.toit:6:3: error: Method doesn't return a value
+  operator == other bad:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:8:3: error: Method doesn't return a value
+  operator < other bad:
+  ^~~~~~~~~~
+tests/negative/operator-test.toit:10:3: error: Method doesn't return a value
+  operator <= other bad:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:12:3: error: Method doesn't return a value
+  operator >= other bad:
+  ^~~~~~~~~~~
+tests/negative/operator-test.toit:14:3: error: Method doesn't return a value
+  operator > other bad:
+  ^~~~~~~~~~
 Compilation failed

--- a/tests/negative/gold/static4-test.gold
+++ b/tests/negative/gold/static4-test.gold
@@ -1,4 +1,7 @@
 tests/negative/static4-test.toit:6:10: error: Operators may not be static
   static operator == other:
          ^~~~~~~~~~~
+tests/negative/static4-test.toit:7:5: error: Type mismatch. Expected 'bool'. Got 'string'
+    return "static =="
+    ^~~~~~
 Compilation failed

--- a/tests/operators-test.toit
+++ b/tests/operators-test.toit
@@ -5,43 +5,100 @@
 import expect show *
 
 class A:
-  operator == other: return "== $other"
-  operator < other: return "< $other"
-  operator <= other: return "<= $other"
-  operator >= other: return ">= $other"
-  operator > other: return "> $other"
-  operator + other: return "+ $other"
-  operator - other: return "- $other"
-  operator * other: return "* $other"
-  operator / other: return "/ $other"
-  operator % other: return "% $other"
-  operator ^ other: return "^ $other"
-  operator & other: return "& $other"
-  operator | other: return "| $other"
-  operator >> other: return ">> $other"
-  operator >>> other: return ">>> $other"
-  operator << other: return "<< $other"
+  last-operator/string? := null
 
-  operator -: return "-"
-  operator ~: return "~"
+  operator == other:
+    last-operator = "== $other"
+    return true
+  operator < other:
+    last-operator = "< $other"
+    return true
+  operator <= other:
+    last-operator = "<= $other"
+    return true
+  operator >= other:
+    last-operator = ">= $other"
+    return true
+  operator > other:
+    last-operator = "> $other"
+    return true
+  operator + other:
+    last-operator = "+ $other"
+    return true
+  operator - other:
+    last-operator = "- $other"
+    return true
+  operator * other:
+    last-operator = "* $other"
+    return true
+  operator / other:
+    last-operator = "/ $other"
+    return true
+  operator % other:
+    last-operator = "% $other"
+    return true
+  operator ^ other:
+    last-operator = "^ $other"
+    return true
+  operator & other:
+    last-operator = "& $other"
+    return true
+  operator | other:
+    last-operator = "| $other"
+    return true
+  operator >> other:
+    last-operator = ">> $other"
+    return true
+  operator >>> other:
+    last-operator = ">>> $other"
+    return true
+  operator << other:
+    last-operator = "<< $other"
+    return true
+
+  operator -:
+    last-operator = "-"
+    return true
+  operator ~:
+    last-operator = "~"
+    return true
 
 main:
-  expect-equals "== 499" A == 499
-  expect-equals "< 499" A < 499
-  expect-equals "<= 499" A <= 499
-  expect-equals ">= 499" A >= 499
-  expect-equals "> 499" A > 499
-  expect-equals "+ 499" A + 499
-  expect-equals "- 499" A - 499
-  expect-equals "* 499" A * 499
-  expect-equals "/ 499" A / 499
-  expect-equals "% 499" A % 499
-  expect-equals "^ 499" A ^ 499
-  expect-equals "& 499" A & 499
-  expect-equals "| 499" A | 499
-  expect-equals ">> 499" A >> 499
-  expect-equals ">>> 499" A >>> 499
-  expect-equals "<< 499" A << 499
+  a := A
+  a == 499
+  expect-equals "== 499" a.last-operator
+  a < 499
+  expect-equals "< 499" a.last-operator
+  a <= 499
+  expect-equals "<= 499" a.last-operator
+  a >= 499
+  expect-equals ">= 499" a.last-operator
+  a > 499
+  expect-equals "> 499" a.last-operator
+  a + 499
+  expect-equals "+ 499" a.last-operator
+  a - 499
+  expect-equals "- 499" a.last-operator
+  a * 499
+  expect-equals "* 499" a.last-operator
+  a / 499
+  expect-equals "/ 499" a.last-operator
+  a % 499
+  expect-equals "% 499" a.last-operator
+  a ^ 499
+  expect-equals "^ 499" a.last-operator
+  a & 499
+  expect-equals "& 499" a.last-operator
+  a | 499
+  expect-equals "| 499" a.last-operator
+  a >> 499
+  expect-equals ">> 499" a.last-operator
+  a >>> 499
+  expect-equals ">>> 499" a.last-operator
+  a << 499
+  expect-equals "<< 499" a.last-operator
 
-  expect-equals "~" ~A
-  expect-equals "-" -A
+  ~a
+  expect-equals "~" a.last-operator
+  -a
+  expect-equals "-" a.last-operator

--- a/tests/type_propagation/gold/null-equals-test.gold
+++ b/tests/type_propagation/gold/null-equals-test.gold
@@ -33,8 +33,8 @@ main tests/type_propagation/null-equals-test.toit
  53[053] - invoke static A tests/type_propagation/null-equals-test.toit // [{A}] -> {A}
  56[042] - allocate instance A
  58[053] - invoke static A tests/type_propagation/null-equals-test.toit // [{A}] -> {A}
- 61[062] - invoke eq // [{A}, {A}] -> {String_}
- 62[053] - invoke static id tests/type_propagation/null-equals-test.toit // [{String_}] -> {String_}
+ 61[062] - invoke eq // [{A}, {A}] -> {True}
+ 62[053] - invoke static id tests/type_propagation/null-equals-test.toit // [{True}] -> {True}
  65[041] - pop 1
  66[042] - allocate instance A
  68[053] - invoke static A tests/type_propagation/null-equals-test.toit // [{A}] -> {A}
@@ -72,10 +72,10 @@ A.== tests/type_propagation/null-equals-test.toit
  - argument 0: {A}
  - argument 1: {*}
   0[052] - load local, as class, pop 2 - A(45 - 46) // {True|False}
-  2[020] - load literal hest
+  2[020] - load literal true
   4[089] - return S1 2
 
 id tests/type_propagation/null-equals-test.toit
- - argument 0: {String_|True|False}
+ - argument 0: {True|False}
   0[016] - load local 2
   1[089] - return S1 1

--- a/tests/type_propagation/gold/null-equals-test.gold-O2
+++ b/tests/type_propagation/gold/null-equals-test.gold-O2
@@ -33,8 +33,8 @@ main tests/type_propagation/null-equals-test.toit
  53[053] - invoke static A tests/type_propagation/null-equals-test.toit // [{A}] -> {A}
  56[042] - allocate instance A
  58[053] - invoke static A tests/type_propagation/null-equals-test.toit // [{A}] -> {A}
- 61[062] - invoke eq // [{A}, {A}] -> {String_}
- 62[053] - invoke static id tests/type_propagation/null-equals-test.toit // [{String_}] -> {String_}
+ 61[062] - invoke eq // [{A}, {A}] -> {True}
+ 62[053] - invoke static id tests/type_propagation/null-equals-test.toit // [{True}] -> {True}
  65[041] - pop 1
  66[042] - allocate instance A
  68[053] - invoke static A tests/type_propagation/null-equals-test.toit // [{A}] -> {A}
@@ -72,10 +72,10 @@ A.== tests/type_propagation/null-equals-test.toit
  - argument 0: {A}
  - argument 1: {*}
   0[052] - load local, as class, pop 2 - A(40 - 41) // {True|False}
-  2[020] - load literal hest
+  2[020] - load literal true
   4[089] - return S1 2
 
 id tests/type_propagation/null-equals-test.toit
- - argument 0: {String_|True|False}
+ - argument 0: {True|False}
   0[016] - load local 2
   1[089] - return S1 1

--- a/tests/type_propagation/null-equals-test.toit
+++ b/tests/type_propagation/null-equals-test.toit
@@ -19,7 +19,7 @@ obfuscate-null:
 
 class A:
   operator == other/A:
-    return "hest"
+    return true
 
 id x:
   return x


### PR DESCRIPTION
A `x == y` or `foo < bar` is now guaranteed to return a boolean type.