### PR TITLE
Use newer pkg-cli with typed options and default command support

### DIFF
--- a/examples/http/package.lock
+++ b/examples/http/package.lock
@@ -1,9 +1,9 @@
-sdk: ^2.0.0-alpha.170
+sdk: ^2.0.0-alpha.190
 prefixes:
   http: pkg-http
 packages:
   pkg-http:
     url: github.com/toitlang/pkg-http
     name: http
-    version: 2.11.0
-    hash: d2cdc57270eaafe8df8d8403bf4ebf95415aa0fd
+    version: 2.12.0
+    hash: b68f3f4a3c26bfdff2beca4fb5ac7bc182f20270

--- a/examples/http/package.yaml
+++ b/examples/http/package.yaml
@@ -1,4 +1,4 @@
 dependencies:
   http:
     url: github.com/toitlang/pkg-http
-    version: ^2.11.0
+    version: ^2.12.0

--- a/tests/hw/esp-tester/package.lock
+++ b/tests/hw/esp-tester/package.lock
@@ -7,8 +7,8 @@ packages:
   pkg-cli:
     url: github.com/toitlang/pkg-cli
     name: cli
-    version: 2.7.1
-    hash: 8376719abcede80c26dae3430da4ddd65de9e63f
+    version: 2.14.0
+    hash: ec895eedf75ad24f944a3c158e8b5c0624609b8a
     prefixes:
       desktop: pkg-desktop
       fs: pkg-fs

--- a/tests/hw/esp-tester/package.yaml
+++ b/tests/hw/esp-tester/package.yaml
@@ -1,7 +1,7 @@
 dependencies:
   cli:
     url: github.com/toitlang/pkg-cli
-    version: ^2.7.1
+    version: ^2.14.0
   fs:
     url: github.com/toitlang/pkg-fs
     version: ^2.3.1

--- a/tests/package.lock
+++ b/tests/package.lock
@@ -17,8 +17,8 @@ packages:
   pkg-cli:
     url: github.com/toitlang/pkg-cli
     name: cli
-    version: 2.7.1
-    hash: 8376719abcede80c26dae3430da4ddd65de9e63f
+    version: 2.14.0
+    hash: ec895eedf75ad24f944a3c158e8b5c0624609b8a
     prefixes:
       desktop: pkg-desktop
       fs: pkg-fs

--- a/tests/package.yaml
+++ b/tests/package.yaml
@@ -7,7 +7,7 @@ dependencies:
     version: ^1.11.0
   cli:
     url: github.com/toitlang/pkg-cli
-    version: ^2.7.1
+    version: ^2.14.0
   font_x11_adobe:
     url: github.com/toitlang/pkg-font-x11-adobe
     version: ^0.1.0

--- a/tests/pkg/package.lock
+++ b/tests/pkg/package.lock
@@ -1,4 +1,4 @@
-sdk: ^2.0.0-alpha.189
+sdk: ^2.0.0-alpha.190
 prefixes:
   certificate_roots: toit-cert-roots
   cli: pkg-cli
@@ -9,8 +9,8 @@ packages:
   pkg-cli:
     url: github.com/toitlang/pkg-cli
     name: cli
-    version: 2.7.1
-    hash: 8376719abcede80c26dae3430da4ddd65de9e63f
+    version: 2.14.0
+    hash: ec895eedf75ad24f944a3c158e8b5c0624609b8a
     prefixes:
       desktop: pkg-desktop
       fs: pkg-fs
@@ -38,8 +38,8 @@ packages:
   pkg-http:
     url: github.com/toitlang/pkg-http
     name: http
-    version: 2.11.0
-    hash: d2cdc57270eaafe8df8d8403bf4ebf95415aa0fd
+    version: 2.12.0
+    hash: b68f3f4a3c26bfdff2beca4fb5ac7bc182f20270
   toit-cert-roots:
     url: github.com/toitware/toit-cert-roots
     name: certificate-roots

--- a/tests/pkg/package.yaml
+++ b/tests/pkg/package.yaml
@@ -4,7 +4,7 @@ dependencies:
     version: ^1.11.0
   cli:
     url: github.com/toitlang/pkg-cli
-    version: ^2.7.1
+    version: ^2.14.0
   fs:
     url: github.com/toitlang/pkg-fs
     version: ^2.3.1
@@ -13,4 +13,4 @@ dependencies:
     version: ^1.17.0
   http:
     url: github.com/toitlang/pkg-http
-    version: ^2.11.0
+    version: ^2.12.0

--- a/tests/toit/CMakeLists.txt
+++ b/tests/toit/CMakeLists.txt
@@ -18,8 +18,6 @@ file(GLOB ASSERT_TESTS "assert*-test.toit")
 
 include(fail.cmake OPTIONAL)
 
-set(TEST_SDK_DIR "${CMAKE_BINARY_DIR}/sdk")
-set(TOIT_BIN_SOURCE "${TOIT_SDK_SOURCE_DIR}/tools/toit.toit")
 
 set(ASSERT_IS_OVERRIDDEN FALSE)
 if (DEFINED ENV{TOIT_ASSERT_OVERRIDE})
@@ -43,7 +41,7 @@ foreach(file ${TOIT_BIN_TESTS})
 
     add_test(
       NAME ${TEST_EXPECTATION_NAME}
-      COMMAND $<TARGET_FILE:toit.run> ${file} $<TARGET_FILE:toit.run> ${TOIT_BIN_SOURCE} ${TEST_SDK_DIR}
+      COMMAND $<TARGET_FILE:toit.run> ${file} $<TARGET_FILE:toit>
       )
     set_tests_properties(${TEST_EXPECTATION_NAME} PROPERTIES TIMEOUT ${SLOW_TIMEOUT})
     if ("${toit_bin_test_name}" IN_LIST TOIT_FAILING_TESTS)

