### PR TITLE
Fix toit decode without a snapshot.

### DIFF
--- a/tools/system_message.toit
+++ b/tools/system_message.toit
@@ -141,7 +141,7 @@ decode invocation/cli.Invocation -> none:
 
   snapshot-content := null
   if snapshot-path:
-    snapshot-content = file.read-contents invocation["snapshot"]
+    snapshot-content = file.read-contents snapshot-path
 
   if encoded-system-message.size < 1 or encoded-system-message[0] != '[':
     pipe.print-to-stderr "\nNot a ubjson message: '$invocation["message"]'\n"


### PR DESCRIPTION
We were looking up the snapshot in the state directory and then not using it.