### PR TITLE
Work around Windows manifest issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,8 @@ jobs:
         run: ccache -s
 
       - name: Enable link-time optimizations
-        if: env.DO_RELEASE == 'true'
+        # TODO(florian): we must not run any rebuild-cmake on Windows.
+        if: env.DO_RELEASE == 'true' && runner.os != 'Windows'
         run: |
           make enable-lto
 


### PR DESCRIPTION
Running cmake multiple times changes the CMakeCache.txt file and makes the manifest compilation not work. This is a temporary work-around until the real reason is determined.