--- a/tests/toit/default-command-test.toit
+++ b/tests/toit/default-command-test.toit
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+import host.file
+import host.pipe
+
+import .utils
+
+main args:
+  toit-exe := ToitExecutable args
+
+  with-tmp-dir: | tmp-dir/string |
+    src-path := "$tmp-dir/hello.toit"
+    file.write-contents --path=src-path """
+      main args:
+        args.do: print it
+      """
+
+    // Test: `toit -- hello.toit arg1 arg2` should run the file with args.
+    output := toit-exe.backticks ["--", src-path, "arg1", "arg2"]
+    expect (output.contains "arg1")
+    expect (output.contains "arg2")
+
+    // Test: `toit -- hello.toit` with no extra args.
+    output = toit-exe.backticks ["--", src-path]
+    // Should succeed without error.
+
+    // Test: bare `toit --` with no source file.
+    fork-result := toit-exe.fork ["--"]
+    expect-not-equals 0 fork-result.exit-code
+    combined := fork-result.stdout + fork-result.stderr
+    expect (combined.contains "Missing source file after")
+
+    // Test: invalid first argument that is not a command or source file.
+    fork-result = toit-exe.fork ["not-a-command"]
+    expect-not-equals 0 fork-result.exit-code
+    combined = fork-result.stdout + fork-result.stderr
+    expect (combined.contains "Unknown command or invalid source file")

--- a/tests/toit/lsp-test.toit
+++ b/tests/toit/lsp-test.toit
@@ -12,12 +12,10 @@ import ...tools.lsp.server.client show with-lsp-client LspClient
 main args:
   toit-exe := ToitExecutable args
 
-  toit-run := args[0]
-  toit-exe-src := args[1]
-  sdk-dir := args[2]
+  toit-binary := args[0]
 
-  server-cmd := toit-run
-  server-args := [toit-exe-src, "tool", "lsp", "--sdk-dir", sdk-dir]
+  server-cmd := toit-binary
+  server-args := ["tool", "lsp"]
   client := LspClient.start
       server-cmd
       server-args

--- a/tests/toit/utils.toit
+++ b/tests/toit/utils.toit
@@ -28,37 +28,24 @@ class ForkResult:
       --.exit-code:
 
 class ToitExecutable:
-  toit-run_/string
-  toit-bin-src_/string
-  sdk-dir_/string
+  toit-exe_/string
 
   constructor args/List:
-    toit-run_ = args[0]
-    toit-bin-src_ = args[1]
-    sdk-dir_ = args[2]
+    toit-exe_ = args[0]
 
-  backticks --with-test-sdk/bool=true args/List:
-    full-command := [toit_run_, toit-bin-src_]
-    if with-test-sdk:
-      full-command += ["--sdk-dir", sdk-dir_]
-    full-command += args
+  backticks args/List:
+    full-command := [toit-exe_] + args
     result := pipe.backticks full-command
     if system.platform == system.PLATFORM-WINDOWS:
       return result.replace --all "\r\n" "\n"
     return result
 
-  run --with-test-sdk/bool=true args/List -> int:
-    full-command := [toit_run_, toit-bin-src_]
-    if with-test-sdk:
-      full-command += ["--sdk-dir", sdk-dir_]
-    full-command += args
+  run args/List -> int:
+    full-command := [toit-exe_] + args
     return pipe.run-program full-command
 
-  fork --with-test-sdk/bool=true args/List -> ForkResult:
-    full-command := [toit_run_, toit-bin-src_]
-    if with-test-sdk:
-      full-command += ["--sdk-dir", sdk-dir_]
-    full-command += args
+  fork args/List -> ForkResult:
+    full-command := [toit-exe_] + args
     process := pipe.fork
         --use-path
         --create-stdout

--- a/tests/toit/version-test.toit
+++ b/tests/toit/version-test.toit
@@ -14,10 +14,8 @@ main args:
   expect-equals "$system.vm-sdk-version\n" version
 
   // The '--version' flag is special-cased in the 'toit' executable.
-  // It must be the first argument. As such, we can have any '--sdk-version'
-  // before it. The '--no-with-test-sdk' make sure we don't any additional
-  // options when calling the binary.
-  dash-version := toit-exe.backticks --no-with-test-sdk ["--version"]
+  // It must be the first argument.
+  dash-version := toit-exe.backticks ["--version"]
   expect-equals "$system.vm-sdk-version\n" dash-version
 
   deprecated-short-version := toit-exe.backticks ["version", "-o", "short"]

--- a/tools/assets.toit
+++ b/tools/assets.toit
@@ -28,10 +28,9 @@ OPTION-ASSETS       ::= "assets"
 OPTION-OUTPUT       ::= "output"
 OPTION-OUTPUT-SHORT ::= "o"
 
-option-output ::= cli.Option OPTION-OUTPUT
+option-output ::= cli.OptionPath OPTION-OUTPUT
     --short-name=OPTION-OUTPUT-SHORT
     --help="Set the output assets file."
-    --type="file"
 
 main arguments/List:
   root-cmd := build-command
