### PR TITLE
Fix the runtime test for the ESP32S3.

### DIFF
--- a/tests/hw/esp-tester/mini-jag.toit
+++ b/tests/hw/esp-tester/mini-jag.toit
@@ -4,6 +4,7 @@
 
 import crypto.crc
 import esp32
+import expect show *
 import io
 import net
 import system.containers
@@ -21,6 +22,10 @@ main:
   print "Wakeup cause: $cause"
   // It looks like resetting the chip through the UART yields RESET-UNKNOWN.
   if cause == esp32.RESET-POWER-ON or cause == esp32.RESET-UNKNOWN:
+    // This check isn't necessary, but is hard to test within our tests.
+    // It just makes sure that the run-time is properly reset when the device is
+    // powered on through a reset.
+    expect esp32.total-run-time < 500_000  // 0.5s
     print "Clearing containers and waiting for new test"
     clear-containers
     with-client: | socket/tcp.Socket |

--- a/tests/hw/esp32/run-time-test.toit
+++ b/tests/hw/esp32/run-time-test.toit
@@ -25,11 +25,14 @@ test:
   if runtime-before-sleep:
     expect current-run-time-us > runtime-before-sleep
     diff := current-run-time-us - runtime-before-sleep
-    expect diff < 500_000  // 0.5s.
+    expect diff < 1_000_000  // 1s.
   else:
+    // We can't expect the current time to have a certain value, as the mini-jag
+    // (testing harness) might have delayed running the test.
+    // However, as of 2025-06-03 mini-jag has a check that the total-run-time is
+    // in a reasonable range.
     new-total := esp32.total-run-time
     expect new-total > current-run-time-us
-    // expect new-total < 500_000  // 0.5s
     bucket[RUNTIME-KEY] = new-total
     bucket.close
     // By going into deep sleep we don't return to the `run-test` function


### PR DESCRIPTION
Turns out the ESP32S3 needs to than 500ms to go through the mini-jag and then start the test.