### PR TITLE
Use FILE_NOT_FOUND for more Windows errors.

### DIFF
--- a/src/error_win.cc
+++ b/src/error_win.cc
@@ -32,7 +32,10 @@ static Object* custom_error(Process* process, const char* txt) {
 Object* windows_error(Process* process, DWORD error_number) {
   DWORD err = GetLastError();
   if (err == ERROR_FILE_NOT_FOUND ||
+      err == ERROR_PATH_NOT_FOUND ||
+      err == ERROR_INVALID_NAME ||
       err == ERROR_INVALID_DRIVE ||
+      err == ERROR_DIRECTORY ||
       err == ERROR_DEV_NOT_EXIST) {
     FAIL(FILE_NOT_FOUND);
   }


### PR DESCRIPTION
This aligns the errors with the Posix versions.

Note that the error is not great: `rmdir "not-found"` or `rmdir "not-dir-but-file"` now throw "FILE_NOT_FOUND", but that's what the Posix versions do.