### PR TITLE
Fix memory leak in float_to_string primitive

### DIFF
--- a/src/primitive_core.cc
+++ b/src/primitive_core.cc
@@ -1514,6 +1514,7 @@ PRIMITIVE(float_to_string) {
     }
   }
   const char* buffer;
+  char* allocated_buffer = null;
   if (precision == process->null_object()) {
     if (receiver == 0.0) {
       if (is_negative) {
@@ -1531,9 +1532,12 @@ PRIMITIVE(float_to_string) {
     if (!is_smi(precision)) FAIL(WRONG_OBJECT_TYPE);
     word prec = Smi::value(precision);
     if (prec < 0 || prec > 64) FAIL(OUT_OF_BOUNDS);
-    buffer = safe_double_print(format, prec, receiver);
+    allocated_buffer = safe_double_print(format, prec, receiver);
+    if (allocated_buffer == null) FAIL(MALLOC_FAILED);
+    buffer = allocated_buffer;
   }
   Object* result = process->allocate_string(buffer);
+  free(allocated_buffer);
   if (result == null) FAIL(ALLOCATION_FAILED);
   return result;
 }


### PR DESCRIPTION
`safe_double_print` returns a malloc'd `char*` that `allocate_string` copies but never frees. Every `"$(%.Nf v)"` interpolation or `v.to-string --precision=N` call leaked ~16 B plus heap overhead, which OOMs apps that format floats in a steady loop.