### PR TITLE
Make the master key optional for ESP-NOW services.

### DIFF
--- a/lib/esp32/espnow.toit
+++ b/lib/esp32/espnow.toit
@@ -236,7 +236,7 @@ class Service:
 
   The $channel parameter must be a valid Wi-Fi channel number.
   */
-  constructor.station --key/Key? --rate/int=RATE-1M-L --.channel=6:
+  constructor.station --key/Key?=null --rate/int=RATE-1M-L --.channel=6:
     if not 0 < channel <= 14: throw "INVALID_ARGUMENT"
 
     key-data := key ? key.data : #[]


### PR DESCRIPTION
The key could already be null, but it was required to provide it.