### PR TITLE
Allow multiple services/characteristics with the same uuid.

### DIFF
--- a/lib/ble/local.toit
+++ b/lib/ble/local.toit
@@ -167,7 +167,6 @@ class LocalService extends Resource_ implements Attribute:
 
   constructor .peripheral-manager .uuid:
     if peripheral-manager.deployed_: throw "Peripheral is already deployed"
-    if (peripheral-manager.services_.any: it.uuid == uuid): throw "Service already exists"
     resource := ble-add-service_ peripheral-manager.resource_ uuid.encode-for-platform_
     super resource
 
@@ -384,7 +383,6 @@ class LocalCharacteristic extends LocalReadWriteElement_ implements Attribute:
 
   constructor .service .uuid .properties .permissions value/io.Data? .read-timeout-ms_:
     if service.peripheral-manager.deployed: throw "Peripheral is already deployed"
-    if (service.characteristics_.any: it.uuid == uuid): throw "Characteristic already exists"
     resource := ble-add-characteristic_ service.resource_ uuid.encode-for-platform_ properties permissions value
     super resource
 
@@ -556,6 +554,18 @@ class LocalCharacteristic extends LocalReadWriteElement_ implements Attribute:
     descriptor := LocalDescriptor this uuid properties permissions value
     descriptors_.add descriptor
     return descriptor
+
+  /**
+  Adds a read-only descriptor to this characteristic.
+  $uuid is the uuid of the descriptor
+  If $secure is specified, the descriptor requires encryption.
+  The peripheral must not yet be deployed.
+  */
+  add-descriptor uuid/BleUuid --value/io.Data --secure/bool=false -> LocalDescriptor:
+    return add-descriptor uuid
+        --properties=CHARACTERISTIC-PROPERTY-READ | CHARACTERISTIC-PROPERTY-WRITE
+        --permissions=(secure ? CHARACTERISTIC-PERMISSION-READ-ENCRYPTED : CHARACTERISTIC-PERMISSION-READ)
+        --value=value
 
   /**
   The handle of the characteristic.

--- a/lib/ble/local.toit
+++ b/lib/ble/local.toit
@@ -556,8 +556,7 @@ class LocalCharacteristic extends LocalReadWriteElement_ implements Attribute:
     return descriptor
 
   /**
-  Adds a read-only descriptor to this characteristic.
-  $uuid is the uuid of the descriptor
+  Adds a read-only descriptor to this characteristic with the given $uuid.
   If $secure is specified, the descriptor requires encryption.
   The peripheral must not yet be deployed.
   */

--- a/tests/hw/esp32/ble7-duplicate-board1.toit
+++ b/tests/hw/esp32/ble7-duplicate-board1.toit
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+// WIRELESS
+
+/**
+See 'ble7-advertise-shared.toit'
+*/
+
+import .ble7-duplicate-shared as shared
+
+main:
+  shared.main-peripheral

--- a/tests/hw/esp32/ble7-duplicate-board2.toit
+++ b/tests/hw/esp32/ble7-duplicate-board2.toit
@@ -1,0 +1,12 @@
+// Copyright (C) 2025 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+/**
+See 'ble7-duplicate-shared.toit'
+*/
+
+import .ble7-duplicate-shared as shared
+
+main:
+  shared.main-central

