### PR TITLE
Only run one CI per branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 on:
   schedule:
     - cron: '00 2 * * *' # 02:00 UTC


### PR DESCRIPTION
On the master, the current workflow is allowed to finish, but intermediate runs might be skipped.
On branches, the latest push cancels existing runs.