### PR TITLE
Ignore mDNS AD/CD/Z bits on reception

### DIFF
--- a/lib/net/modules/dns.toit
+++ b/lib/net/modules/dns.toit
@@ -349,7 +349,7 @@ abstract class DnsClientBase_ implements DnsClient:
     and the more funky record types needed for mDNS.
   */
   decode-and-cache-response_ query/DnsQuery_ response/ByteArray --mdns/bool=false -> List?:
-    decoded := decode-packet response --error-name=query.name
+    decoded := decode-packet response --error-name=query.name --mdns=mdns
 
     // Check for expected response, but mask out the authoritative bit
     // and the recursion available bit, which we do not care about.
@@ -613,7 +613,7 @@ find-in-cache top-cache/Map name type/int -> List?:
 Decodes a DNS packet.
 The $error-name is only used for error messages.
 */
-decode-packet packet/ByteArray --error-name/string?=null -> DecodedPacket:
+decode-packet packet/ByteArray --error-name/string?=null --mdns/bool=false -> DecodedPacket:
   response := packet
   reader := io.Reader response
   received-id    := reader.big-endian.read-uint16
@@ -627,6 +627,10 @@ decode-packet packet/ByteArray --error-name/string?=null -> DecodedPacket:
   if error != ERROR-NONE:
     detail := ERROR-NAMES.get error --if-absent=: "error code $error"
     throw (DnsException "Server responded: $detail" --name=error-name)
+
+  if mdns:
+    // RFC 6762 requires receivers to ignore these flag bits in mDNS packets.
+    status-bits &= ~0x0070
 
   result := DecodedPacket --id=received-id --status-bits=status-bits
 

--- a/tests/dns-tools-test.toit
+++ b/tests/dns-tools-test.toit
@@ -3,6 +3,7 @@
 // be found in the tests/LICENSE file.
 
 import expect show *
+import io
 import net
 import net.modules.dns
 
@@ -12,6 +13,7 @@ main:
   cname-test network
   parse-numeric-test
   encode-decode-packets-test
+  mdns-query-ignores-ad-bit-test
 
 txt-test network/net.Client:
   client := dns.DnsClient [
@@ -126,3 +128,24 @@ encode-decode-packets-test:
   second-l := packet[first-l + 1..].index-of 'l'
   expect second-l < 0  // Not found.
 
+mdns-query-ignores-ad-bit-test:
+  packet := io.Buffer
+  packet.big-endian.write-int16 0x1234
+  packet.big-endian.write-int16 0x0120
+  packet.big-endian.write-int16 1
+  packet.big-endian.write-int16 0
+  packet.big-endian.write-int16 0
+  packet.big-endian.write-int16 0
+  packet.write-byte 7; packet.write "service"
+  packet.write-byte 5; packet.write "local"
+  packet.write-byte 0
+  packet.big-endian.write-int16 dns.RECORD-PTR
+  packet.big-endian.write-int16 1
+
+  decoded := dns.decode-packet packet.bytes --mdns
+
+  expect-equals 0x1234 decoded.id
+  expect-not decoded.is-response
+  expect-equals 0x0100 decoded.status-bits
+  expect-equals 1 decoded.questions.size
+  expect-equals "service.local" decoded.questions[0].name


### PR DESCRIPTION
## Summary
- mask the mDNS-only ignored status bits before `DecodedPacket` validation
- keep regular DNS decoding strict while allowing Android-style multicast queries through the lenient path
- add a regression test for an mDNS query with the AD bit set

## Testing
- `ctest --test-dir build/host -R 'tests/dns-tools-test\\.toit$' -C slow --output-on-failure`
- `build/host/sdk/bin/toit tests/dns_packet_test.toit foo bar gee`