--- a/tests/hw/esp32/ble7-duplicate-shared.toit
+++ b/tests/hw/esp32/ble7-duplicate-shared.toit
@@ -1,0 +1,126 @@
+// Copyright (C) 2025 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+/**
+Tests that there can be multiple services with the same UUID.
+Similarly, test, that there can be multiple characteristics with the same UUID.
+
+Run `ble7-duplicate-board1.toit` on board1, first.
+Once that one is running, run `ble7-duplicate-board2.toit` on board2.
+*/
+
+import ble show *
+import expect show *
+import monitor
+
+import .ble-util
+import .test
+import .variants
+
+TEST-SERVICE ::= BleUuid Variant.CURRENT.ble7-service
+TEST-CHARACTERISTIC ::= BleUuid "788e77dc-28df-43d1-b40e-eca5c4f551a3"
+TEST-DESCRIPTOR ::= BleUuid "505f69ff-f90c-49d2-af8c-84cd47fdb8ff"
+
+DONE-CHARACTERISTIC ::= BleUuid "f975accd-c715-46e6-9458-1cac128dacb5"
+
+main-peripheral:
+  run-test: test-peripheral
+
+test-peripheral:
+  adapter := Adapter
+  peripheral := adapter.peripheral
+
+  service := peripheral.add-service TEST-SERVICE
+  characteristic1_1 := service.add-read-only-characteristic
+      TEST-CHARACTERISTIC
+      --value=#[11]
+  characteristic1_1.add-descriptor TEST-DESCRIPTOR --value=#[1, 1]
+  characteristic1_2 := service.add-read-only-characteristic
+      TEST-CHARACTERISTIC
+      --value=#[12]
+  characteristic1_2.add-descriptor TEST-DESCRIPTOR --value=#[1, 2]
+
+  service2 := peripheral.add-service TEST-SERVICE
+  characteristic2_1 := service2.add-read-only-characteristic
+      TEST-CHARACTERISTIC
+      --value=#[21]
+  characteristic2_1.add-descriptor TEST-DESCRIPTOR --value=#[2, 1]
+  characteristic2_2 := service2.add-read-only-characteristic
+      TEST-CHARACTERISTIC
+      --value=#[22]
+  characteristic2_2.add-descriptor TEST-DESCRIPTOR --value=#[2, 2]
+
+  done := service.add-write-only-characteristic DONE-CHARACTERISTIC
+
+  peripheral.deploy
+
+  advertisement := Advertisement
+      --name="Test"
+      --services=[TEST-SERVICE]
+
+  peripheral.start-advertise --connection-mode=BLE-CONNECT-MODE-UNDIRECTIONAL advertisement
+
+  done.read
+
+  peripheral.close
+  adapter.close
+
+  print "done"
+
+scan identifier/ByteArray --central/Central -> RemoteScannedDevice:
+  central.scan --duration=(Duration --s=3): | device/RemoteScannedDevice |
+    if device.identifier == identifier:
+      return device
+  throw "Device not found"
+
+main-central:
+  run-test: test-central
+
+test-central:
+  adapter := Adapter
+  central := adapter.central
+
+  identifier := find-device-with-service central TEST-SERVICE
+
+  remote-device := central.connect identifier
+  all-services := remote-device.discover-services
+  test-services := []
+  all-services.do: | service/RemoteService |
+    if service.uuid == TEST-SERVICE:
+      test-services.add service
+
+  expect-equals 2 test-services.size
+
+  done/RemoteCharacteristic? := null
+  characteristics-values := {:}
+  test-services.do: | service/RemoteService |
+    characteristics := service.discover-characteristics
+    characteristics.do: | characteristic/RemoteCharacteristic |
+      if characteristic.uuid == DONE-CHARACTERISTIC:
+        done = characteristic
+      if characteristic.uuid == TEST-CHARACTERISTIC:
+        value := characteristic.read
+        descriptors := characteristic.discover-descriptors
+        descriptors.do: | descriptor/RemoteDescriptor |
+          if descriptor.uuid == TEST-DESCRIPTOR:
+            characteristics-values[value] = descriptor.read
+
+  expect-equals 4 characteristics-values.size
+  keys := characteristics-values.keys.map: it[0]
+  expect-equals [11, 12, 21, 22] keys.sort
+  expect-equals #[1, 1] characteristics-values[#[11]]
+  values := characteristics-values.values
+  [
+    #[1, 1],
+    #[1, 2],
+    #[2, 1],
+    #[2, 2],
+  ].do: | expected/ByteArray |
+    expect (values.contains expected)
+
+  done.write #[100]
+
+  remote-device.close
+  central.close
+  adapter.close

--- a/tests/hw/esp32/variants.toit
+++ b/tests/hw/esp32/variants.toit
@@ -112,6 +112,8 @@ abstract class Variant:
 
   abstract ble6-service -> string
 
+  abstract ble7-service -> string
+
   /**
   The ESP-NOW channel and password.
 
@@ -453,6 +455,8 @@ class Esp32 extends Variant:
 
   ble6-service ::= "eede145e-b6a6-4d61-8156-ed10d5b75903"
 
+  ble7-service ::= "2c099659-d917-41a2-955d-18a4966b54c8"
+
   espnow-channel ::= 1
   espnow-password ::= "pmk-esp32-123456"
 
@@ -553,6 +557,8 @@ class Esp32s3 extends Variant:
   ble5-service ::= "ef738562-e999-482d-88a1-16ea26fa18d3"
 
   ble6-service ::= "eed6e6d2-6f4f-46e4-9ed2-116515189eba"
+
+  ble7-service ::= "0c9b0be3-1612-447d-ba1e-ab7293a3c795"
 
   espnow-channel ::= 5
   espnow-password ::= "pmk-esp32s3-1234"


### PR DESCRIPTION
In theory it could be possible to also allow duplicate descriptors under each characteristic, but that's just asking for troubles.

Also make it nicer to add a read-only descriptor (which is the most common one).