### PR TITLE
Use tab for the dependency file.

### DIFF
--- a/src/compiler/dep_writer.cc
+++ b/src/compiler/dep_writer.cc
@@ -105,7 +105,7 @@ void PlainDepWriter::generate_dependency_entry(const char* source, List<const ch
   write(source);
   write(":\n");
   for (auto dep : dependencies) {
-    write("  ");
+    write("\t");
     writeln(dep);
   }
 }


### PR DESCRIPTION
This makes it possible to use the plain dependency file as input for make.