### PR TITLE
Remove the gpio library.

### DIFF
--- a/lib/gpio/gpio.toit
+++ b/lib/gpio/gpio.toit
@@ -1,7 +1,0 @@
-// Copyright (C) 2021 Toitware ApS. All rights reserved.
-// Use of this source code is governed by an MIT-style license that can be
-// found in the lib/LICENSE file.
-
-import .pin
-
-export *


### PR DESCRIPTION
The pin.toit library is moved to its location in a follow-up PR.