### PR TITLE
A few more renames from toit.pkg to 'toit pkg'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ You should then be able to execute a toit file:
 build/host/sdk/bin/toit examples/hello.toit
 ```
 
-The package manager is found at `build/host/sdk/bin/toit.pkg`:
+The `toit` executable also serves as package manager:
 
 ``` sh
 build/host/sdk/bin/toit pkg init --project-root=<some-directory>

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -5,7 +5,7 @@ This example shows how to do simple HTTP operations.
 It uses a package which needs to be installed first:
 
 ```
-../../build/host/sdk/bin/toit.pkg install
+../../build/host/sdk/bin/toit pkg install
 ```
 
 in the examples/http folder.

--- a/examples/ntp/README.md
+++ b/examples/ntp/README.md
@@ -5,7 +5,7 @@ This example shows how to synchronize time using the NTP protocol.
 It uses a package which needs to be installed first, so run:
 
 ``` sh
-../../build/host/sdk/bin/toit.pkg install
+../../build/host/sdk/bin/toit pkg install
 ```
 
 in the examples/ntp folder.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -152,8 +152,10 @@ if (NOT "${TOIT_SYSTEM_NAME}" MATCHES "esp32")
     )
   set_target_properties(toit PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/sdk/bin")
   # Add the toit.{compile,run} as dependency, so we can start using the executable once it's built.
-  # This doesn't include toit.pkg, though.
-  add_dependencies(toit toit.compile toit.run)
+  # As soon as the 'toit' executable is built, it might be used to call `toit pkg` in
+  # which case the `toit.pkg` executable is needed. That's why we add the `build_go_tools`
+  # dependency.
+  add_dependencies(toit toit.compile toit.run build_go_tools)
   add_dependencies(build_tools toit)
 
   add_executable(

--- a/tools/pkg/project/project.toit
+++ b/tools/pkg/project/project.toit
@@ -57,7 +57,7 @@ class ProjectConfiguration:
     if not project-root_ and not specification-file-exists:
       ui_.abort """
           Command must be executed in project root.
-          Run 'toit.pkg init' first to create a new application here, or
+          Run 'toit pkg init' first to create a new application here, or
             run with '--$OPTION-PROJECT-ROOT=.'
           """
 


### PR DESCRIPTION
Also a fix where `toit` was built and then used as `toit pkg` but `toit.pkg` wasn't ready yet.