### PR TITLE
Fix assert in snapshot.toit.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   schedule:
     - cron: '00 2 * * *' # 02:00 UTC
-    - cron: '30 2 * * *'
-    - cron: '00 3 * * *'
   push:
     branches-ignore:
       - "wip/**"

--- a/tools/snapshot.toit
+++ b/tools/snapshot.toit
@@ -530,7 +530,10 @@ class ToitMethod:
 
   bci-from-absolute-bci absolute-bci/int -> int:
     bci := absolute-bci - id - HEADER-SIZE
-    assert: 0 <= bci < bytecodes.size
+    // For method calls the return-bci is just after the call. If a method
+    // is known not to return, then there might not be any bytecodes left and
+    // the bci is equal to the bytecode size.
+    assert: 0 <= bci <= bytecodes.size
     return bci
 
   absolute-bci-from-bci bci/int -> int:


### PR DESCRIPTION
This fixes the nightly run that runs with `-O2` and `--enable-asserts`.

Also run the slow test only once per night.