@@ -54,10 +53,9 @@ build-command -> cli.Command:
               print decoded["my-asset"]
         """
       --options=[
-        cli.Option OPTION-ASSETS
+        cli.OptionPath OPTION-ASSETS
             --short-name="e"
             --help="The assets to work on."
-            --type="file"
             --required
       ]
   cmd.add create-cmd
@@ -89,8 +87,7 @@ add-cmd -> cli.Command:
       --rest=[
         cli.Option "name"
             --required,
-        cli.Option "path"
-            --type="file"
+        cli.OptionPath "path"
             --required
       ]
       --run=:: add-asset it
@@ -122,10 +119,9 @@ get-cmd -> cli.Command:
         cli.OptionEnum "format" ["auto", "binary", "ubjson", "tison"]
             --default="auto"
             --help="The encoding format.",
-        cli.Option "output"
+        cli.OptionPath "output"
             --short-name="o"
             --help="The name of the output file."
-            --type="file"
             --required,
       ]
       --rest=[

--- a/tools/dump_types.toit
+++ b/tools/dump_types.toit
@@ -18,7 +18,6 @@
 import cli
 import encoding.base64 as base64
 import encoding.json
-import host.file
 import host.pipe
 import .snapshot
 
@@ -32,12 +31,12 @@ main args:
       Then use the generated snapshot and types for this tool.
       """
       --options=[
-        cli.Option "snapshot" --required --short-name="s"
+        cli.OptionInFile "snapshot" --required --short-name="s"
             --help="The snapshot file for the program."
-            --type="file",
-        cli.Option "types" --required --short-name="t"
+            --extensions=[".snapshot"],
+        cli.OptionInFile "types" --required --short-name="t"
             --help="The collected types in a JSON file."
-            --type="file",
+            --extensions=[".json"],
         cli.Flag "sdk"
             --help="Show types for the sdk."
             --default=false,
@@ -48,8 +47,10 @@ main args:
   command.run args
 
 decode-types invocation/cli.Invocation -> none:
-  snapshot-content := file.read-contents invocation["snapshot"]
-  types-content := file.read-contents invocation["types"]
+  snapshot-in/cli.InFile := invocation["snapshot"]
+  types-in/cli.InFile := invocation["types"]
+  snapshot-content := snapshot-in.read-contents
+  types-content := types-in.read-contents
   types := json.decode types-content
   show-types types snapshot-content
       --sdk=invocation["sdk"]

--- a/tools/firmware.toit
+++ b/tools/firmware.toit
@@ -135,10 +135,9 @@ build-command --create-esp32-only/bool=false -> cli.Command:
         This command can be used to create, inspect, extract, and manipulate envelopes.
         """
       --options=[
-        cli.Option OPTION-ENVELOPE
+        cli.OptionPath OPTION-ENVELOPE
             --short-name="e"
             --help="Set the envelope to work on."
-            --type="file"
             --required
       ]
   if create-esp32-only:
@@ -155,9 +154,8 @@ build-command --create-esp32-only/bool=false -> cli.Command:
 
 create-cmd -> cli.Command:
   options := AR-ENTRY-ESP32-FILE-MAP.map: | key/string value/string |
-    cli.Option key
+    cli.OptionPath key
         --help="Set the $key part."
-        --type="file"
         --required=(key == "firmware.bin")
   cmd := cli.Command "create"
       --help="""
@@ -169,9 +167,8 @@ create-cmd -> cli.Command:
 
 create-esp32-cmd --name/string -> cli.Command:
   options := AR-ENTRY-ESP32-FILE-MAP.map: | key/string value/string |
-    cli.Option key
+    cli.OptionPath key
         --help="Set the $key part."
-        --type="file"
         --required=(key == "firmware.bin")
   return cli.Command name
       --help="""
@@ -180,8 +177,8 @@ create-esp32-cmd --name/string -> cli.Command:
         Add the Toit system snapshot to the envelope with the 'firmware.bin' option.
         """
       --options=options.values + [
-        cli.Option "system.snapshot"
-            --type="file"
+        cli.OptionPath "system.snapshot"
+            --extensions=[".snapshot"]
             --required,
       ]
       --run=:: create-envelope-esp32 it
@@ -226,9 +223,8 @@ create-host-cmd -> cli.Command:
         Create a firmware envelope for the host system.
         """
       --options=[
-        cli.Option "run-image"
+        cli.OptionPath "run-image"
             --help="Path to the run-image executable."
-            --type="file"
             --required,
         cli.OptionInt "word-size"
             --required,
@@ -260,10 +256,9 @@ create-envelope-host invocation/cli.Invocation -> none:
 container-cmd -> cli.Command:
   cmd := cli.Command "container"
       --help="Manipulate Toit containers in a firmware envelope."
-  option-output := cli.Option OPTION-OUTPUT
+  option-output := cli.OptionPath OPTION-OUTPUT
       --short-name=OPTION-OUTPUT-SHORT
       --help="Set the output envelope."
-      --type="file"
   option-name := cli.Option "name"
       --type="string"
       --required
@@ -274,9 +269,8 @@ container-cmd -> cli.Command:
           --aliases=["add"]
           --options=[
             option-output,
-            cli.Option "assets"
-                --help="Add assets to the container."
-                --type="file",
+            cli.OptionPath "assets"
+                --help="Add assets to the container.",
             cli.OptionEnum "trigger" ["none", "boot"]
                 --help="Trigger the container to run automatically."
                 --default="boot",
@@ -285,8 +279,7 @@ container-cmd -> cli.Command:
           ]
           --rest=[
             option-name,
-            cli.Option "image"
-                --type="file"
+            cli.OptionPath "image"
                 --required
           ]
           --run=:: container-install it
@@ -495,10 +488,9 @@ property-cmd -> cli.Command:
   cmd := cli.Command "property"
       --help="Manipulate properties in a firmware envelope."
 
-  option-output := cli.Option OPTION-OUTPUT
+  option-output := cli.OptionPath OPTION-OUTPUT
       --short-name=OPTION-OUTPUT-SHORT
       --help="Set the output envelope."
-      --type="file"
   option-key := cli.Option "key"
       --type="string"
   option-key-required := cli.Option option-key.name
@@ -643,19 +635,16 @@ extract-cmd -> cli.Command:
         ```
         """
       --options=[
-        cli.Option OPTION-OUTPUT
+        cli.OptionPath OPTION-OUTPUT
             --short-name=OPTION-OUTPUT-SHORT
             --help="Set the output file."
-            --type="file"
             --required,
-        cli.Option "config"
-            --type="file",
+        cli.OptionPath "config",
         cli.OptionEnum "format" ["binary", "elf", "ubjson", "image", "qemu", "tar"]
             --help="Set the output format."
             --default="binary",
-        cli.Option "partitions"
-            --help="Override the partition table of the envelope."
-            --type="file",
+        cli.OptionPath "partitions"
+            --help="Override the partition table of the envelope.",
         cli.OptionPatterns "partition"
             ["file:<name>=<path>", "empty:<name>=<size>"]
             --help="Replace the content of a partition or add a custom partition to the flashed image."
@@ -1053,10 +1042,8 @@ flash-cmd -> cli.Command:
           want to use the bundled version.
           """
       --options=[
-        cli.Option "config"
-            --type="file",
-        cli.Option "port"
-            --type="file"
+        cli.OptionPath "config",
+        cli.OptionPath "port"
             --short-name="p"
             --required,
         cli.OptionInt "baud"
@@ -1069,9 +1056,8 @@ flash-cmd -> cli.Command:
             --help="Replace the content of a partition or add a custom partition to the flashed image."
             --split-commas
             --multi,
-        cli.Option "partitions"
-            --help="Override the partition table."
-            --type="file",
+        cli.OptionPath "partitions"
+            --help="Override the partition table.",
       ]
       --run=:: flash it
 
@@ -1317,7 +1303,7 @@ show-cmd -> cli.Command:
         cli.Flag "all"
             --help="Show all information, including non-container entries."
             --short-name="a",
-        cli.Option "output"
+        cli.OptionPath "output"
             --help="Write output to the given file."
             --short-name="o",
       ]

--- a/tools/info.toit
+++ b/tools/info.toit
@@ -55,9 +55,9 @@ build-command --sdk-dir-from-args/Lambda -> cli.Command:
             toit info pkg --output-format=json | jq -r '.packages | keys[]'
           """
       --options=[
-        cli.Option "project-root"
+        cli.OptionPath "project-root"
             --help="Path to the project root that contains the package.lock file."
-            --type="dir",
+            --directory,
         cli.Option "package"
             --help="Show imports from a specific package's perspective.",
       ]

--- a/tools/lsp/server/package.lock
+++ b/tools/lsp/server/package.lock
@@ -8,8 +8,8 @@ packages:
   pkg-cli:
     url: github.com/toitlang/pkg-cli
     name: cli
-    version: 2.7.1
-    hash: 8376719abcede80c26dae3430da4ddd65de9e63f
+    version: 2.14.0
+    hash: ec895eedf75ad24f944a3c158e8b5c0624609b8a
     prefixes:
       desktop: pkg-desktop
       fs: pkg-fs

--- a/tools/lsp/server/package.yaml
+++ b/tools/lsp/server/package.yaml
@@ -1,7 +1,7 @@
 dependencies:
   cli:
     url: github.com/toitlang/pkg-cli
-    version: ^2.7.1
+    version: ^2.14.0
   fs:
     url: github.com/toitlang/pkg-fs
     version: ^2.3.1

--- a/tools/lsp/server/replay.toit
+++ b/tools/lsp/server/replay.toit
@@ -57,7 +57,7 @@ main args:
   parameters/cli.Parameters? := null
   parser := cli.Command "replay"
       --rest=[
-          cli.Option "debug-file" --required
+          cli.OptionPath "debug-file" --required
       ]
       --options=[
           cli.Flag "print-out" --default=false,

--- a/tools/lsp/server/repro.toit
+++ b/tools/lsp/server/repro.toit
@@ -203,8 +203,8 @@ main args:
             --default=0,
       ]
       --rest=[
-        cli.Option "archive"
-            --type="file"
+        cli.OptionPath "archive"
+            --extensions=[".tar"]
             --required,
       ]
       --run=:: serve it["archive"] it["port"]
@@ -213,14 +213,12 @@ main args:
   create-cmd := cli.Command "create"
       --help="Create a repro."
       --rest=[
-        cli.Option "compiler-path"
-            --type="file"
+        cli.OptionPath "compiler-path"
             --required,
-        cli.Option "entry-path"
-            --type="file"
+        cli.OptionPath "entry-path"
+            --extensions=[".toit"]
             --required,
-        cli.Option "out-path"
-            --type="file"
+        cli.OptionPath "out-path"
             --required,
       ]
       --run=:: create-archive null it["compiler-path"] it["entry-path"] it["out-path"]

--- a/tools/package.lock
+++ b/tools/package.lock
@@ -19,8 +19,8 @@ packages:
   pkg-cli:
     url: github.com/toitlang/pkg-cli
     name: cli
-    version: 2.7.1
-    hash: 8376719abcede80c26dae3430da4ddd65de9e63f
+    version: 2.14.0
+    hash: ec895eedf75ad24f944a3c158e8b5c0624609b8a
     prefixes:
       desktop: pkg-desktop
       fs: pkg-fs
@@ -48,8 +48,8 @@ packages:
   pkg-http:
     url: github.com/toitlang/pkg-http
     name: http
-    version: 2.11.0
-    hash: d2cdc57270eaafe8df8d8403bf4ebf95415aa0fd
+    version: 2.12.0
+    hash: b68f3f4a3c26bfdff2beca4fb5ac7bc182f20270
   pkg-tar:
     url: github.com/toitlang/pkg-tar
     name: tar
@@ -78,5 +78,5 @@ packages:
   toit-semver:
     url: github.com/toitware/toit-semver
     name: semver
-    version: 1.1.1
-    hash: 74e61f2cbba360e8a13c004842bdc1a74c16c3c3
+    version: 1.2.0
+    hash: 7b862ca7b40601ae2a63ec6ffbacebb48c929e02

--- a/tools/package.yaml
+++ b/tools/package.yaml
@@ -7,7 +7,7 @@ dependencies:
     version: ^1.11.0
   cli:
     url: github.com/toitlang/pkg-cli
-    version: ^2.7.1
+    version: ^2.14.0
   desktop:
     url: github.com/toitlang/pkg-desktop
     version: ^1.1.0
@@ -19,13 +19,13 @@ dependencies:
     version: ^1.17.0
   http:
     url: github.com/toitlang/pkg-http
-    version: ^2.11.0
+    version: ^2.12.0
   partition-table:
     url: github.com/toitware/toit-partition-table-esp32
     version: ^1.4.0
   semver:
     url: github.com/toitware/toit-semver
-    version: ^1.1.1
+    version: ^1.2.0
   tar:
     url: github.com/toitlang/pkg-tar
     version: ^2.1.0

--- a/tools/pkg/package.lock
+++ b/tools/pkg/package.lock
@@ -1,4 +1,4 @@
-sdk: ^2.0.0-alpha.189
+sdk: ^2.0.0-alpha.190
 prefixes:
   certificate_roots: toit-cert-roots
   cli: pkg-cli
@@ -9,8 +9,8 @@ packages:
   pkg-cli:
     url: github.com/toitlang/pkg-cli
     name: cli
-    version: 2.7.1
-    hash: 8376719abcede80c26dae3430da4ddd65de9e63f
+    version: 2.14.0
+    hash: ec895eedf75ad24f944a3c158e8b5c0624609b8a
     prefixes:
       desktop: pkg-desktop
       fs: pkg-fs
@@ -38,8 +38,8 @@ packages:
   pkg-http:
     url: github.com/toitlang/pkg-http
     name: http
-    version: 2.11.0
-    hash: d2cdc57270eaafe8df8d8403bf4ebf95415aa0fd
+    version: 2.12.0
+    hash: b68f3f4a3c26bfdff2beca4fb5ac7bc182f20270
   toit-cert-roots:
     url: github.com/toitware/toit-cert-roots
     name: certificate-roots

--- a/tools/pkg/package.yaml
+++ b/tools/pkg/package.yaml
@@ -4,7 +4,7 @@ dependencies:
     version: ^1.11.0
   cli:
     url: github.com/toitlang/pkg-cli
-    version: ^2.7.1
+    version: ^2.14.0
   fs:
     url: github.com/toitlang/pkg-fs
     version: ^2.3.1
@@ -13,4 +13,4 @@ dependencies:
     version: ^1.17.0
   http:
     url: github.com/toitlang/pkg-http
-    version: ^2.11.0
+    version: ^2.12.0

--- a/tools/stacktrace.toit
+++ b/tools/stacktrace.toit
@@ -29,7 +29,7 @@ main args/List:
 build-command -> cli.Command:
   cmd := cli.Command "stacktrace"
       --help="Decode an ESP-IDF backtrace message from the UART console."
-      --rest=[cli.Option --required ELF-FILE --type="path"]
+      --rest=[cli.OptionPath --required ELF-FILE --extensions=[".elf"]]
       --options=[
           cli.Flag "disassemble" --short-name="d",
           cli.Option "objdump" --default=OBJDUMP,

--- a/tools/system_message.toit
+++ b/tools/system_message.toit
@@ -61,8 +61,9 @@ build-command --use-old-api/bool=false -> cli.Command:
   message-option := cli.Option "message" --short-name="m" --required
         --help="The base64-encoded message from the device."
   options := [
-    cli.Option "snapshot" --short-name="s"
-        --help="The snapshot file of the program that produced the message.",
+    cli.OptionPath "snapshot" --short-name="s"
+        --help="The snapshot file of the program that produced the message."
+        --extensions=[".snapshot"],
     cli.Option "uuid" --short-name="u"
         --help="UUID of the snapshot that produced the message. Deprecated."
         --hidden=(not use-old-api),

--- a/tools/toit.toit
+++ b/tools/toit.toit
@@ -16,6 +16,7 @@
 import cli
 import cli show Ui
 import fs
+import host.directory
 import host.file
 import host.pipe
 import system
@@ -58,14 +59,62 @@ main args/List:
     print system.vm-sdk-version
     return
 
-  root-command := cli.Command "toit"
-      --help="The Toit command line tool."
-      --options=[
-        cli.Option "sdk-dir"
-            --help="Path to the SDK root."
-            --type="dir"
-            --hidden,
+  sdk-dir-option := cli.OptionPath "sdk-dir"
+      --help="Path to the SDK root."
+      --directory
+      --hidden
+
+  // Late-binding reference so the default command's callback can
+  // re-dispatch through the root command group.
+  root-ref/cli.CommandGroup? := null
+
+  // The default command handles direct file arguments like `toit foo.toit`.
+  // It is part of the CommandGroup below. In practice, this command's
+  // run callback is usually not invoked because we intercept toit-source
+  // arguments early (see below) and rewrite them to `run -- <args>`. The
+  // early interception is needed so that `toit foo.toit -- arg` forwards
+  // the `--` to the program rather than having the CLI parser consume it.
+  // However, the callback *is* reached when the early interception doesn't
+  // fire, for example `toit -- foo.toit arg1 arg2`, or when the first
+  // argument isn't a known command and isn't a Toit source file.
+  default-command := cli.Command "default"
+      --rest=[
+        cli.OptionPath "source"
+            --help="The Toit source or snapshot file to run."
+            --extensions=[".toit", ".snapshot"]
+            --required,
+        cli.Option "arg"
+            --help="Argument to pass to the program."
+            --multi,
       ]
+      --dash-dash-is-rest
+      --run=:: | invocation/cli.Invocation |
+        source := invocation["source"]
+        rest-args := invocation["arg"]
+        // With --dash-dash-is-rest, a leading `--` is not consumed as
+        // a separator but becomes the source value. Skip it and take
+        // the actual source from the remaining args.
+        if source == "--":
+          if rest-args.is-empty:
+            invocation.cli.ui.abort "Missing source file after '--'"
+          source = rest-args[0]
+          rest-args = rest-args[1..]
+        if not is-toit-source source:
+          invocation.cli.ui.abort "Unknown command or invalid source file: '$source'"
+        // This path is reached when the early interception (which
+        // rewrites `toit foo.toit` to `toit run -- foo.toit`) does
+        // not fire. For example, `toit -- foo.toit arg1 arg2`.
+        root-ref.run ["run", "--"] + [source] + rest-args
+
+  commands-command := cli.Command "commands"
+      --options=[sdk-dir-option]
+
+  root-command := cli.CommandGroup "toit"
+      --help="The Toit command line tool."
+      --default=default-command
+      --default-title="Run"
+      --commands=commands-command
+  root-ref = root-command
 
   toitc-from-args := :: | invocation/cli.Invocation |
       sdk-dir := invocation["sdk-dir"]
@@ -86,16 +135,16 @@ main args/List:
       ]
       --run=:: | invocation/cli.Invocation |
         invocation.cli.ui.emit --result system.vm-sdk-version
-  root-command.add version-command
+  commands-command.add version-command
 
   compile-analyze-run-options := [
     cli.Flag "show-package-warnings"
         --help="Show warnings from packages.",
     cli.Flag "Werror" --short-name="Werror"
         --help="Treat warnings as errors.",
-    cli.Option "project-root"
+    cli.OptionPath "project-root"
         --help="Path to the project root. Any package.lock file must be in that folder."
-        --type="dir",
+        --directory,
     cli.Option "X" --short-name="X"
         --help="Provide a compiler flag."
         --hidden
@@ -129,28 +178,30 @@ main args/List:
       --help="Runs the given Toit source or snapshot file."
       --options=compile-analyze-run-options + compile-run-options
       --rest=[
-        cli.Option "source"
+        cli.OptionPath "source"
           --help="The source file to run."
+          --extensions=[".toit"]
           --required,
         cli.Option "arg"
           --help="Argument to pass to the program."
           --multi,
       ]
       --run=:: compile-or-analyze-or-run --command="run" it
-  root-command.add run-command
+  commands-command.add run-command
 
   analyze-command := cli.Command "analyze"
       --help="""
         Analyze the given Toit source files."""
       --options=compile-analyze-run-options + compile-analyze-options
       --rest=[
-        cli.Option "source"
+        cli.OptionPath "source"
           --help="The source files to analyze."
+          --extensions=[".toit"]
           --required
           --multi,
       ]
       --run=:: compile-or-analyze-or-run --command="analyze" it
-  root-command.add analyze-command
+  commands-command.add analyze-command
 
   compile-command := cli.Command "compile"
       --help="""
@@ -161,39 +212,40 @@ main args/List:
         cli.Flag "strip"
             --help="Strip the output of debug information.",
         cli.Option "os"
-            // TODO(florian): find valid values depending on which vessels exist.
-            --help="Set the target OS for cross compilation.",
+            --help="Set the target OS for cross compilation."
+            --completion=:: | context/cli.CompletionContext | complete-cross-os context,
         cli.Option "arch"
-            // TODO(florian): find valid values depending on which vessels exist.
-            --help="Set the target architecture for cross compilation.",
-        cli.Option "vessels-root"
+            --help="Set the target architecture for cross compilation."
+            --completion=:: | context/cli.CompletionContext | complete-cross-arch context,
+        cli.OptionPath "vessels-root"
             --help="Path to the vessels root."
-            --type="dir",
-        cli.Option "output" --short-name="o"
+            --directory,
+        cli.OptionPath "output" --short-name="o"
             --help="Set the output file name."
             --required,
       ]
       --rest=[
-        cli.Option "source"
+        cli.OptionPath "source"
           --help="The source file to compile."
+          --extensions=[".toit"]
           --required,
       ]
       --run=:: compile-or-analyze-or-run --command="compile" it
-  root-command.add compile-command
+  commands-command.add compile-command
 
   pkg-command := cli.Command "pkg"
       --help="Manage packages."
       --options=[
-        cli.Option "project-root"
+        cli.OptionPath "project-root"
             --help="Path to the project root that contains the package.{yaml|lock} file."
-            --type="dir",
+            --directory,
         cli.Option "sdk-version"
             --help="The SDK version to resolve dependencies against.",
         cli.Flag "auto-sync"
             --help="Automatically synchronize registries."
             --default=true,
       ]
-  root-command.add pkg-command
+  commands-command.add pkg-command
 
   pkg-clean-command := cli.Command "clean"
       --help="""
@@ -227,9 +279,9 @@ main args/List:
             --help="Allow local dependencies and don't report them.",
         cli.Flag "disallow-local-deps"
             --help="Always disallow local dependencies and report them.",
-        cli.Option "out-dir"
+        cli.OptionPath "out-dir"
             --help="The directory to write the description file to."
-            --type="dir",
+            --directory,
         cli.Flag "verbose"
             --help="Show more information.",
       ]
@@ -496,7 +548,7 @@ main args/List:
   tool-command := cli.Command "tool"
       --aliases=["tools"]
       --help="Run a tool."
-  root-command.add tool-command
+  commands-command.add tool-command
 
   tool-command.add toitp.build-command
   tool-command.add firmware.build-command
@@ -520,13 +572,13 @@ main args/List:
   toitdoc-command := toitdoc.build-command
       --toit-from-args=toit-from-args
       --sdk-path-from-args=:: | invocation/cli.Invocation | invocation["sdk-dir"]
-  root-command.add toitdoc-command
+  commands-command.add toitdoc-command
 
   info-command := info.build-command
       --sdk-dir-from-args=:: | invocation/cli.Invocation | invocation["sdk-dir"]
-  root-command.add info-command
+  commands-command.add info-command
 
-  root-command.add system-message.build-command
+  commands-command.add system-message.build-command
 
   assert:
     // Run the CLI package checks.
@@ -542,6 +594,82 @@ main args/List:
     args = ["run", "--"] + args
 
   root-command.run args
+
+/**
+Resolves the vessels root directory based on the completion $context.
+
+Looks for an explicit --vessels-root option, otherwise derives the vessels
+  directory from --sdk-dir (if given) or from the binary's own location.
+Returns null if no directory can be determined.
+*/
+vessels-root-from-context context/cli.CompletionContext -> string?:
+  seen := context.seen-options
+  vessels-root-values := seen.get "vessels-root"
+  if vessels-root-values and not vessels-root-values.is-empty:
+    return vessels-root-values.last
+  sdk-dir-values := seen.get "sdk-dir"
+  sdk-dir/string? := null
+  if sdk-dir-values and not sdk-dir-values.is-empty:
+    sdk-dir = sdk-dir-values.last
+  else:
+    our-dir := fs.dirname system.program-path
+    sdk-dir = fs.join our-dir ".."
+  return fs.join sdk-dir "lib" "toit" "vessels"
+
+/**
+Lists the direct subdirectories of $dir.
+
+Returns an empty list if $dir does not exist or cannot be read.
+*/
+list-subdirs dir/string -> List:
+  if not file.is-directory dir: return []
+  result := []
+  exception := catch:
+    stream := directory.DirectoryStream dir
+    try:
+      while entry := stream.next:
+        path := fs.join dir entry
+        if file.is-directory path: result.add entry
+    finally:
+      stream.close
+  return result
+
+/**
+Completion callback for the `--os` option of `toit compile`.
+
+Suggests the OS names for which vessels are installed.
+*/
+complete-cross-os context/cli.CompletionContext -> List:
+  vessels-root := vessels-root-from-context context
+  if not vessels-root: return []
+  result := []
+  (list-subdirs vessels-root).do: | os/string |
+    if os.starts-with context.prefix: result.add (cli.CompletionCandidate os)
+  return result
+
+/**
+Completion callback for the `--arch` option of `toit compile`.
+
+Suggests architectures for which vessels are installed. If an `--os`
+  has already been provided, restricts to its architectures; otherwise
+  returns architectures across all known OSes.
+*/
+complete-cross-arch context/cli.CompletionContext -> List:
+  vessels-root := vessels-root-from-context context
+  if not vessels-root: return []
+  os-values := context.seen-options.get "os"
+  os-list/List := ?
+  if os-values and not os-values.is-empty:
+    os-list = [os-values.last]
+  else:
+    os-list = list-subdirs vessels-root
+  archs := {}
+  os-list.do: | os/string |
+    (list-subdirs (fs.join vessels-root os)).do: archs.add it
+  result := []
+  archs.do: | arch/string |
+    if arch.starts-with context.prefix: result.add (cli.CompletionCandidate arch)
+  return result
 
 tool-path sdk-dir/string? tool/string -> string:
   if system.platform == system.PLATFORM-WINDOWS:

--- a/tools/toitdoc/toitdoc.toit
+++ b/tools/toitdoc/toitdoc.toit
@@ -20,6 +20,7 @@ import encoding.yaml
 import fs
 import host.directory
 import host.file
+import io
 
 import .lsp-exports as lsp
 import .serve
@@ -71,15 +72,13 @@ build-command --sdk-path-from-args/Lambda --toit-from-args/Lambda -> cli.Command
         at https://github.com/toitware/web-toitdocs.
         """
       --options=[
-        cli.Option "output"
+        cli.OptionOutFile "output"
             --short-name="o"
             --help="Output JSON file."
-            --type="file"
             --required,
       ]
       --rest=[
-        cli.Option "source"
-            --type="file|dir"
+        cli.OptionPath "source"
             --help="Source directory or file. Defaults to the current directory.",
       ]
       --run=::
@@ -106,8 +105,7 @@ build-command --sdk-path-from-args/Lambda --toit-from-args/Lambda -> cli.Command
             --default=true,
       ]
       --rest=[
-        cli.Option "source"
-            --type="file|dir"
+        cli.OptionPath "source"
             --help="Source directory or file. Defaults to the current directory.",
       ]
       --examples=[
@@ -200,7 +198,7 @@ compute-sdk-path --sdk-path/string? --toit/string? --ui/Ui -> string:
     return sdk-path
   throw "Couldn't determine SDK path"
 
-toitdoc invocation/cli.Invocation --toit/string --sdk-path/string? --output/string -> none:
+toitdoc invocation/cli.Invocation --toit/string --sdk-path/string? -> ByteArray:
   for-package := invocation["package"] == true
   for-sdk := invocation["sdk"] == true
   version := invocation["version"]
@@ -302,12 +300,12 @@ toitdoc invocation/cli.Invocation --toit/string --sdk-path/string? --output/stri
   if for-package: built-toitdoc["mode"] = "package"
   if for-sdk: built-toitdoc["mode"] = "sdk"
 
-  file.write-contents --path=output (json.encode built-toitdoc)
+  return json.encode built-toitdoc
 
 toitdoc-build invocation/cli.Invocation --toit/string --sdk-path/string?:
-  output := invocation["output"]
-
-  toitdoc invocation --toit=toit --sdk-path=sdk-path --output=output
+  output/cli.OutFile := invocation["output"]
+  encoded := toitdoc invocation --toit=toit --sdk-path=sdk-path
+  output.do: | writer/io.Writer | writer.write encoded
 
 toitdoc-serve invocation/cli.Invocation --toit/string --sdk-path/string?:
   port := invocation["port"]
@@ -317,7 +315,8 @@ toitdoc-serve invocation/cli.Invocation --toit/string --sdk-path/string?:
   try:
     output := "$tmp-dir/toitdoc.json"
 
-    toitdoc invocation --toit=toit --sdk-path=sdk-path --output=output
+    encoded := toitdoc invocation --toit=toit --sdk-path=sdk-path
+    file.write-contents --path=output encoded
     serve output --port=port --open-browser=open-browser --cli=invocation.cli
   finally:
     directory.rmdir --recursive tmp-dir

--- a/tools/toitp.toit
+++ b/tools/toitp.toit
@@ -140,12 +140,13 @@ build-command -> cli.Command:
           Inspect a Toit snapshot.
           """
 
-  snapshot-option := cli.Option "snapshot"
+  snapshot-option := cli.OptionPath "snapshot"
       --help="The snapshot to inspect."
-      --type="file"
+      --extensions=[".snapshot"]
       --required
   filter-option := cli.Option "filter"
       --help="Only print elements matching the filter pattern."
+      --completion=:: | context/cli.CompletionContext | complete-filter context
   filter-help := """
           The optional filter pattern is a glob pattern, where '*' matches any sequence of
           characters and '?' matches any single character. The filter is case-sensitive."""
@@ -321,11 +322,52 @@ build-command -> cli.Command:
 
   return snapshot-command
 
+/**
+Completion callback for the `filter` argument.
+
+Loads the snapshot provided as the first positional argument and
+  returns the program elements (classes, methods, literals, ...) that
+  the current subcommand iterates over, filtered by the completion prefix.
+*/
+complete-filter context/cli.CompletionContext -> List:
+  print-on-stderr_ "COMPLETING"
+  seen := context.seen-options
+  snapshot-values := seen.get "snapshot"
+  if not snapshot-values or snapshot-values.is-empty: return []
+  snapshot-path := snapshot-values.first
+  program/Program? := null
+  catch:
+    snapshot := SnapshotBundle.from-file snapshot-path
+    program = snapshot.decode
+  if not program: return []
+  command-name := context.command.name
+  names := {}
+  if command-name == "classes":
+    program.class-tags.size.repeat: | id/int |
+      names.add (program.class-name-for id)
+  else if command-name == "literals":
+    program.literals.do: | literal | names.add literal.stringify
+  else if command-name == "primitive-table":
+    program.primitive-table.size.repeat: | module-index/int |
+      module := program.primitive-table[module-index]
+      module.primitives.size.repeat: | primitive-index/int |
+        names.add (program.primitive-name module-index primitive-index)
+  else:
+    // "method-table", "method-sizes", "bytecodes", "callers", "dispatch-table".
+    program.do --method-infos: | method-info/MethodInfo |
+      names.add method-info.name
+  prefix := context.prefix
+  result := []
+  names.do: | name/string |
+    if name.starts-with prefix:
+      result.add (cli.CompletionCandidate name)
+  return result
+
 main args:
   parameters/cli.Parameters? := null
   parser := cli.Command "toitp"
       --rest=[
-          cli.Option "snapshot" --type="file" --required,
+          cli.OptionPath "snapshot" --extensions=[".snapshot"] --required,
           cli.Option "filter",
       ]
       --options=[


### PR DESCRIPTION
Upgrade pkg-cli to 2.14.0 and pkg-http to 2.12.0. Migrate all CLI option declarations from `cli.Option --type="file"/"dir"` to the typed alternatives (OptionPath, OptionInFile, OptionOutFile). Add a default command to the root `toit` CLI so that `toit foo.toit` runs the file directly. Add shell completion callbacks for --os/--arch in compile and for the filter argument in toitp.