### PR TITLE
Fix JSON encoding of floats; reject NaN and infinity

### DIFF
--- a/lib/encoding/json.toit
+++ b/lib/encoding/json.toit
@@ -172,6 +172,8 @@ class Encoder extends EncoderBase_:
     writer_.write-byte '"'
 
   encode-number_ number:
+    if number is float and not number.is-finite:
+      throw "INVALID_JSON_NUMBER"
     str := number.to-string
     writer_.write str
 

--- a/lib/encoding/json.toit
+++ b/lib/encoding/json.toit
@@ -172,7 +172,7 @@ class Encoder extends EncoderBase_:
     writer_.write-byte '"'
 
   encode-number_ number:
-    str := number is float ? number.stringify 2 : number.stringify
+    str := number.to-string
     writer_.write str
 
   encode-true_:

--- a/tests/health/gold/sdk/tests__json-test.toit.gold
+++ b/tests/health/gold/sdk/tests__json-test.toit.gold
@@ -1,3 +1,3 @@
-tests/json-test.toit:386:17: warning: Class 'BufferedReader' is deprecated. Use 'io.Reader' instead
+tests/json-test.toit:393:17: warning: Class 'BufferedReader' is deprecated. Use 'io.Reader' instead
     buffered := BufferedReader (TestReader it)
                 ^~~~~~~~~~~~~~

--- a/tests/json-test.toit
+++ b/tests/json-test.toit
@@ -37,6 +37,13 @@ test-stringify:
   expect-equals "0.0" (json.stringify 0.0)
   expect-equals "-0.00001" (json.stringify -0.00001)
 
+  expect-throw "INVALID_JSON_NUMBER": json.stringify float.NAN
+  expect-throw "INVALID_JSON_NUMBER": json.stringify float.INFINITY
+  expect-throw "INVALID_JSON_NUMBER": json.stringify -float.INFINITY
+  expect-throw "INVALID_JSON_NUMBER": json.encode float.NAN
+  expect-throw "INVALID_JSON_NUMBER": json.encode float.INFINITY
+  expect-throw "INVALID_JSON_NUMBER": json.encode -float.INFINITY
+
   expect-equals "true" (json.stringify true)
   expect-equals "false" (json.stringify false)
   expect-equals "null" (json.stringify null)

--- a/tests/json-test.toit
+++ b/tests/json-test.toit
@@ -32,10 +32,10 @@ test-stringify:
   expect-equals "\"\\u0001\"" (json.stringify "\x01")
 
   expect-equals "5" (json.stringify 5)
-  expect-equals "5.00" (json.stringify 5.0)
+  expect-equals "5.0" (json.stringify 5.0)
   expect-equals "0" (json.stringify 0)
-  expect-equals "0.00" (json.stringify 0.0)
-  expect-equals "-0.00" (json.stringify -0.00001)
+  expect-equals "0.0" (json.stringify 0.0)
+  expect-equals "-0.00001" (json.stringify -0.00001)
 
   expect-equals "true" (json.stringify true)
   expect-equals "false" (json.stringify false)


### PR DESCRIPTION
Two related fixes to `lib/encoding/json.toit`:

1. **Fix data loss when encoding floats.** The encoder used
   `float.stringify 2`, forcing 2-decimal-place format and
   silently truncating small magnitudes (e.g. `-0.00001` was
   encoded as `-0.00`). Switched to `float.to-string`, which
   produces the shortest representation that round-trips back
   to the original value. Also drops a deprecated API call.

2. **Reject NaN and ±Infinity.** These are not valid JSON
   numbers but were written into the output as bare `nan` /
   `inf` / `-inf` tokens that JSON parsers generally won't
   accept. Now throws `INVALID_JSON_NUMBER` so the encoder
   either produces valid JSON or fails loudly. Matches the
   behaviour of Go's `encoding/json` and Rust's `serde_json`.