### PR TITLE
Set the MBEDTLS_ALLOW_PRIVATE_ACCESS flag all the time.

### DIFF
--- a/src/aes.h
+++ b/src/aes.h
@@ -17,6 +17,7 @@
 
 #include "top.h"
 
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
 #include <mbedtls/aes.h>
 
 #include "resource.h"
@@ -45,16 +46,16 @@ class AesContext : public SimpleResource {
 };
 
 /*
-  AES-CBC context class. 
+  AES-CBC context class.
   In addition to the base AES context,
-  this cipher type also needs an initialization 
+  this cipher type also needs an initialization
   vector.
 */
 class AesCbcContext : public AesContext {
  public:
   TAG(AesCbcContext);
   AesCbcContext(SimpleResourceGroup* group, const Blob* key, const uint8* iv, bool encrypt);
-  
+
   uint8 iv_[AES_BLOCK_SIZE];
 };
 

--- a/src/entropy_mixer.h
+++ b/src/entropy_mixer.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
 #include <mbedtls/error.h>
 #include <mbedtls/entropy.h>
 

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
 #include <mbedtls/aes.h>
 
 #include "top.h"

--- a/src/primitive_crypto.cc
+++ b/src/primitive_crypto.cc
@@ -21,6 +21,7 @@
 #define CONFIG_TOIT_CRYPTO_EXTRA 1
 #endif
 
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
 #include "mbedtls/gcm.h"
 #include "mbedtls/chachapoly.h"
 

--- a/src/resources/tls.h
+++ b/src/resources/tls.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/debug.h>
 #include <mbedtls/entropy.h>

--- a/src/resources/x509.h
+++ b/src/resources/x509.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
 #include <mbedtls/x509_crt.h>
 
 #include "../heap.h"

--- a/src/sha.h
+++ b/src/sha.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
 #include <mbedtls/sha256.h>
 #include <mbedtls/sha512.h>
 #if MBEDTLS_VERSION_MAJOR >= 3

--- a/src/snapshot_bundle.cc
+++ b/src/snapshot_bundle.cc
@@ -15,6 +15,7 @@
 
 #include "top.h"
 #include "uuid.h"
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
 #include <mbedtls/sha256.h>
 #if MBEDTLS_VERSION_MAJOR >= 3
 // Bring back the _ret names for sha functions.


### PR DESCRIPTION
This removes the warnings we get with link-time optimizations.
It's unfortunately also exposing all of the privates of mbedtls.

Ideally we would like to use `private_foo` members, so it's clear where we use non-public functionality. However, we need to import some private headers and these must have `MBEDTLS_ALLOW_PRIVATE_ACCESS` defined, which makes it impossible (or very hard) for us not to set it.

The difference between setting `MBEDTLS_ALLOW_PRIVATE_ACCESS` and not:
Without:
```
typedef struct mbedtls_entropy_context {
    mbedtls_md_context_t private_accumulator;
    int private_accumulator_started;
    int private_source_count;
    mbedtls_entropy_source_state private_source[20];
}
mbedtls_entropy_context;
```
With:
```
typedef struct mbedtls_entropy_context {
    mbedtls_md_context_t accumulator;
    int accumulator_started;
    int source_count;
    mbedtls_entropy_source_state source[20];
}
mbedtls_entropy_context;
```