### PR TITLE
Use the VM version when calling 'toit version'.

### DIFF
--- a/tools/toit.toit
+++ b/tools/toit.toit
@@ -84,7 +84,7 @@ main args/List:
         cli.Option "output" --short-name="o" --hidden
       ]
       --run=:: | invocation/cli.Invocation |
-        invocation.cli.ui.emit --result system.app-sdk-version
+        invocation.cli.ui.emit --result system.vm-sdk-version
   root-command.add version-command
 
   compile-analyze-run-options := [


### PR DESCRIPTION
Normally, the app and vm version of the 'toit' executable should be the same, but during development, the 'toit' snapshot is sometimes not rebuilt. In that case we want to report the VM version.