### PR TITLE
Clamp out-of-range positions in compute_source_offset

### DIFF
--- a/src/compiler/compiler.cc
+++ b/src/compiler/compiler.cc
@@ -968,17 +968,22 @@ SnapshotBundle Compiler::compile(const char* source_path,
 /// The line number should be 1-based.
 /// The column number should be 1-based.
 ///
-/// Aborts the program if the file is not big enough.
+/// If the requested position is past the end of the file (or past the end of
+/// the requested line), the offset is clamped to the closest valid position.
+/// LSP clients can legitimately send positions that don't align with the
+/// server's view of the buffer (e.g. a stale request after a buffer edit), so
+/// we must not abort.
 static int compute_source_offset(const uint8* source, int line_number, int utf16_column_number) {
   int offset = 0;
   int line = 1;  // The line number of the offset position.
   // Skip to the correct line first.
   while (line < line_number) {
-    int c = source[offset++];
+    int c = source[offset];
     if (c == '\0') {
-      // Didn't find enough lines.
-      UNREACHABLE();
+      // Didn't find enough lines -- clamp to end of file.
+      return offset;
     }
+    offset++;
     if (c == 10 || c == 13) {
       int other = (c == 10) ? 13 : 10;
       if (source[offset] == other) offset++;
@@ -987,16 +992,16 @@ static int compute_source_offset(const uint8* source, int line_number, int utf16
   }
   // Advance in the same line.
   //  [offset] is pointing to the first character of the line.
-  // Note that we don't look whether we hit another new-line character. We
-  //  just assume that the client sent us a correct request.
-  // However, we need to convert the utf-16 column number to utf-8 offsets.
-  // Also we don't want to accidentally access invalid memory.
+  // We need to convert the utf-16 column number to utf-8 offsets, and stop
+  // at the end of the line (or end of file) instead of walking past it.
   for (int i = 1; i < utf16_column_number; i++) {
-    if (source[offset] == '\0') {
-      // Didn't find enough characters.
-      UNREACHABLE();
+    int c = source[offset];
+    if (c == '\0' || c == 10 || c == 13) {
+      // Reached end of line / end of file before consuming the requested
+      // number of UTF-16 code units -- clamp.
+      break;
     }
-    int nb_bytes = Utils::bytes_in_utf_8_sequence(source[offset]);
+    int nb_bytes = Utils::bytes_in_utf_8_sequence(c);
     offset += nb_bytes;
     // If the UTF-8 sequence takes more than 3 bytes, it is encoded as surrogate pair in UTF-16.
     if (nb_bytes > 3) i++;

--- a/src/compiler/type_check.cc
+++ b/src/compiler/type_check.cc
@@ -577,11 +577,16 @@ class TypeChecker : public ReturningVisitor<Type> {
     auto global = node->global();
     check_deprecated(node->range(), global);
     auto right_type = visit(node->right());
-    if (global->return_type().is_any() && right_type.is_none()) {
+    auto receiver_type = global->return_type();
+    // The receiver type can be invalid when the assignment lives inside the
+    // global's own initializer (the type hasn't been computed yet) or when
+    // type inference for the global failed (e.g. a cyclic type dependency).
+    if (!receiver_type.is_valid()) return right_type;
+    if (receiver_type.is_any() && right_type.is_none()) {
       // TODO(florian): check that 'none' types aren't used.
       // report_error(node->right()->range(), "Can't use value of type 'none'");
     } else {
-      check(node->range(), global->return_type(), right_type);
+      check(node->range(), receiver_type, right_type);
     }
     return right_type;
   }

--- a/tests/lsp/past-eol-completion-compiler-test.toit
+++ b/tests/lsp/past-eol-completion-compiler-test.toit
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import .lsp-client show LspClient run-client-test
+import expect show *
+
+// Regression test for https://github.com/toitlang/toit/issues/2950.
+//
+// The LSP server is asynchronous: a `did-change` that arrives between when
+// a completion request is queued and when the forked compiler actually
+// reads the buffer can leave the compiler with a (line, col) position that
+// is past the end of the (now shorter) line. The compiler must clamp the
+// position instead of aborting on `compute_source_offset`'s UNREACHABLE.
+//
+// We can't easily replay that exact race in a test, so we approximate it
+// by asking for completion at LSP positions that are explicitly past the
+// end of the line (and past the end of the file). Both used to crash;
+// after the fix they must just return without aborting.
+
+main args:
+  run-client-test args: test it
+
+test client/LspClient:
+  // A small file whose last line has no trailing newline -- exactly the
+  // shape the original repros had (line beyond EOF / col beyond EOL).
+  untitled-uri := "untitled:Untitled-past-eol"
+  client.send-did-open --uri=untitled-uri --text="""
+      interface I_ implements:
+
+      foo"""
+
+  // Line 0 = "interface I_ implements:" (24 chars). Past-EOL column.
+  client.send-completion-request --uri=untitled-uri 0 80
+
+  // Line 2 = "foo" (3 chars, no trailing newline). Past-EOL column.
+  client.send-completion-request --uri=untitled-uri 2 80
+
+  // A line that does not exist at all (file only has 3 lines: 0..2).
+  client.send-completion-request --uri=untitled-uri 99 0
+  client.send-completion-request --uri=untitled-uri 99 80
+
+  // Sanity check that the server is still alive and returning meaningful
+  // completions for an in-bounds position.
+  response := client.send-completion-request --uri=untitled-uri 2 3
+  expect (response is List)

--- a/tests/negative/global-init-self-assign-test.toit
+++ b/tests/negative/global-init-self-assign-test.toit
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+// Regression test for https://github.com/toitlang/toit/issues/2950.
+// A global initializer whose body contains an assignment to the global
+// being initialized must not crash the type checker. The global's
+// `return_type` has not been computed yet, so the type checker has to
+// handle the invalid receiver type gracefully.
+
+just-block [block] -> int: return 1
+store-lambda fn/Lambda -> int: return 1
+
+some-global := just-block: some-global = some-global
+some-global2 := store-lambda:: some-global2 = some-global2
+
+main:
+  some-global
+  some-global2

--- a/tests/negative/gold/global-init-self-assign-test.gold
+++ b/tests/negative/gold/global-init-self-assign-test.gold
@@ -1,0 +1,10 @@
+tests/negative/global-init-self-assign-test.toit:14:42: error: Can't access global 'some-global' while initializing it
+some-global := just-block: some-global = some-global
+                                         ^~~~~~~~~~~
+tests/negative/global-init-self-assign-test.toit:14:1: error: Cyclic type dependency
+some-global := just-block: some-global = some-global
+^~~~~~~~~~~
+tests/negative/global-init-self-assign-test.toit:15:1: error: Cyclic type dependency
+some-global2 := store-lambda:: some-global2 = some-global2
+^~~~~~~~~~~~
+Compilation failed

--- a/tools/lsp/server/SKILL.md
+++ b/tools/lsp/server/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: debug-lsp-repro
+description: Use this when debugging compiler crashes captured as LSP "repro" tar archives (e.g. attached to GitHub issues). Explains how to extract a repro, replay it against `toit.compile`, get a symbolized backtrace under gdb, and reduce the crash to a minimal source snippet that fits in `tests/negative/`.
+---
+
+# Debugging LSP repro tar archives
+
+The LSP server (and the standalone `tools/lsp/server/repro.toit` tool) can
+capture a "repro" — a tar file containing every source file the compiler
+served plus the exact stdin that drove it. These archives end up on GitHub
+issues whenever the LSP segfaults or asserts. This skill is the runbook for
+turning one of those archives into a fix.
+
+## Tar archive layout
+
+Each repro tar contains the original served files at their absolute paths
+plus these special metadata members:
+
+| Member                       | Purpose                                            |
+|------------------------------|----------------------------------------------------|
+| `/<info>`                    | Crash reason (`Segmentation fault`, `Killed`, …)  |
+| `/<compiler-input>`          | Stdin payload that drove the compiler             |
+| `/<compiler-flags>`          | Newline-separated CLI flags (usually `--lsp …`)   |
+| `/<cwd>`                     | Original working directory                        |
+| `/<sdk-path>`                | SDK root used                                     |
+| `/<package-cache-paths>`     | Newline-separated package cache paths             |
+| `/<meta>`                    | JSON: `{files: …, directories: …}` metadata       |
+
+`tar xOf <archive> '/<info>'` is the fastest way to triage: ignore archives
+whose info is just `Killed after timeout` (load issue, not a real crash);
+keep the ones with `Segmentation fault`, `assertion failure`, etc.
+
+## Reproducing a crash
+
+The compiler talks to the file server over TCP. Two steps:
+
+1. Run `toit tools/lsp/server/repro.toit serve --port=0 <archive>` in the
+   background. It prints `Server started at <port>` and keeps serving.
+2. Drive `toit.compile -Xno_fork --lsp` with stdin = `<port>\n` followed
+   by the contents of `/<compiler-input>`.
+
+For a quick session, this script (drop it next to your repros) does both
+and optionally runs the compiler under `gdb --batch` for a symbolized
+backtrace:
+
+```bash
+#!/usr/bin/env bash
+# usage: run_repro.sh <archive.tar> [gdb]
+set -u
+ARCHIVE=${1:?need archive}; GDB=${2:-}
+REPO=/path/to/toit
+TOIT=$REPO/build/host/sdk/bin/toit
+COMPILE=$REPO/build/host/sdk/lib/toit/bin/toit.compile
+
+WORK=$(mktemp -d); LOG=$WORK/server.log
+tar xOf "$ARCHIVE" '/<compiler-input>' > "$WORK/in" 2>/dev/null
+"$TOIT" run "$REPO/tools/lsp/server/repro.toit" -- serve --port=0 "$ARCHIVE" \
+    > "$LOG" 2>&1 &
+SERVER=$!
+for _ in $(seq 50); do
+  grep -q 'Server started at' "$LOG" && break; sleep 0.2
+done
+PORT=$(awk '/Server started at/{print $4; exit}' "$LOG")
+{ echo "$PORT"; cat "$WORK/in"; } > "$WORK/stdin"
+if [[ "$GDB" == gdb ]]; then
+  gdb --batch -ex 'set pagination off' -ex 'handle SIGPIPE nostop noprint pass' \
+      -ex run -ex bt -ex 'bt full' -ex 'thread apply all bt' \
+      --args "$COMPILE" -Xno_fork --lsp < "$WORK/stdin"
+else
+  "$COMPILE" -Xno_fork --lsp < "$WORK/stdin"
+fi
+kill $SERVER 2>/dev/null; wait 2>/dev/null
+```
+
+Build the SDK with debug info first (`-O0 -g`) so backtraces are useful;
+otherwise gdb shows raw addresses only.
+
+## From repro to minimal test
+
+Once you have a stack trace and the assertion file:line, look at the
+served source the compiler was analyzing — the path is the last line of
+`/<compiler-input>` (often an `inmemory://…` document):
+
+```
+tar xOf <archive> '<served-path>'
+```
+
+Then reduce. The repro often involves parser error-recovery, so the crash
+may depend on subtle textual conditions (leading indentation, missing
+preceding declarations). Two tactics that help reduce:
+
+- Try the same snippet through the *non-LSP* path:
+  `toit.compile --analyze /tmp/min.toit`. If it crashes there too, the bug
+  isn't LSP-specific and the test belongs in `tests/negative/`.
+- If you need LSP-only behaviour to crash, write the test in
+  `tests/lsp/` and drive it with `LspClient` (see
+  `tests/lsp/repro-compiler-test-slow.toit` for the pattern).
+
+## Writing a negative test
+
+`tests/negative/<name>-test.toit` files are run via `toit.run`; the
+compiler error output is compared to `tests/negative/gold/<name>-test.gold`.
+The runner expects a non-zero exit code, so the test must trigger at least
+one compile error.
+
+To generate / refresh gold files after changing a test:
+
+```
+make update-gold
+```
+
+Then run the single test:
+
+```
+(cd build/host && ctest -R '<name>' --output-on-failure)
+```
+
+## Common crash patterns seen so far
+
+- `type_check.cc` ASSERT on `is_valid()` of a receiver/value type:
+  the type checker is visiting a node whose target's
+  `return_type()` hasn't been computed yet (e.g. an `AssignmentGlobal`
+  inside the global's own initializer, or after a cyclic-type error).
+  Fix is usually to short-circuit the type check when the receiver type
+  is invalid, mirroring how `visit_ReferenceGlobal` already does.
+
+- `Killed after timeout` in `<info>`: ignore. These are CI overload, not
+  real bugs.

--- a/tools/lsp/server/debug-lsp-repro-skill.md
+++ b/tools/lsp/server/debug-lsp-repro-skill.md
@@ -73,7 +73,8 @@ kill $SERVER 2>/dev/null; wait 2>/dev/null
 ```
 
 Build the SDK with debug info first (`-O0 -g`) so backtraces are useful;
-otherwise gdb shows raw addresses only.
+otherwise gdb shows raw addresses only. See `make debug`. You might need to
+delete `build/host` first.
 
 ## From repro to minimal test
 
@@ -90,7 +91,7 @@ may depend on subtle textual conditions (leading indentation, missing
 preceding declarations). Two tactics that help reduce:
 
 - Try the same snippet through the *non-LSP* path:
-  `toit.compile --analyze /tmp/min.toit`. If it crashes there too, the bug
+  `toit analyze --analyze /tmp/min.toit`. If it crashes there too, the bug
   isn't LSP-specific and the test belongs in `tests/negative/`.
 - If you need LSP-only behaviour to crash, write the test in
   `tests/lsp/` and drive it with `LspClient` (see
@@ -114,15 +115,3 @@ Then run the single test:
 ```
 (cd build/host && ctest -R '<name>' --output-on-failure)
 ```
-
-## Common crash patterns seen so far
-
-- `type_check.cc` ASSERT on `is_valid()` of a receiver/value type:
-  the type checker is visiting a node whose target's
-  `return_type()` hasn't been computed yet (e.g. an `AssignmentGlobal`
-  inside the global's own initializer, or after a cyclic-type error).
-  Fix is usually to short-circuit the type check when the receiver type
-  is invalid, mirroring how `visit_ReferenceGlobal` already does.
-
-- `Killed after timeout` in `<info>`: ignore. These are CI overload, not
-  real bugs.


### PR DESCRIPTION
The LSP server is asynchronous: a `did-change` that arrives between the moment a completion (or definition / hover / rename) request is queued and the moment the forked compiler actually reads the buffer over the TCP file-server can leave the compiler with a (line, column) position that is past the end of the (now shorter) line. The compiler then walks past the end-of-line/end-of-file sentinel and aborts on the `UNREACHABLE()` in `compute_source_offset`.

The same shape also occurs without any race when the cursor is at the end of the last line of a file with no trailing newline -- LSP allows column = N for an N-character line, which already lands on the trailing '\0' in the C string view.

Make `compute_source_offset` clamp to the closest valid position instead of aborting in both spots, and document the new contract.

LSP regression test exercises positions past EOL and past EOF. Closes the SIGABRT crashes from #2950 (the "Aborted" repros).