### PR TITLE
Add UTF-8 manifest to all executables.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,6 +133,15 @@ endforeach()
 
 add_custom_target(build_boot_snapshot DEPENDS "${EMBEDDED_PROGRAM_SNAPSHOT_CC_toit}")
 
+if ("${TOIT_SYSTEM_NAME}" MATCHES "Windows" OR "${TOIT_SYSTEM_NAME}" MATCHES "MSYS")
+  add_library(utf8_manifest OBJECT
+    manifest.rc
+    manifest.xml
+  )
+  enable_language(RC)
+  set(UTF_8_MANIFEST_LIB utf8_manifest)
+endif()
+
 if (NOT "${TOIT_SYSTEM_NAME}" MATCHES "esp32")
   add_executable(
     toit
@@ -145,7 +154,6 @@ if (NOT "${TOIT_SYSTEM_NAME}" MATCHES "esp32")
   # Add the toit.{compile,run} as dependency, so we can start using the executable once it's built.
   # This doesn't include toit.pkg, though.
   add_dependencies(toit toit.compile toit.run)
-
   add_dependencies(build_tools toit)
 
   add_executable(
@@ -155,7 +163,6 @@ if (NOT "${TOIT_SYSTEM_NAME}" MATCHES "esp32")
     "${run_SRC}"
     )
   set_target_properties(toit.run PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/sdk/lib/toit/bin")
-
   add_dependencies(build_tools toit.run)
 
   add_executable(
@@ -163,13 +170,11 @@ if (NOT "${TOIT_SYSTEM_NAME}" MATCHES "esp32")
     toit_run_image.cc
     "${EMBEDDED_PROGRAM_IMAGE_CC_run_image}"
     )
-
-  add_dependencies(build_tools toit_run_image)
-
   set_target_properties(toit_run_image
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/run_image"
     )
+  add_dependencies(build_tools toit_run_image)
 endif()
 
 # On linux, we need to link statically against libgcc as well.
@@ -233,6 +238,11 @@ set(TOIT_LINK_LIBS
 target_link_libraries(
   toit_vm
   ${TOIT_WINDOWS_LIBS}
+)
+
+target_link_libraries(
+  toit_vm
+  ${UTF_8_MANIFEST_LIB}
 )
 
 if (NOT "${TOIT_SYSTEM_NAME}" MATCHES "esp32")

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(
   ${TOIT_COMPILER_STATIC}
   ${YAML_STATIC_LIB_NAME}
   ${SEMVER_STATIC_LIB_NAME}
+  ${UTF_8_MANIFEST_LIB}
   )
 
 add_executable(

--- a/src/manifest.rc
+++ b/src/manifest.rc
@@ -1,0 +1,2 @@
+#include <windows.h>
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "manifest.xml"

--- a/src/manifest.xml
+++ b/src/manifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
This instructs Windows (10+) to interact with the program in UTF-8.