### PR TITLE
Make it easier to build and flash with jag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ compile_commands.json
 *_mock.go
 tedi_test.go
 /third_party/benchmarks/java/*.class
+wifi.json
 
 **/node_modules/
 /tools/lsp/client/npm-debug.log

--- a/README.md
+++ b/README.md
@@ -314,18 +314,18 @@ in `build/esp32/firmware.envelope`:
 make esp32
 ```
 
-If you want to flash the generated firmware on your device, you can use the `firmware`
-too. Internally, the `firmware` tool calls out to
-[esptool](https://github.com/espressif/esptool)
-so you need to install that one first.
-You can also set the environment variable `ESPTOOL_PATH` to point
-to a valid esptool (for example the one in the shipped esp-idf:
-`export ESPTOOL_PATH=$PWD/third_party/esp-idf/components/esptool_py/esptool/esptool.py`).
-Assuming your device is connected through `/dev/ttyUSB0`
-you can then flash a device as follows:
+For other chip variants use the corresponding make target. For example, for the ESP32-C6 which would generate in `build/esp32c6/firmware.envelope`:
 
 ``` sh
-build/host/sdk/lib/toit/tool firmware -e build/esp32/firmware.envelope \
+make esp32c6
+```
+
+If you want to flash the generated firmware on your device, you can use the `firmware`
+tool. Internally it calls the bundled esptool from the esp-idf submodule.
+You can override this with the `ESPTOOL_PATH` environment variable if you want to use a different version of esptool.
+
+``` sh
+build/host/sdk/bin/toit tool firmware -e build/esp32/firmware.envelope \
     flash --port /dev/ttyUSB0 --baud 921600
 ```
 
@@ -339,6 +339,39 @@ build/host/sdk/bin/toit tool firmware -e build/esp32/firmware.envelope \
 build/host/sdk/bin/toit tool firmware -e build/esp32/firmware.envelope \
     flash --port /dev/ttyUSB0 --baud 921600
 ```
+
+### Flashing with Jaguar (live reloading)
+
+To run Jaguar on your locally built firmware, compile the Jaguar service snapshot
+using your SDK (so the versions match) and install it as a container before flashing.
+The Jaguar source lives in [toitlang/jaguar](https://github.com/toitlang/jaguar).
+Set `JAG_PATH` to its location, or leave it unset to default to `../jaguar`
+(i.e. checked out alongside this repo):
+
+``` sh
+JAG_PATH=${JAG_PATH:-../jaguar}
+
+# Install jaguar's dependencies and compile its service snapshot
+build/host/sdk/bin/toit pkg --project-root="$JAG_PATH" install
+build/host/sdk/bin/toit compile -O2 --snapshot \
+    -o /tmp/jaguar.snapshot "$JAG_PATH/src/jaguar.toit"
+
+# Add jaguar to the firmware envelope
+build/host/sdk/bin/toit tool firmware \
+    -e build/esp32c6/firmware.envelope \
+    container install -o /tmp/firmware-jaguar.envelope \
+    jaguar /tmp/jaguar.snapshot
+
+# Flash with WiFi credentials
+# echo '{ "wifi": { "wifi.ssid": "YourSSID", "wifi.password": "YourPassword" } }' > wifi.json
+build/host/sdk/bin/toit tool firmware \
+    -e /tmp/firmware-jaguar.envelope \
+    flash --config wifi.json --port /dev/ttyACM0 --baud 921600
+```
+
+> **Note:** The jaguar snapshot must be compiled with the same SDK version as the
+> firmware envelope. `jag flash` alone uses jag's pre-built snapshot which is pinned
+> to a release tag and will not match a local dev build's version suffix.
 
 ### Adding multiple containers
 

--- a/tools/firmware.toit
+++ b/tools/firmware.toit
@@ -1116,21 +1116,9 @@ flash invocation/cli.Invocation -> none:
 
           esptool := find-esptool_
 
-          // The new esptool has deprecated underscores in some arguments.
-          // TODO(floitsch): remove these replacements when the esp-idf has been updated
-          //   to a version that uses the new arguments.
           before-args := flashing["extra_esptool_args"]["before"]
           after-args := flashing["extra_esptool_args"]["after"]
           write-flash-args := flashing["write_flash_args"]
-          before-args = before-args.replace --all "default_reset" "default-reset"
-          before-args = before-args.replace --all "no_reset" "no-reset"
-          after-args = after-args.replace --all "hard_reset" "hard-reset"
-          after-args = after-args.replace --all "no_reset" "no-reset"
-          write-flash-args.map --in-place:
-            if it == "--flash_mode": "--flash-mode"
-            else if it == "--flash_size": "--flash-size"
-            else if it == "--flash_freq": "--flash-freq"
-            else: it
 
           code := pipe.run-program esptool + [
             "--port", port,
@@ -1138,7 +1126,7 @@ flash invocation/cli.Invocation -> none:
             "--chip", chip,
             "--before", before-args,
             "--after", after-args
-          ] + [ "write-flash" ] + write-flash-args + partition-args
+          ] + [ "write_flash" ] + write-flash-args + partition-args
           if code != 0: exit 1
         finally:
           directory.rmdir --recursive tmp


### PR DESCRIPTION
I once again found myself wanting to poke the toit code with an app runnable via
jaguar, and encountered some issue while following the README, but to me it's all
very nice and eacy to follow and or copy and paste now!

Changes:

README: Hints about other chip builds
README: Hints about other port formats
README: Section on "Flashing with Jaguar (live reloading)"
README: remove external esptool download/ESPTOOL_PATH workaround?

Remove underscore→hyphen conversion in firmware.toit so bundled esptool v4.x works
Rebuild SDK and verify flashing with bundled esptool
