### PR TITLE
Add a getter for the level of a logger.

### DIFF
--- a/lib/log/log.toit
+++ b/lib/log/log.toit
@@ -152,7 +152,7 @@ class Logger:
       keys_ = keys
       values_ = values
 
-  /** Returns the level of the logger. */
+  /** The level of the logger. */
   level -> int:
     return level_
 

--- a/lib/log/log.toit
+++ b/lib/log/log.toit
@@ -152,6 +152,10 @@ class Logger:
       keys_ = keys
       values_ = values
 
+  /** Returns the level of the logger. */
+  level -> int:
+    return level_
+
   /** Adds the $name to a copy of this logger. */
   with-name name/string -> Logger:
     return Logger.internal_ this --name=name


### PR DESCRIPTION
Usecases:
 - Making a new logger or logging related service
   that is the same level as the current default
   logger.
 - Using the level of the default logger to decide
   at runtime how to construct logged strings.
   eg. If log level is debug or higher, I might
   include clickable URLs to further tools or
   resources.
