### PR TITLE
Add TRACE log level

### DIFF
--- a/lib/log/level.toit
+++ b/lib/log/level.toit
@@ -2,13 +2,15 @@
 // Use of this source code is governed by an MIT-style license that can be
 // found in the lib/LICENSE file.
 
-DEBUG-LEVEL ::= 0
-INFO-LEVEL  ::= 1
-WARN-LEVEL  ::= 2
-ERROR-LEVEL ::= 3
-FATAL-LEVEL ::= 4
+TRACE-LEVEL ::= 0
+DEBUG-LEVEL ::= 1
+INFO-LEVEL  ::= 2
+WARN-LEVEL  ::= 3
+ERROR-LEVEL ::= 4
+FATAL-LEVEL ::= 5
 
 level-name level/int -> string:
+  if level == TRACE-LEVEL: return "TRACE"
   if level == DEBUG-LEVEL: return "DEBUG"
   if level == INFO-LEVEL: return "INFO"
   if level == WARN-LEVEL: return "WARN"

--- a/lib/log/log.toit
+++ b/lib/log/log.toit
@@ -12,9 +12,10 @@ Logging support.
 
 Each application has a default logger, $default, that is global to the
   application. By default it is set to log all messages at $DEBUG-LEVEL.
+  To log all messages including trace, set the level to $TRACE-LEVEL.
 
-Messages on the default logger are created by calling $log, $debug,
-  $info, $warn, $error or $fatal. The same functions exist as
+Messages on the default logger are created by calling $log, $trace,
+  $debug, $info, $warn, $error or $fatal. The same functions exist as
   methods on the $Logger class as well.
 
 Instead of creating strings that contain context relevant information,
@@ -68,6 +69,14 @@ Includes the given $tags in the log message.
 */
 log level/int message/string --tags/Map?=null -> none:
   default_.log level message --tags=tags
+
+/**
+Logs the $message to the default logger at trace level ($TRACE-LEVEL).
+
+Includes the given $tags in the log message.
+*/
+trace message/string --tags/Map?=null -> none:
+  default_.log TRACE-LEVEL message --tags=tags
 
 /**
 Logs the $message to the default logger at debug level ($DEBUG-LEVEL).
@@ -194,6 +203,14 @@ class Logger:
     merge-tags_ tags keys_ values_: | keys/List? values/List? |
       target_.log level message names_ keys values
     if level == FATAL-LEVEL: throw "FATAL"
+
+  /**
+  Logs the $message at trace level ($TRACE-LEVEL).
+
+  Includes the given $tags in the log message.
+  */
+  trace message/string --tags/Map?=null -> none:
+    log TRACE-LEVEL message --tags=tags
 
   /**
   Logs the $message at debug level ($DEBUG-LEVEL).


### PR DESCRIPTION
TRACE is a commonly accepted log level these days.
So allow users to use it directly.
These logs will not be logged by defualt, as the
default level is DEBUG.
