### PR TITLE
Fix type-checker crash on global initializer with self-assignment

### DIFF
--- a/src/compiler/type_check.cc
+++ b/src/compiler/type_check.cc
@@ -577,11 +577,16 @@ class TypeChecker : public ReturningVisitor<Type> {
     auto global = node->global();
     check_deprecated(node->range(), global);
     auto right_type = visit(node->right());
-    if (global->return_type().is_any() && right_type.is_none()) {
+    auto receiver_type = global->return_type();
+    // The receiver type can be invalid when the assignment lives inside the
+    // global's own initializer (the type hasn't been computed yet) or when
+    // type inference for the global failed (e.g. a cyclic type dependency).
+    if (!receiver_type.is_valid()) return right_type;
+    if (receiver_type.is_any() && right_type.is_none()) {
       // TODO(florian): check that 'none' types aren't used.
       // report_error(node->right()->range(), "Can't use value of type 'none'");
     } else {
-      check(node->range(), global->return_type(), right_type);
+      check(node->range(), receiver_type, right_type);
     }
     return right_type;
   }

--- a/tests/negative/global-init-self-assign-test.toit
+++ b/tests/negative/global-init-self-assign-test.toit
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+// Regression test for https://github.com/toitlang/toit/issues/2950.
+// A global initializer whose body contains an assignment to the global
+// being initialized must not crash the type checker. The global's
+// `return_type` has not been computed yet, so the type checker has to
+// handle the invalid receiver type gracefully.
+
+just-block [block] -> int: return 1
+store-lambda fn/Lambda -> int: return 1
+
+some-global := just-block: some-global = some-global
+some-global2 := store-lambda:: some-global2 = some-global2
+
+main:
+  some-global
+  some-global2

--- a/tests/negative/gold/global-init-self-assign-test.gold
+++ b/tests/negative/gold/global-init-self-assign-test.gold
@@ -1,0 +1,10 @@
+tests/negative/global-init-self-assign-test.toit:14:42: error: Can't access global 'some-global' while initializing it
+some-global := just-block: some-global = some-global
+                                         ^~~~~~~~~~~
+tests/negative/global-init-self-assign-test.toit:14:1: error: Cyclic type dependency
+some-global := just-block: some-global = some-global
+^~~~~~~~~~~
+tests/negative/global-init-self-assign-test.toit:15:1: error: Cyclic type dependency
+some-global2 := store-lambda:: some-global2 = some-global2
+^~~~~~~~~~~~
+Compilation failed


### PR DESCRIPTION
When a global initializer contains an assignment back to the same global (e.g. inside a block argument), the type checker visits the assignment before the global's return type has been computed. The ASSERT in `check` then fired because `global->return_type()` is invalid.

`AssignmentGlobal` creation in the resolver already documents that the receiver type may be unset at this point and that the type check is inserted "later" — handle the invalid type gracefully here instead of crashing.

Regression test in tests/negative covers the block and lambda variants. Closes the assertion crash from #2950.