### PR TITLE
feat(debug): host bytecode debugger (dbg: protocol, breakpoints, stepping, inspect)

### DIFF
--- a/docs/debugger.md
+++ b/docs/debugger.md
@@ -1,0 +1,164 @@
+# Host bytecode debugger
+
+The host (POSIX) Toit VM has an in‑image bytecode debugger: a breakpoint /
+single‑step mechanism in the interpreter plus a controller that speaks the
+line‑based `dbg:` protocol over stdin/stdout. It lets an operator set
+breakpoints, step, and inspect live frames of a program running under the host
+VM.
+
+This document is the in‑repo reference for the VM side. The operator‑facing
+tooling — the `jag debug` CLI and its `--web` browser UI, which resolve method
+**names**, source **lines**, and class **names** offline from the snapshot — lives
+in the `jaguar` repo (`docs/debug_spec.md` / `docs/debug_design.md` there). The
+`dbg:` protocol mirrors the OEVM reference debugger so a Toit node can be debugged
+like the OEVM node.
+
+## Enabling it
+
+The debugger is active only when debugging is requested: the `--debug` flag on the
+inner runner (`toit.run --debug <snapshot>`) or the `OEVM_DEBUG` / `TOIT_DEBUG`
+environment variable. When off, the only cost on the bytecode path is a single
+predicted‑not‑taken branch on a `false` flag — **zero measurable overhead** when
+not debugging (a hard design constraint).
+
+Debug a **pre‑compiled snapshot**, not raw source. Bytecode indices (`bci`) are
+program‑relative and the runtime interleaves several programs (privileged system,
+services, and under `toit run` the compiler); debugging a snapshot means only the
+target app + system run, so breakpoints can key on `(program, method‑id, offset)`.
+
+## The `dbg:` protocol
+
+Line‑based, newline‑delimited, over the VM's stdin (requests) and stdout
+(responses). Response lines are interleaved with the program's own stdout; the
+operator splits on `\n` and distinguishes protocol lines by the `dbg:` prefix.
+
+**Requests** (operator → VM):
+
+| Request | Meaning |
+|---|---|
+| `dbg:methods` | list the target's methods |
+| `dbg:break <id> <off>` | set a breakpoint at method `id`, offset `off` |
+| `dbg:clear <id> <off>` | clear that breakpoint |
+| `dbg:continue` | resume the parked process |
+| `dbg:step` / `dbg:over` / `dbg:out` | single‑step (into / over / out) |
+| `dbg:inspect [frame]` | dump a parked frame's registers (default frame 0) |
+
+**Responses** (VM → operator):
+
+| Response | Meaning |
+|---|---|
+| `dbg:ready` | the controller is up; emitted once before the program runs |
+| `dbg:ok <verb>` | acknowledges a request |
+| `dbg:paused break <id> <off>` | hit a breakpoint at method `id`, offset `off` |
+| `dbg:paused step <id> <off>` | stopped after a step |
+| `dbg:stack off=<bci> r0=<v> r1=<v> …` | a frame's registers (answer to `inspect`) |
+| `dbg:error <msg>` | error (e.g. unknown method id) |
+
+The VM emits **numeric method ids only**; ids are 1‑based, assigned by
+`dbg:methods` in dispatch‑table order, and stable for the session. Names, source
+positions, and class names are all resolved **offline** from the snapshot by the
+operator tooling — the wire protocol stays "VM numeric, names resolved offline".
+
+After `dbg:ready`, the VM forces a pause at the first non‑privileged program's
+entry (`dbg:paused break -1 0`) so the operator can install breakpoints before the
+program makes progress.
+
+## Architecture
+
+Three layers, with a deliberate thread split (`src/debugger.{h,cc}`,
+`src/interpreter*.{h,cc}`, `src/scheduler.{h,cc}`):
+
+1. **Interpreter mechanism.** For every bytecode of a non‑privileged process,
+   `should_break(program, bci)` is checked (gated behind the debug‑active flag). On
+   a hit — a matching breakpoint, or any bytecode while stepping — the interpreter
+   stores the stack and returns a new `Result::DEBUG_PAUSED`.
+2. **Scheduler park/resume.** On `DEBUG_PAUSED` the scheduler **parks** the process
+   (does *not* re‑ready it) and calls `register_paused`. `resume_debug_process(pid,
+   step_mode)` re‑readies it later. While debugging, the scheduler is capped to a
+   single worker thread.
+3. **Controller thread.** A dedicated OS thread (not a scheduler worker, so it may
+   block on stdin) reads `dbg:` commands, mutates the breakpoint table, walks the
+   parked stack for `inspect`, and resumes the target. The debugger's state is
+   guarded by a mutex; a condition variable hands pause/target events between the
+   scheduler thread and the controller.
+
+**Why park instead of run‑to‑completion or block in place:** a breakpoint must
+suspend just the target process without blocking a scheduler worker (the spike
+proved an in‑worker block deadlocks the VM). `DEBUG_PAUSED` + a separate controller
+thread is the mechanism.
+
+Stepping carries a mode on resume (1 step / 2 over / 3 out) plus the frame depth at
+the pause; `should_break` then stops on the next bytecode (step), at `depth ≤
+start` (over), or `depth < start` (out). The `is_privileged` guard keeps stepping
+out of system/service frames.
+
+## Register values
+
+`dbg:inspect` answers with `dbg:stack off=<bci> r<slot>=<value> …` for the parked
+frame. `emit_stack` formats each register by type so the operator sees real values:
+
+- `null`, `true`, `false`; integers (smi) and doubles as numbers.
+- Strings via `emit_string`: a double‑quoted, escaped token (`\" \\ \n \r \t`,
+  `\xNN` for control chars), capped at 128 chars — so a value with spaces stays
+  whitespace‑delimited on the wire.
+- Any other heap object: `<obj:<class_id>>`, the **numeric** class id. The operator
+  resolves the id to a class name offline (see the dumps below).
+
+Local variable **names** are not available — registers are raw stack slots. Named
+locals would need compiler‑emitted local metadata (out of scope).
+
+## Offline snapshot dumps (`tools/toitp.toit`)
+
+The operator resolves the VM's numeric ids against the snapshot via three
+subcommands of `toit tool snapshot`:
+
+- `bytecodes` — per‑method blocks with names + entry bci (method‑name resolution).
+- `positions` — one line per bytecode, `<absolute_bci> <path> <line> <col>`, where
+  `absolute_bci = method.entry_bci + off`. `<path>` is the compiler's error‑path:
+  the user file's path as compiled, `<sdk>/…` for the SDK, `<pkg:..>/…` for package
+  files. Drives source‑line highlighting and gutter→breakpoint mapping.
+- `class-names` — `<class_id> <name>` per line (from `program.class-tags` /
+  `program.class-name-for`), resolving the `<obj:<class_id>>` register markers.
+
+Keeping resolution offline keeps the VM change minimal and matches `jag decode`.
+
+## Tradeoffs & constraints
+
+- **Zero overhead when off** is a hard constraint — the per‑bytecode hook is a
+  single branch on a flag that is false unless debugging.
+- **Snapshot, not raw source** — required for stable, program‑relative bci.
+- **stdin ownership** — the debug channel owns the VM's stdin; a debugged program
+  that itself reads stdin is unsupported (matches OEVM).
+- **Target selection** — the debuggee is the first non‑privileged program whose
+  `Program*` differs from the system program. Multi‑app would need an explicit
+  debuggee marker.
+- **Single worker thread under debug** — avoids cross‑thread pause hazards; the
+  host has ample CPU, so this is a non‑issue for the host path.
+
+## Out of scope / deferred
+
+- **In‑image protocol loop.** The controller is C++. Porting the `dbg:` loop to a
+  Toit "debug supervisor" process (via `primitive_debug.cc` primitives) is the
+  natural shape for a later device/ESP32 phase, where there is no separate OS
+  thread. Not built for the host MVP.
+- **Device/FreeRTOS.** The debugger is host‑only today (a POSIX controller thread on
+  stdin). Device debugging needs the in‑image supervisor and new VM primitives.
+- **Named locals**, conditional breakpoints, watchpoints, expression evaluation
+  beyond `inspect`, and DAP/editor integration are out of scope.
+
+## Build & run
+
+```bash
+# Build the host VM/SDK after changing src/debugger.cc (or .h):
+cd build/host && ninja sdk/bin/toit
+# After changing tools/toitp.toit (a Toit tool compiled into the snapshot):
+cd build/host && ninja generated/toit.snapshot sdk/bin/toit   # ninja, not make
+```
+
+Run a snapshot under the debugger directly with
+`build/host/sdk/lib/toit/bin/toit.run --debug <snapshot>` and drive it over stdin,
+or — the ergonomic path — use `jag debug` from the `jaguar` repo, which compiles,
+launches, and relays for you.
+
+`tools/debug/` holds the original Python proof‑of‑concept driver that validated the
+protocol end to end; `jag debug` is its first‑class replacement.

--- a/docs/debugger.md
+++ b/docs/debugger.md
@@ -134,6 +134,13 @@ Keeping resolution offline keeps the VM change minimal and matches `jag decode`.
   debuggee marker.
 - **Single worker thread under debug** — avoids cross‑thread pause hazards; the
   host has ample CPU, so this is a non‑issue for the host path.
+- **Tasks** — a breakpoint parks the whole process, so it is task‑aware: it stops
+  in whichever task runs the code, once per task per pass, and `inspect` reads the
+  paused task's stack. But the step/over/out depth is tracked against a single
+  task's stack, so **stepping over a `yield`** (a cooperative task switch) loses
+  the stop condition and runs to completion — the same class as stepping over an
+  exception unwind. Breakpoints (not single‑stepping) are the way to debug across
+  task switches.
 
 ## Out of scope / deferred
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,8 @@ file(GLOB toit_core_SRC
   "*.c"
   "*.cc"
   )
+# Note: debugger.cc (the in-image bytecode debugger) is picked up by the glob
+# above and compiled into the core library.
 
 # Sources that are only needed to run a program.
 file(GLOB run_SRC

--- a/src/debugger.cc
+++ b/src/debugger.cc
@@ -161,6 +161,12 @@ void Debugger::handle_command(const char* line) {
     if (sscanf(line + 12, "%d", &frame) == 1) cmd_inspect(frame);
   } else if (strcmp(line, "dbg:continue") == 0) {
     cmd_continue();
+  } else if (strcmp(line, "dbg:step") == 0) {
+    cmd_step(1, "step");
+  } else if (strcmp(line, "dbg:over") == 0) {
+    cmd_step(2, "over");
+  } else if (strcmp(line, "dbg:out") == 0) {
+    cmd_step(3, "out");
   }
   // Unknown verbs are silently ignored in this task; the full verb set and
   // error reporting arrive in later tasks.
@@ -177,16 +183,16 @@ Program* Debugger::await_target() {
 }
 
 void Debugger::build_registry(Program* program) {
-  // Cached per program: the registry is immutable for a given program, and is
-  // only ever read/written on the controller thread, so no lock is needed.
+  // Cached per program: the registry is immutable for a given program. It is
+  // built/read on the controller thread, but `resolve_step_location` reads it
+  // from the scheduler thread, so the mutation is guarded by `mutex_`.
   if (registry_program_ == program) return;
-  registry_program_ = program;
-  registry_.clear();
 
   // Enumerate the program's methods from its dispatch table, deduplicating by
   // entry bci (a method may appear under several dispatch indices). 1-based ids
   // are simply the position in `registry_`. We keep the dispatch-table order
   // (rather than sorting) so ids stay identical to Task 2's enumeration.
+  std::vector<MethodInfo> built;
   std::vector<word> seen;
   for (int i = 0; i < program->dispatch_table.length(); i++) {
     int32 header_bci = program->dispatch_table[i];
@@ -199,8 +205,30 @@ void Debugger::build_registry(Program* program) {
     }
     if (duplicate) continue;
     seen.push_back(entry_bci);
-    registry_.push_back(MethodInfo{entry_bci, method.arity()});
+    built.push_back(MethodInfo{entry_bci, method.arity()});
   }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  registry_program_ = program;
+  registry_ = std::move(built);
+}
+
+void Debugger::resolve_step_location(Program* program, word bci) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  // The containing method is the one with the greatest entry bci <= bci. If the
+  // registry has not been built yet (no `dbg:methods` issued), fall back to the
+  // absolute bci with an unknown id, mirroring the stop-at-entry pause.
+  word best_entry = -1;
+  int best_id = -1;
+  for (int i = 0; i < static_cast<int>(registry_.size()); i++) {
+    word entry = registry_[i].entry_bci;
+    if (entry <= bci && entry > best_entry) {
+      best_entry = entry;
+      best_id = i + 1;
+    }
+  }
+  last_id_ = best_id;
+  last_off_ = best_entry < 0 ? bci : (bci - best_entry);
 }
 
 void Debugger::cmd_methods() {
@@ -302,6 +330,22 @@ void Debugger::cmd_continue() {
   }
   // Resume outside our own lock: resume_debug_process takes the scheduler lock.
   scheduler_->resume_debug_process(pid, 0);
+}
+
+void Debugger::cmd_step(int step_mode, const char* verb) {
+  int pid;
+  { std::unique_lock<std::mutex> lock(mutex_);
+    cond_.wait_for(lock, std::chrono::milliseconds(800),
+                   [this] { return paused_pid_ != -1 || stopped_; });
+    if (stopped_ || paused_pid_ == -1) return;  // Nothing parked: ignore.
+    pid = paused_pid_;
+    paused_pid_ = -1;
+  }
+  // Resume the target in the requested step mode. The interpreter captures the
+  // start depth on the resumed bytecode and pauses again per the step rule.
+  scheduler_->resume_debug_process(pid, step_mode);
+  printf("dbg:ok %s\n", verb);
+  fflush(stdout);
 }
 
 } // namespace toit

--- a/src/debugger.cc
+++ b/src/debugger.cc
@@ -298,6 +298,35 @@ void Debugger::cmd_inspect(int frame_index) {
   scheduler_->inspect_debug_process(pid, this, frame_index);
 }
 
+void Debugger::emit_string(String* string) {
+  // Cap the emitted content so a huge string cannot flood the wire; the operator
+  // UI shows a value, not the whole heap. Truncation is marked with an ellipsis
+  // inside the quotes.
+  static const word MAX_CHARS = 128;
+  String::Bytes bytes(string);
+  word length = bytes.length();
+  word emit = length < MAX_CHARS ? length : MAX_CHARS;
+  putchar('"');
+  for (word i = 0; i < emit; i++) {
+    uint8 c = bytes.at(i);
+    switch (c) {
+      case '"':  printf("\\\""); break;
+      case '\\': printf("\\\\"); break;
+      case '\n': printf("\\n"); break;
+      case '\r': printf("\\r"); break;
+      case '\t': printf("\\t"); break;
+      default:
+        if (c < 0x20) {
+          printf("\\x%02x", c);
+        } else {
+          putchar(c);
+        }
+    }
+  }
+  if (length > emit) printf("...");
+  putchar('"');
+}
+
 void Debugger::emit_stack(Locker& locker, Process* process, int frame_index) {
   Program* program = process->program();
   Stack* stack = process->task()->stack();
@@ -308,9 +337,23 @@ void Debugger::emit_stack(Locker& locker, Process* process, int frame_index) {
     Object* value = stack->frame_register(program, frame_index, i);
     if (is_smi(value)) {
       printf(" r%d=%lld", i, static_cast<long long>(Smi::value(value)));
+    } else if (value == program->null_object()) {
+      printf(" r%d=null", i);
+    } else if (value == program->true_object()) {
+      printf(" r%d=true", i);
+    } else if (value == program->false_object()) {
+      printf(" r%d=false", i);
+    } else if (is_double(value)) {
+      printf(" r%d=%g", i, Double::cast(value)->value());
+    } else if (is_string(value)) {
+      printf(" r%d=", i);
+      emit_string(String::cast(value));
     } else {
-      // Class-name resolution for heap objects is a later phase; emit a marker.
-      printf(" r%d=<obj>", i);
+      // Heap object: emit the numeric class id. The operator-side tool resolves
+      // the class name offline (the wire protocol stays "VM numeric, names
+      // resolved offline").
+      int class_id = Smi::value(HeapObject::cast(value)->class_id());
+      printf(" r%d=<obj:%d>", i, class_id);
     }
   }
   printf("\n");

--- a/src/debugger.cc
+++ b/src/debugger.cc
@@ -154,6 +154,11 @@ void Debugger::handle_command(const char* line) {
     if (sscanf(line + 10, "%d %d", &id, &off) == 2) {
       cmd_clear(id, off);
     }
+  } else if (strcmp(line, "dbg:inspect") == 0) {
+    cmd_inspect(0);
+  } else if (strncmp(line, "dbg:inspect ", 12) == 0) {
+    int frame = 0;
+    if (sscanf(line + 12, "%d", &frame) == 1) cmd_inspect(frame);
   } else if (strcmp(line, "dbg:continue") == 0) {
     cmd_continue();
   }
@@ -248,6 +253,39 @@ void Debugger::cmd_clear(int id, int off) {
     }
   }
   printf("dbg:ok clear\n");
+  fflush(stdout);
+}
+
+void Debugger::cmd_inspect(int frame_index) {
+  int pid;
+  { std::unique_lock<std::mutex> lock(mutex_);
+    // Wait briefly for a parked process; do NOT clear paused_pid_ — inspection
+    // leaves the process parked so the operator can continue (or inspect again).
+    cond_.wait_for(lock, std::chrono::milliseconds(800),
+                   [this] { return paused_pid_ != -1 || stopped_; });
+    if (stopped_ || paused_pid_ == -1) return;  // Nothing parked: ignore.
+    pid = paused_pid_;
+  }
+  // Read the parked stack under the scheduler lock (emit_stack does the output).
+  scheduler_->inspect_debug_process(pid, this, frame_index);
+}
+
+void Debugger::emit_stack(Locker& locker, Process* process, int frame_index) {
+  Program* program = process->program();
+  Stack* stack = process->task()->stack();
+  word off = stack->frame_absolute_bci(program, frame_index);
+  int count = stack->frame_register_count(program, frame_index);
+  printf("dbg:stack off=%d", static_cast<int>(off));
+  for (int i = 0; i < count; i++) {
+    Object* value = stack->frame_register(program, frame_index, i);
+    if (is_smi(value)) {
+      printf(" r%d=%lld", i, static_cast<long long>(Smi::value(value)));
+    } else {
+      // Class-name resolution for heap objects is a later phase; emit a marker.
+      printf(" r%d=<obj>", i);
+    }
+  }
+  printf("\n");
   fflush(stdout);
 }
 

--- a/src/debugger.cc
+++ b/src/debugger.cc
@@ -148,6 +148,12 @@ void Debugger::handle_command(const char* line) {
     if (sscanf(line + 10, "%d %d", &id, &off) == 2) {
       cmd_break(id, off);
     }
+  } else if (strncmp(line, "dbg:clear ", 10) == 0) {
+    int id = 0;
+    int off = 0;
+    if (sscanf(line + 10, "%d %d", &id, &off) == 2) {
+      cmd_clear(id, off);
+    }
   } else if (strcmp(line, "dbg:continue") == 0) {
     cmd_continue();
   }
@@ -155,21 +161,28 @@ void Debugger::handle_command(const char* line) {
   // error reporting arrive in later tasks.
 }
 
-void Debugger::cmd_methods() {
-  // Wait until the target program is known (it is captured when the first
-  // non-privileged process runs and parks at its entry).
-  Program* program;
-  { std::unique_lock<std::mutex> lock(mutex_);
-    cond_.wait(lock, [this] { return target_program_ != null || stopped_; });
-    if (stopped_) return;
-    program = target_program_;
-    registry_entry_bcis_.clear();
-  }
+// Returns the target program once it is known, or null if the session is
+// stopping. Blocks until the first non-privileged process has parked at its
+// entry (which is when `target_program_` is captured).
+Program* Debugger::await_target() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  cond_.wait(lock, [this] { return target_program_ != null || stopped_; });
+  if (stopped_) return null;
+  return target_program_;
+}
 
-  // Minimal registry: enumerate the program's methods from the dispatch table,
-  // deduplicating by entry bci. 1-based ids; emit `<id> <entry_bci> <arity>`.
+void Debugger::build_registry(Program* program) {
+  // Cached per program: the registry is immutable for a given program, and is
+  // only ever read/written on the controller thread, so no lock is needed.
+  if (registry_program_ == program) return;
+  registry_program_ = program;
+  registry_.clear();
+
+  // Enumerate the program's methods from its dispatch table, deduplicating by
+  // entry bci (a method may appear under several dispatch indices). 1-based ids
+  // are simply the position in `registry_`. We keep the dispatch-table order
+  // (rather than sorting) so ids stay identical to Task 2's enumeration.
   std::vector<word> seen;
-  int id = 0;
   for (int i = 0; i < program->dispatch_table.length(); i++) {
     int32 header_bci = program->dispatch_table[i];
     if (header_bci < 0) continue;
@@ -181,26 +194,60 @@ void Debugger::cmd_methods() {
     }
     if (duplicate) continue;
     seen.push_back(entry_bci);
-    id++;
-    registry_entry_bcis_.push_back(entry_bci);
-    printf("%d %d %d\n", id, static_cast<int>(entry_bci), method.arity());
+    registry_.push_back(MethodInfo{entry_bci, method.arity()});
+  }
+}
+
+void Debugger::cmd_methods() {
+  Program* program = await_target();
+  if (program == null) return;
+  build_registry(program);
+
+  // One line per method: `<id> <entry_bci> <arity>`, then the terminator.
+  for (int i = 0; i < static_cast<int>(registry_.size()); i++) {
+    const MethodInfo& method = registry_[i];
+    printf("%d %d %d\n", i + 1, static_cast<int>(method.entry_bci), method.arity);
   }
   printf("dbg:ok methods\n");
   fflush(stdout);
 }
 
 void Debugger::cmd_break(int id, int off) {
-  Program* program;
-  word entry_bci;
-  { std::lock_guard<std::mutex> lock(mutex_);
-    program = target_program_;
-    if (program == null || id < 1 || id > static_cast<int>(registry_entry_bcis_.size())) {
-      return;
-    }
-    entry_bci = registry_entry_bcis_[id - 1];
+  Program* program = await_target();
+  if (program == null) return;
+  build_registry(program);
+  if (id < 1 || id > static_cast<int>(registry_.size())) {
+    printf("dbg:error no-method\n");
+    fflush(stdout);
+    return;
   }
-  add_breakpoint(program, entry_bci, off, id);
+  add_breakpoint(program, registry_[id - 1].entry_bci, off, id);
   printf("dbg:ok break\n");
+  fflush(stdout);
+}
+
+void Debugger::cmd_clear(int id, int off) {
+  Program* program = await_target();
+  if (program == null) return;
+  build_registry(program);
+  if (id < 1 || id > static_cast<int>(registry_.size())) {
+    printf("dbg:error no-method\n");
+    fflush(stdout);
+    return;
+  }
+  word entry_bci = registry_[id - 1].entry_bci;
+  // Clearing is idempotent: removing a breakpoint that was never set still
+  // reports `dbg:ok clear`. Only an unknown id is an error (handled above).
+  { std::lock_guard<std::mutex> lock(mutex_);
+    for (auto it = breakpoints_.begin(); it != breakpoints_.end();) {
+      if (it->program == program && it->entry_bci == entry_bci && it->off == off) {
+        it = breakpoints_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+  printf("dbg:ok clear\n");
   fflush(stdout);
 }
 

--- a/src/debugger.cc
+++ b/src/debugger.cc
@@ -1,0 +1,222 @@
+// Copyright (C) 2026 Toitware ApS.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#include "debugger.h"
+
+#include <chrono>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "objects.h"
+#include "process.h"
+#include "program.h"
+#include "scheduler.h"
+
+namespace toit {
+
+// The controller thread is a real OS thread (not a scheduler worker), so it is
+// allowed to block on stdin while reading `dbg:` commands.
+class Debugger::ControllerThread : public Thread {
+ public:
+  explicit ControllerThread(Debugger* debugger)
+      : Thread("Debugger")
+      , debugger_(debugger) {}
+
+ protected:
+  void entry() override { debugger_->run_controller(); }
+
+ private:
+  Debugger* const debugger_;
+};
+
+Debugger::Debugger(Scheduler* scheduler) : scheduler_(scheduler) {}
+
+Debugger::~Debugger() {
+  // The process is exiting; the controller thread (if blocked on stdin) is
+  // reaped by the OS. We intentionally do not join it here to avoid hanging on
+  // a blocking read during teardown.
+  delete controller_;
+}
+
+void Debugger::start() {
+  // The debugger uses STL containers (std::vector/std::condition_variable)
+  // whose allocations go through the throwing global `operator new`, which the
+  // VM normally forbids. Debugging is an opt-in, dev-only mode, so we lift the
+  // guard for the session.
+  throwing_new_allowed = true;
+  printf("dbg:ready\n");
+  fflush(stdout);
+  controller_ = _new ControllerThread(this);
+  if (controller_ == null) FATAL("Cannot allocate debugger controller thread");
+  if (!controller_->spawn()) FATAL("Cannot spawn debugger controller thread");
+}
+
+void Debugger::stop() {
+  { std::lock_guard<std::mutex> lock(mutex_);
+    if (stopped_) return;
+    stopped_ = true;
+    cond_.notify_all();
+  }
+  // Best-effort unblock of the controller's blocking stdin read; it also exits
+  // when the operator (or the harness) closes stdin and the read sees EOF.
+  close(STDIN_FILENO);
+  if (controller_ != null) controller_->join();
+}
+
+bool Debugger::should_break(Program* program, word bci) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (target_program_ == null) {
+    // First non-privileged program: bind the debugger to it and force a pause
+    // at its entry so breakpoints can be installed before it makes progress.
+    target_program_ = program;
+    last_id_ = -1;
+    last_off_ = 0;
+    cond_.notify_all();
+    return true;
+  }
+  if (program != target_program_) return false;
+  for (auto& bp : breakpoints_) {
+    if (program == bp.program && bci == bp.entry_bci + bp.off) {
+      last_id_ = bp.id;
+      last_off_ = bp.off;
+      return true;
+    }
+  }
+  return false;
+}
+
+void Debugger::on_pause(Process* process, Program* program, word bci, int reason) {
+  const char* kind = reason == REASON_STEP ? "step" : "break";
+  printf("dbg:paused %s %d %d\n", kind, last_id_, static_cast<int>(last_off_));
+  fflush(stdout);
+}
+
+void Debugger::add_breakpoint(Program* program, word entry_bci, word off, int id) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  breakpoints_.push_back(Breakpoint{program, entry_bci, off, id});
+}
+
+void Debugger::register_paused(Locker& locker, Process* process) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  paused_pid_ = process->id();
+  cond_.notify_all();
+}
+
+// --- Controller thread -----------------------------------------------------
+
+void Debugger::run_controller() {
+  // Line-buffered reader over stdin. We use raw read() so we are not affected
+  // by stdio buffering of the (possibly shared) stdin stream.
+  char buffer[512];
+  int length = 0;
+  while (true) {
+    { std::lock_guard<std::mutex> lock(mutex_);
+      if (stopped_) break;
+    }
+    char c;
+    int n = read(STDIN_FILENO, &c, 1);
+    if (n <= 0) break;  // EOF or error: the session is over.
+    if (c == '\n') {
+      buffer[length] = '\0';
+      handle_command(buffer);
+      length = 0;
+    } else if (length < static_cast<int>(sizeof(buffer)) - 1) {
+      buffer[length++] = c;
+    }
+  }
+}
+
+void Debugger::handle_command(const char* line) {
+  if (strcmp(line, "dbg:methods") == 0) {
+    cmd_methods();
+  } else if (strncmp(line, "dbg:break ", 10) == 0) {
+    int id = 0;
+    int off = 0;
+    if (sscanf(line + 10, "%d %d", &id, &off) == 2) {
+      cmd_break(id, off);
+    }
+  } else if (strcmp(line, "dbg:continue") == 0) {
+    cmd_continue();
+  }
+  // Unknown verbs are silently ignored in this task; the full verb set and
+  // error reporting arrive in later tasks.
+}
+
+void Debugger::cmd_methods() {
+  // Wait until the target program is known (it is captured when the first
+  // non-privileged process runs and parks at its entry).
+  Program* program;
+  { std::unique_lock<std::mutex> lock(mutex_);
+    cond_.wait(lock, [this] { return target_program_ != null || stopped_; });
+    if (stopped_) return;
+    program = target_program_;
+    registry_entry_bcis_.clear();
+  }
+
+  // Minimal registry: enumerate the program's methods from the dispatch table,
+  // deduplicating by entry bci. 1-based ids; emit `<id> <entry_bci> <arity>`.
+  std::vector<word> seen;
+  int id = 0;
+  for (int i = 0; i < program->dispatch_table.length(); i++) {
+    int32 header_bci = program->dispatch_table[i];
+    if (header_bci < 0) continue;
+    Method method(&program->bytecodes[header_bci]);
+    word entry_bci = program->absolute_bci_from_bcp(method.entry());
+    bool duplicate = false;
+    for (auto e : seen) {
+      if (e == entry_bci) { duplicate = true; break; }
+    }
+    if (duplicate) continue;
+    seen.push_back(entry_bci);
+    id++;
+    registry_entry_bcis_.push_back(entry_bci);
+    printf("%d %d %d\n", id, static_cast<int>(entry_bci), method.arity());
+  }
+  printf("dbg:ok methods\n");
+  fflush(stdout);
+}
+
+void Debugger::cmd_break(int id, int off) {
+  Program* program;
+  word entry_bci;
+  { std::lock_guard<std::mutex> lock(mutex_);
+    program = target_program_;
+    if (program == null || id < 1 || id > static_cast<int>(registry_entry_bcis_.size())) {
+      return;
+    }
+    entry_bci = registry_entry_bcis_[id - 1];
+  }
+  add_breakpoint(program, entry_bci, off, id);
+  printf("dbg:ok break\n");
+  fflush(stdout);
+}
+
+void Debugger::cmd_continue() {
+  int pid;
+  { std::unique_lock<std::mutex> lock(mutex_);
+    // Wait briefly for a parked process. Bounded so that surplus `continue`
+    // commands (after the program has finished) do not block forever.
+    cond_.wait_for(lock, std::chrono::milliseconds(800),
+                   [this] { return paused_pid_ != -1 || stopped_; });
+    if (stopped_ || paused_pid_ == -1) return;  // Nothing parked: ignore.
+    pid = paused_pid_;
+    paused_pid_ = -1;
+  }
+  // Resume outside our own lock: resume_debug_process takes the scheduler lock.
+  scheduler_->resume_debug_process(pid, 0);
+}
+
+} // namespace toit

--- a/src/debugger.h
+++ b/src/debugger.h
@@ -94,6 +94,11 @@ class Debugger {
   // holds the scheduler lock, so the parked stack is stable while we read it.
   void emit_stack(Locker& locker, Process* process, int frame_index);
 
+  // Prints a String register value as a double-quoted, escaped token (escapes
+  // " \ and control chars so the value stays whitespace-delimited on the wire,
+  // and truncates over-long strings). Used by emit_stack.
+  void emit_string(String* string);
+
  private:
   struct Breakpoint {
     Program* program;

--- a/src/debugger.h
+++ b/src/debugger.h
@@ -92,11 +92,26 @@ class Debugger {
 
   class ControllerThread;
 
+  // A registered method of the target program. `entry_bci` is program-relative
+  // (the bci of the method's first bytecode); breakpoints are keyed on it.
+  struct MethodInfo {
+    word entry_bci;
+    int arity;
+  };
+
   // Controller-thread command handling.
   void run_controller();
   void handle_command(const char* line);
+  // Block until the target program is captured (or the session stops); returns
+  // the program, or null if stopping.
+  Program* await_target();
+  // Build (once, then cache) the id->method registry for `program`. Enumerates
+  // the program's methods from its dispatch table, deduplicating by entry bci,
+  // and assigns 1-based ids. Only ever touched on the controller thread.
+  void build_registry(Program* program);
   void cmd_methods();
   void cmd_break(int id, int off);
+  void cmd_clear(int id, int off);
   void cmd_continue();
 
   Scheduler* const scheduler_;
@@ -121,9 +136,13 @@ class Debugger {
   int last_id_ = -1;
   word last_off_ = 0;
 
-  // Minimal id->entry_bci registry built by `cmd_methods`, used by `cmd_break`.
-  // (A full, name-resolving registry is Task 4.)
-  std::vector<word> registry_entry_bcis_;
+  // Numeric id -> method registry for the target program, built lazily by
+  // `build_registry` and cached per program. `registry_[id - 1]` holds the
+  // method for 1-based id. Used by `cmd_break`/`cmd_clear` to resolve ids.
+  // (Method-name resolution stays in the offline driver; the VM is numeric
+  // only.)
+  Program* registry_program_ = null;
+  std::vector<MethodInfo> registry_;
 };
 
 } // namespace toit

--- a/src/debugger.h
+++ b/src/debugger.h
@@ -75,6 +75,13 @@ class Debugger {
   // Print the `dbg:paused ...` line for the current pause.
   void on_pause(Process* process, Program* program, word bci, int reason);
 
+  // Resolve the `<id> <off>` reported for a single-step pause at `bci`: finds
+  // the registered method that contains `bci` (the greatest entry bci <= bci)
+  // and records its id plus the method-relative offset, so a step pause is
+  // reported just like a breakpoint. Called from the interpreter (scheduler
+  // thread); guards the registry with `mutex_`.
+  void resolve_step_location(Program* program, word bci);
+
   // Install a breakpoint at `entry_bci + off` in `program`, reported as `id`.
   void add_breakpoint(Program* program, word entry_bci, word off, int id);
 
@@ -119,6 +126,9 @@ class Debugger {
   void cmd_clear(int id, int off);
   void cmd_inspect(int frame_index);
   void cmd_continue();
+  // Resume the parked process in a step mode (1 step, 2 over, 3 out) and
+  // acknowledge with `dbg:ok <verb>`.
+  void cmd_step(int step_mode, const char* verb);
 
   Scheduler* const scheduler_;
   ControllerThread* controller_ = null;

--- a/src/debugger.h
+++ b/src/debugger.h
@@ -82,6 +82,11 @@ class Debugger {
   // DEBUG_PAUSED result. Records it and wakes a waiting controller command.
   void register_paused(Locker& locker, Process* process);
 
+  // Emit `dbg:stack off=<bci> r0=<v> r1=<v> …` for `frame_index` of the parked
+  // `process`. Called by the scheduler from `inspect_debug_process` while it
+  // holds the scheduler lock, so the parked stack is stable while we read it.
+  void emit_stack(Locker& locker, Process* process, int frame_index);
+
  private:
   struct Breakpoint {
     Program* program;
@@ -112,6 +117,7 @@ class Debugger {
   void cmd_methods();
   void cmd_break(int id, int off);
   void cmd_clear(int id, int off);
+  void cmd_inspect(int frame_index);
   void cmd_continue();
 
   Scheduler* const scheduler_;

--- a/src/debugger.h
+++ b/src/debugger.h
@@ -1,0 +1,129 @@
+// Copyright (C) 2026 Toitware ApS.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+#include <vector>
+
+#include "os.h"
+#include "top.h"
+
+namespace toit {
+
+class Locker;
+class Process;
+class Program;
+class Scheduler;
+
+// An in-image bytecode debugger speaking the line-based `dbg:` protocol over
+// stdout/stdin. It is owned by the VM and active only when debugging is enabled
+// (the `--debug` flag or the OEVM_DEBUG/TOIT_DEBUG environment variable).
+//
+// Threading model:
+//   - The interpreter (a scheduler worker thread) calls `should_break` /
+//     `on_pause` for every bytecode of a non-privileged process. On a hit it
+//     returns DEBUG_PAUSED and the scheduler parks the process.
+//   - `register_paused` runs on the scheduler thread, under the scheduler lock,
+//     once the process is actually parked.
+//   - A dedicated controller thread (NOT a scheduler worker, so it may block on
+//     stdin) reads `dbg:` commands and re-readies parked processes via
+//     `Scheduler::resume_debug_process`.
+// The debugger's own state is guarded by `mutex_`; a condition variable hands
+// off pause/target events between the threads.
+class Debugger {
+ public:
+  // Reason a process paused. Passed to `on_pause`.
+  enum Reason {
+    REASON_BREAK,
+    REASON_STEP,
+  };
+
+  explicit Debugger(Scheduler* scheduler);
+  ~Debugger();
+
+  bool active() const { return true; }
+
+  // Print `dbg:ready` and start the controller thread. Call once, before the
+  // target program runs.
+  void start();
+
+  // Stop the controller thread and join it. Must be called before the scheduler
+  // is torn down so the controller can no longer touch it.
+  void stop();
+
+  // Called from the interpreter for every bytecode of a non-privileged process.
+  // Returns true if execution should pause at `bci` (program-relative). Keys
+  // breakpoints on (Program*, entry_bci, off). Also captures the first
+  // non-privileged program and forces a pause at its entry so the operator can
+  // install breakpoints before the program makes progress.
+  bool should_break(Program* program, word bci);
+
+  // Print the `dbg:paused ...` line for the current pause.
+  void on_pause(Process* process, Program* program, word bci, int reason);
+
+  // Install a breakpoint at `entry_bci + off` in `program`, reported as `id`.
+  void add_breakpoint(Program* program, word entry_bci, word off, int id);
+
+  // Called by the scheduler (under its lock) once a process has parked on a
+  // DEBUG_PAUSED result. Records it and wakes a waiting controller command.
+  void register_paused(Locker& locker, Process* process);
+
+ private:
+  struct Breakpoint {
+    Program* program;
+    word entry_bci;
+    word off;
+    int id;
+  };
+
+  class ControllerThread;
+
+  // Controller-thread command handling.
+  void run_controller();
+  void handle_command(const char* line);
+  void cmd_methods();
+  void cmd_break(int id, int off);
+  void cmd_continue();
+
+  Scheduler* const scheduler_;
+  ControllerThread* controller_ = null;
+
+  std::mutex mutex_;
+  std::condition_variable cond_;
+
+  // The user program we are debugging (first non-privileged program seen).
+  Program* target_program_ = null;
+  std::vector<Breakpoint> breakpoints_;
+
+  // The currently parked process (or -1 if none is parked).
+  int paused_pid_ = -1;
+
+  // Set during teardown to wake any waiting controller command and stop the
+  // controller loop from touching the scheduler.
+  bool stopped_ = false;
+
+  // Information about the most recent pause, for `on_pause` to report. Only
+  // touched on the single scheduler worker thread.
+  int last_id_ = -1;
+  word last_off_ = 0;
+
+  // Minimal id->entry_bci registry built by `cmd_methods`, used by `cmd_break`.
+  // (A full, name-resolving registry is Task 4.)
+  std::vector<word> registry_entry_bcis_;
+};
+
+} // namespace toit

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -55,28 +55,60 @@ void Interpreter::set_debugger(Debugger* debugger) {
 }
 
 void Interpreter::debug_resume(int step_mode) {
-  // We are parked on the breakpoint bytecode. Skip the break check exactly
-  // once so we make progress past it, then resume normal (or stepping) checks.
-  debug_skip_once_ = true;
-  debug_stepping_ = step_mode != 0;
+  // We are parked on the breakpoint bytecode. Record the step state on the
+  // *process* (not the shared interpreter) so it can never leak to another
+  // process. The skip-once lets us make progress past the bytecode we parked
+  // on; the start depth is captured lazily on that skipped bytecode below.
+  process_->debug_begin_resume(step_mode);
+}
+
+int Interpreter::debug_frame_depth(Object** sp) {
+  // While running, the Stack's stored top is -1, so `frames_do` is unusable.
+  // Count frame markers directly between the live `sp` and the stack base.
+  // This is a self-consistent depth metric: deeper calls push more markers, so
+  // the value rises on a call and falls on a return, which is all the step/over/
+  // out comparisons need.
+  Object* marker = process_->program()->frame_marker();
+  int depth = 0;
+  for (Object** p = sp; p < base_; p++) {
+    if (*p == marker) depth++;
+  }
+  return depth;
 }
 
 bool Interpreter::debug_check(uint8* bcp, Object** sp) {
-  if (debug_skip_once_) {
-    debug_skip_once_ = false;
+  Process* process = process_;
+  if (process->debug_skip_once()) {
+    process->clear_debug_skip_once();
+    // Capture the start depth at the resume site so over/out can compare
+    // against it. Only needed when actively stepping (mode != 0).
+    if (process->debug_step_mode() != 0) {
+      process->set_debug_step_depth(debug_frame_depth(sp));
+    }
     return false;
   }
   // Never pause privileged (system) processes; the debugger targets user code.
-  if (process_->is_privileged()) return false;
-  Program* program = process_->program();
+  if (process->is_privileged()) return false;
+  Program* program = process->program();
   word bci = program->absolute_bci_from_bcp(bcp);
   if (debugger_->should_break(program, bci)) {
-    debugger_->on_pause(process_, program, bci, Debugger::REASON_BREAK);
+    debugger_->on_pause(process, program, bci, Debugger::REASON_BREAK);
     return true;
   }
-  if (debug_stepping_) {
-    debugger_->on_pause(process_, program, bci, Debugger::REASON_STEP);
-    return true;
+  int mode = process->debug_step_mode();
+  if (mode != 0) {
+    int depth = debug_frame_depth(sp);
+    // step (1): pause on every bytecode.
+    // over (2): pause when back at or above the start depth (don't descend).
+    // out  (3): pause only after returning to a shallower frame.
+    bool hit = (mode == 1) ||
+               (mode == 2 && depth <= process->debug_step_depth()) ||
+               (mode == 3 && depth < process->debug_step_depth());
+    if (hit) {
+      debugger_->resolve_step_location(program, bci);
+      debugger_->on_pause(process, program, bci, Debugger::REASON_STEP);
+      return true;
+    }
   }
   return false;
 }

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -15,11 +15,13 @@
 
 #include "interpreter.h"
 
+#include "debugger.h"
 #include "flags.h"
 #include "heap_report.h"
 #include "objects_inline.h"
 #include "printing.h"
 #include "process.h"
+#include "program.h"
 #include "scheduler.h"
 #include "vm.h"
 
@@ -45,6 +47,38 @@ void Interpreter::deactivate() {
 
 void Interpreter::preempt() {
   watermark_ = PREEMPTION_MARKER;
+}
+
+void Interpreter::set_debugger(Debugger* debugger) {
+  debugger_ = debugger;
+  debug_active_ = debugger != null && debugger->active();
+}
+
+void Interpreter::debug_resume(int step_mode) {
+  // We are parked on the breakpoint bytecode. Skip the break check exactly
+  // once so we make progress past it, then resume normal (or stepping) checks.
+  debug_skip_once_ = true;
+  debug_stepping_ = step_mode != 0;
+}
+
+bool Interpreter::debug_check(uint8* bcp, Object** sp) {
+  if (debug_skip_once_) {
+    debug_skip_once_ = false;
+    return false;
+  }
+  // Never pause privileged (system) processes; the debugger targets user code.
+  if (process_->is_privileged()) return false;
+  Program* program = process_->program();
+  word bci = program->absolute_bci_from_bcp(bcp);
+  if (debugger_->should_break(program, bci)) {
+    debugger_->on_pause(process_, program, bci, Debugger::REASON_BREAK);
+    return true;
+  }
+  if (debug_stepping_) {
+    debugger_->on_pause(process_, program, bci, Debugger::REASON_STEP);
+    return true;
+  }
+  return false;
 }
 
 Method Interpreter::lookup_entry() {

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -42,6 +42,8 @@
 
 namespace toit {
 
+class Debugger;
+
 typedef double (double_op)(double a, double b);
 
 class Interpreter {
@@ -87,6 +89,7 @@ class Interpreter {
       YIELDED,
       TERMINATED,
       DEEP_SLEEP,
+      DEBUG_PAUSED,   // breakpoint/step hit: park the process for the debugger.
     };
 
     explicit Result(State state) : state_(state), value_(0) {}
@@ -148,6 +151,14 @@ class Interpreter {
   void preempt();
   uint8* preemption_method_header_bcp() const { return preemption_method_header_bcp_; }
 
+  // Debugger support. Attaching a (possibly null) debugger toggles the
+  // per-bytecode hook. When no debugger is attached, `debug_active_` is false
+  // and the hook is a single, well-predicted branch with no extra work.
+  void set_debugger(Debugger* debugger);
+  // Arrange for the next bytecode (the one we are parked on) to skip the break
+  // check once, and configure single-stepping for the resumed run.
+  void debug_resume(int step_mode);
+
   static bool are_smis(Object* a, Object* b);
   static bool are_floats(Object* a, Object* b);
 
@@ -166,6 +177,15 @@ class Interpreter {
 
   // Preemption method.
   uint8* preemption_method_header_bcp_;
+
+  // Debugger support.
+  Debugger* debugger_ = null;
+  bool debug_active_ = false;
+  bool debug_stepping_ = false;
+  bool debug_skip_once_ = false;
+  // Called from the dispatch loop for every bytecode when `debug_active_`.
+  // Returns true if execution should pause here (breakpoint or step).
+  bool debug_check(uint8* bcp, Object** sp);
 
   void trace(uint8* bcp);
   Method lookup_entry();

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -178,14 +178,19 @@ class Interpreter {
   // Preemption method.
   uint8* preemption_method_header_bcp_;
 
-  // Debugger support.
+  // Debugger support. The interpreter only holds the attach flag + debugger
+  // pointer; all per-step state (mode, skip-once, captured depth) lives on the
+  // Process so the shared per-thread interpreter never carries it across
+  // processes. See `Process::debug_begin_resume`.
   Debugger* debugger_ = null;
   bool debug_active_ = false;
-  bool debug_stepping_ = false;
-  bool debug_skip_once_ = false;
   // Called from the dispatch loop for every bytecode when `debug_active_`.
   // Returns true if execution should pause here (breakpoint or step).
   bool debug_check(uint8* bcp, Object** sp);
+  // Frame count between `sp` and the stack base, used as the stepping depth.
+  // Computed live (the Stack's stored top is -1 while running), so it counts
+  // frame markers directly rather than calling `Stack::frames_do`.
+  int debug_frame_depth(Object** sp);
 
   void trace(uint8* bcp);
   Method lookup_entry();

--- a/src/interpreter_run.cc
+++ b/src/interpreter_run.cc
@@ -98,8 +98,19 @@ Method Program::find_method(Object* receiver, word offset) {
 
 // OPCODE_TRACE is only called from within Interpreter::run which gives access to:
 //   uint8* bcp;
+// When a debugger is attached (`debug_active_`), every bytecode runs the debug
+// hook. The hook is gated on a single bool so there is zero overhead when not
+// debugging. On a breakpoint/step hit we store the stack (exactly like
+// CHECK_PREEMPT) and return DEBUG_PAUSED so the scheduler can park the process.
 #define OPCODE_TRACE() \
-  if (Flags::trace) trace(bcp);
+  if (Flags::trace) trace(bcp); \
+  if (debug_active_ && debug_check(bcp, sp)) {                        \
+    static_assert(FRAME_SIZE == 2, "Unexpected frame size");          \
+    PUSH(reinterpret_cast<Object*>(bcp));                             \
+    PUSH(program->frame_marker());                                    \
+    store_stack(sp);                                                  \
+    return Result(Result::DEBUG_PAUSED);                              \
+  }
 
 // Dispatching helper macros.
 #define DISPATCH(n)                                                                \

--- a/src/objects.cc
+++ b/src/objects.cc
@@ -332,6 +332,49 @@ int Stack::frames_do(Program* program, FrameCallback* cb) {
   return frame_no;
 }
 
+word Stack::_frame_marker_slot(Program* program, int frame_index) {
+  if (frame_index < 0) return -1;
+  word stack_length = _stack_base_addr() - _stack_sp_addr();
+  int marker = 0;
+  for (word index = 0; index < stack_length; index++) {
+    if (at(index) != program->frame_marker()) continue;
+    if (marker == frame_index) return index;
+    marker++;
+  }
+  return -1;
+}
+
+word Stack::frame_absolute_bci(Program* program, int frame_index) {
+  word slot = _frame_marker_slot(program, frame_index);
+  if (slot < 0) return -1;
+  word stack_length = _stack_base_addr() - _stack_sp_addr();
+  if (slot + 1 >= stack_length) return -1;
+  uint8* bcp = reinterpret_cast<uint8*>(at(slot + 1));
+  if (!program->bytecodes.is_inside(bcp)) return -1;
+  return program->absolute_bci_from_bcp(bcp);
+}
+
+int Stack::frame_register_count(Program* program, int frame_index) {
+  word slot = _frame_marker_slot(program, frame_index);
+  if (slot < 0) return 0;
+  // Registers occupy the slots between this frame's marker (plus its saved bcp)
+  // and the next frame's marker; for the bottom frame they run to the base.
+  word start = slot + 2;
+  word next = _frame_marker_slot(program, frame_index + 1);
+  word end = (next >= 0) ? next : (_stack_base_addr() - _stack_sp_addr());
+  if (start >= end) return 0;
+  return static_cast<int>(end - start);
+}
+
+Object* Stack::frame_register(Program* program, int frame_index, int reg_index) {
+  word slot = _frame_marker_slot(program, frame_index);
+  if (slot < 0) return program->null_object();
+  word index = slot + 2 + reg_index;
+  word stack_length = _stack_base_addr() - _stack_sp_addr();
+  if (reg_index < 0 || index >= stack_length) return program->null_object();
+  return at(index);
+}
+
 void Instance::instance_roots_do(word instance_size, RootCallback* cb) {
   if (has_active_finalizer() && cb->skip_marking(this)) return;
   word fields = fields_from_size(instance_size);

--- a/src/objects.h
+++ b/src/objects.h
@@ -944,6 +944,20 @@ class Stack : public HeapObject {
   // Iterates over all frames on this stack and returns the number of frames.
   int frames_do(Program* program, FrameCallback* cb);
 
+  // Debugger support: read the registers/locals of a single frame of a stored
+  // (parked) stack. `frame_index` 0 is the top (innermost) frame. These are
+  // only safe to call while the owning process is parked and the heap is stable
+  // under the scheduler lock; they walk the frame markers exactly like
+  // `frames_do` but expose one frame's slots instead of unwinding.
+  //
+  // Layout: a frame's marker sits at some slot, its saved bcp at slot+1, and
+  // its registers at slot+2 .. up to the next frame's marker. For the top frame
+  // this marker is the one the debug hook pushed before parking, so slot+1 is
+  // the bytecode the process paused on.
+  word frame_absolute_bci(Program* program, int frame_index);
+  int frame_register_count(Program* program, int frame_index);
+  Object* frame_register(Program* program, int frame_index, int reg_index);
+
   static INLINE word initial_length() { return 64; }
   static INLINE word max_length();
 
@@ -990,6 +1004,11 @@ class Stack : public HeapObject {
   static const word PENDING_STACK_CHECK_METHOD_OFFSET = TRY_TOP_OFFSET + WORD_SIZE;
   static const word GUARD_ZONE_OFFSET = PENDING_STACK_CHECK_METHOD_OFFSET + WORD_SIZE;
   static const word HEADER_SIZE = GUARD_ZONE_OFFSET + GUARD_ZONE_SIZE;
+
+  // Slot index of the `frame_index`-th frame marker counting from sp (0 == top
+  // frame's marker), or -1 if there is no such frame. Used by the debugger frame
+  // readers above.
+  word _frame_marker_slot(Program* program, int frame_index);
 
   void _set_length(word value) { _word_at_put(LENGTH_OFFSET, value); }
   void _set_top(word value) { _word_at_put(TOP_OFFSET, value); }

--- a/src/process.h
+++ b/src/process.h
@@ -158,6 +158,17 @@ class Process : public ProcessListFromProcessGroup::Element,
   void clear_signal(Signal signal);
   uint32 signals() const { return signals_; }
 
+  // Debugger support. When a parked process is resumed by the debug controller,
+  // it stashes the step mode here; the scheduler consumes it (transfers it to
+  // the interpreter) the next time it runs the process. -1 means no pending
+  // debug resume.
+  void set_debug_resume(int step_mode) { debug_resume_ = step_mode; }
+  int take_debug_resume() {
+    int result = debug_resume_;
+    debug_resume_ = -1;
+    return result;
+  }
+
   // Processes have a priority in the range [0..255]. The scheduler
   // prioritizes running processes with higher priorities, so processes
   // with lower priorities might get starved by more important things.
@@ -299,6 +310,7 @@ class Process : public ProcessListFromProcessGroup::Element,
   int const id_;
   int next_task_id_;
   bool is_privileged_ = false;
+  int debug_resume_ = -1;
 
   Program* program_;
   ProcessRunner* runner_;

--- a/src/process.h
+++ b/src/process.h
@@ -169,6 +169,24 @@ class Process : public ProcessListFromProcessGroup::Element,
     return result;
   }
 
+  // Live single-step state, read/written by the interpreter's `debug_check` on
+  // the scheduler thread. It lives on the Process (NOT the shared per-thread
+  // Interpreter, which is reused across processes) so a step initiated for one
+  // process can never pause a different process that happens to run on the same
+  // interpreter. `step_mode`: 0 none, 1 step, 2 over, 3 out. `step_depth` is the
+  // frame count at the resume site, captured lazily on the first (skipped)
+  // bytecode after the resume. Begun once per resume by the interpreter.
+  void debug_begin_resume(int step_mode) {
+    debug_step_mode_ = step_mode;
+    debug_skip_once_ = true;
+    debug_step_depth_ = -1;
+  }
+  int debug_step_mode() const { return debug_step_mode_; }
+  bool debug_skip_once() const { return debug_skip_once_; }
+  void clear_debug_skip_once() { debug_skip_once_ = false; }
+  int debug_step_depth() const { return debug_step_depth_; }
+  void set_debug_step_depth(int depth) { debug_step_depth_ = depth; }
+
   // Processes have a priority in the range [0..255]. The scheduler
   // prioritizes running processes with higher priorities, so processes
   // with lower priorities might get starved by more important things.
@@ -311,6 +329,9 @@ class Process : public ProcessListFromProcessGroup::Element,
   int next_task_id_;
   bool is_privileged_ = false;
   int debug_resume_ = -1;
+  int debug_step_mode_ = 0;
+  bool debug_skip_once_ = false;
+  int debug_step_depth_ = -1;
 
   Program* program_;
   ProcessRunner* runner_;

--- a/src/run.cc
+++ b/src/run.cc
@@ -15,6 +15,7 @@
 
 #include <errno.h>
 #include <libgen.h>
+#include <stdlib.h>
 
 #include "top.h"
 #include "run.h"
@@ -64,6 +65,11 @@ int run_program(SnapshotBundle boot_bundle, SnapshotBundle application_bundle, c
     Scheduler::ExitState exit;
     { VM vm;
       vm.load_platform_event_sources();
+      // Activate the in-image debugger when requested. The `--debug` flag sets
+      // OEVM_DEBUG; the env vars also work directly.
+      if (getenv("OEVM_DEBUG") != null || getenv("TOIT_DEBUG") != null) {
+        vm.start_debugger();
+      }
       create_and_start_external_message_handlers(&vm);
       ProgramImage boot_image = read_image_from_bundle(boot_bundle);
       int group_id = vm.scheduler()->next_group_id();

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -14,6 +14,7 @@
 // directory of this repository.
 
 #include "resource.h"
+#include "debugger.h"
 #include "flags.h"
 #include "interpreter.h"
 #include "objects_inline.h"
@@ -48,8 +49,9 @@ void SchedulerThread::entry() {
   scheduler_->run(this);
 }
 
-Scheduler::Scheduler()
-    : mutex_(OS::allocate_mutex(2, "Scheduler"))
+Scheduler::Scheduler(VM* vm)
+    : vm_(vm)
+    , mutex_(OS::allocate_mutex(2, "Scheduler"))
     , has_processes_(OS::allocate_condition_variable(mutex_))
     , has_threads_(OS::allocate_condition_variable(mutex_))
     , gc_condition_(OS::allocate_condition_variable(mutex_))
@@ -59,7 +61,10 @@ Scheduler::Scheduler()
     , next_group_id_(0)
     , next_process_id_(0)
     , num_threads_(0)
-    , max_threads_(OS::num_cores())
+    // When debugging we cap to a single scheduler thread so a parked process
+    // cannot race sibling threads. The activation condition matches the one the
+    // VM uses to start the debugger (the `--debug` flag sets OEVM_DEBUG).
+    , max_threads_((getenv("OEVM_DEBUG") || getenv("TOIT_DEBUG")) ? 1 : OS::num_cores())
     , boot_process_(null) {
   Locker locker(mutex_);
 #ifdef TOIT_FREERTOS
@@ -637,6 +642,11 @@ void Scheduler::run_process(Locker& locker, Process* process, SchedulerThread* s
 
     Interpreter* interpreter = scheduler_thread->interpreter();
     interpreter->activate(process);
+    // Attach the debugger (null when not debugging: zero-overhead). If this
+    // process is resuming from a debug pause, transfer the step mode.
+    interpreter->set_debugger(vm_->debugger());
+    int debug_resume = process->take_debug_resume();
+    if (debug_resume >= 0) interpreter->debug_resume(debug_resume);
     process->set_idle_since_gc(false);
     if (process->signals() == 0) {
       Unlocker unlock(locker);
@@ -742,7 +752,22 @@ void Scheduler::run_process(Locker& locker, Process* process, SchedulerThread* s
       terminate_execution(locker, exit);
       break;
     }
+
+    case Interpreter::Result::DEBUG_PAUSED:
+      wait_for_any_gc_to_complete(locker, process, Process::IDLE);
+      // Do NOT process_ready: leave the target parked. The debug controller
+      // re-readies it via resume_debug_process when the operator continues.
+      vm_->debugger()->register_paused(locker, process);
+      break;
   }
+}
+
+void Scheduler::resume_debug_process(int pid, int step_mode) {
+  Locker locker(mutex_);
+  Process* process = find_process(locker, pid);
+  if (process == null) return;
+  process->set_debug_resume(step_mode);
+  process_ready(locker, process);
 }
 
 int Scheduler::get_priority(int pid) {

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -770,6 +770,14 @@ void Scheduler::resume_debug_process(int pid, int step_mode) {
   process_ready(locker, process);
 }
 
+void Scheduler::inspect_debug_process(int pid, Debugger* debugger, int frame_index) {
+  Locker locker(mutex_);
+  Process* process = find_process(locker, pid);
+  if (process == null) return;
+  // The process stays parked: we only read its stored stack, under the lock.
+  debugger->emit_stack(locker, process, frame_index);
+}
+
 int Scheduler::get_priority(int pid) {
   Locker locker(mutex_);
   Process* process = find_process(locker, pid);

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -25,6 +25,8 @@
 
 namespace toit {
 
+class VM;
+
 typedef LinkedList<SchedulerThread> SchedulerThreadList;
 
 class SchedulerThread : public Thread, public SchedulerThreadList::Element {
@@ -62,8 +64,14 @@ class Scheduler {
     int64 value;
   };
 
-  Scheduler();
+  explicit Scheduler(VM* vm);
   ~Scheduler();
+
+  // Re-ready a process that was parked on a DEBUG_PAUSED result. Called from the
+  // debugger's controller thread. `step_mode`: 0=continue, 1=step, 2=over,
+  // 3=out. The mode is stashed on the process and transferred to the
+  // interpreter when the process next runs.
+  void resume_debug_process(int pid, int step_mode);
 
 #ifdef TOIT_FREERTOS
   // Run the boot program and wait for all processes to run to completion.
@@ -208,6 +216,7 @@ class Scheduler {
   // Get the time for the next tick for process preemption.
   int64 tick_next() const { return next_tick_; }
 
+  VM* const vm_;
   Mutex* mutex_;
   ConditionVariable* has_processes_;
   ConditionVariable* has_threads_;

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -26,6 +26,7 @@
 namespace toit {
 
 class VM;
+class Debugger;
 
 typedef LinkedList<SchedulerThread> SchedulerThreadList;
 
@@ -72,6 +73,12 @@ class Scheduler {
   // 3=out. The mode is stashed on the process and transferred to the
   // interpreter when the process next runs.
   void resume_debug_process(int pid, int step_mode);
+
+  // Inspect a parked process under the scheduler lock so its heap (and stack) is
+  // stable while the debugger reads it. Finds the process by `pid` and, if it is
+  // still parked, calls back into `debugger->emit_stack` to emit the requested
+  // frame. Called from the debugger's controller thread.
+  void inspect_debug_process(int pid, Debugger* debugger, int frame_index);
 
 #ifdef TOIT_FREERTOS
   // Run the boot program and wait for all processes to run to completion.

--- a/src/toit_run.cc
+++ b/src/toit_run.cc
@@ -35,6 +35,7 @@
 
 #include <errno.h>
 #include <libgen.h>
+#include <stdlib.h>
 
 namespace toit {
 
@@ -82,6 +83,20 @@ static bool is_binary_file(const char* path) {
 
 int main(int argc, char **argv) {
   Flags::process_args(&argc, argv);
+
+  // Extract the `--debug` flag wherever it appears and remove it from argv, so
+  // the rest of the argument handling (including snapshot detection on argv[1])
+  // is unaffected. We activate the in-image debugger by setting OEVM_DEBUG,
+  // which is the single condition read by the scheduler and the VM.
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "--debug") == 0) {
+      setenv("OEVM_DEBUG", "1", 1);
+      for (int j = i; j < argc - 1; j++) argv[j] = argv[j + 1];
+      argc--;
+      i--;
+    }
+  }
+
   if (argc < 2) print_usage(1);
 
   FlashRegistry::set_up();

--- a/src/vm.cc
+++ b/src/vm.cc
@@ -15,6 +15,7 @@
 
 #include <signal.h>
 
+#include "debugger.h"
 #include "entropy_mixer.h"
 #include "memory.h"
 #include "program_memory.h"
@@ -43,7 +44,7 @@ VM::VM() {
 
   OS::reset_monotonic_time();  // Reset "up time".
   Primitive::set_up();
-  scheduler_ = _new Scheduler();
+  scheduler_ = _new Scheduler(this);
 
   event_manager_ = _new EventSourceManager();
   nop_event_source_ = _new NopEventSource();
@@ -52,8 +53,19 @@ VM::VM() {
 
 VM::~VM() {
   delete event_manager_;
+  // Stop the debug controller thread before tearing down the scheduler so it
+  // can no longer reach into it.
+  if (debugger_ != null) debugger_->stop();
   delete scheduler_;
+  delete debugger_;
   current_ = null;
+}
+
+void VM::start_debugger() {
+  ASSERT(debugger_ == null);
+  debugger_ = _new Debugger(scheduler_);
+  if (debugger_ == null) FATAL("Cannot allocate debugger");
+  debugger_->start();
 }
 
 VM* VM::current_ = null;

--- a/src/vm.h
+++ b/src/vm.h
@@ -19,6 +19,7 @@
 
 namespace toit {
 
+class Debugger;
 class EventSource;
 class EventSourceManager;
 class Scheduler;
@@ -42,9 +43,17 @@ class VM {
   EventSourceManager* event_manager() const { return event_manager_; }
   EventSource* nop_event_source() const { return nop_event_source_; }
 
+  // The debugger, or null when not debugging.
+  Debugger* debugger() const { return debugger_; }
+
+  // Create the debugger, start its controller thread, and print `dbg:ready`.
+  // Called once at startup when the debug condition holds.
+  void start_debugger();
+
  private:
   static VM* current_;
   Scheduler* scheduler_;
+  Debugger* debugger_ = null;
 
   EventSourceManager* event_manager_ = null;
   EventSource* nop_event_source_ = null;

--- a/tests/debugger/targets/call_in_loop.toit
+++ b/tests/debugger/targets/call_in_loop.toit
@@ -1,0 +1,18 @@
+// tests/debugger/targets/call_in_loop.toit
+//
+// Unlike count_to.toit (whose loop body lowers to smi intrinsics with no Toit
+// call frame), this target's loop body invokes a real Toit method (`helper`),
+// so it exercises the difference between `dbg:over` (skip the callee frame) and
+// `dbg:step` (descend into it).
+main:
+  result := run-loop 3
+  print "result=$result"
+
+helper x/int -> int:
+  return x + 1
+
+run-loop n/int -> int:
+  acc := 0
+  for i := 0; i < n; i++:
+    acc += helper i
+  return acc

--- a/tests/debugger/targets/count_to.toit
+++ b/tests/debugger/targets/count_to.toit
@@ -1,0 +1,10 @@
+// tests/debugger/targets/count_to.toit
+main:
+  result := count-to 5
+  print "result=$result"
+
+count-to n/int -> int:
+  sum := 0
+  for i := 0; i < n; i++:
+    sum += i
+  return sum

--- a/tests/debugger/test_dbg_protocol.py
+++ b/tests/debugger/test_dbg_protocol.py
@@ -1,0 +1,11 @@
+from tools.debug.dbg_protocol import parse_line
+
+def test_parse_paused_break():
+    assert parse_line("dbg:paused break 2 0") == {"kind": "paused", "mode": "break", "id": 2, "off": 0}
+
+def test_parse_stack():
+    p = parse_line("dbg:stack off=295 r0=0 r1=6")
+    assert p == {"kind": "stack", "off": 295, "regs": {0: "0", 1: "6"}}
+
+def test_parse_app_output_passthrough():
+    assert parse_line("result=10") == {"kind": "app", "text": "result=10"}

--- a/tests/debugger/test_dbg_protocol.py
+++ b/tests/debugger/test_dbg_protocol.py
@@ -1,4 +1,6 @@
-from tools.debug.dbg_protocol import parse_line
+import os
+
+from tools.debug.dbg_protocol import parse_line, format_methods, FifoChannel
 
 def test_parse_paused_break():
     assert parse_line("dbg:paused break 2 0") == {"kind": "paused", "mode": "break", "id": 2, "off": 0}
@@ -9,3 +11,35 @@ def test_parse_stack():
 
 def test_parse_app_output_passthrough():
     assert parse_line("result=10") == {"kind": "app", "text": "result=10"}
+
+def test_parse_stack_malformed_falls_through():
+    # Missing off= value: must not raise, falls through to "other".
+    assert parse_line("dbg:stack r0=0") == {"kind": "other", "text": "dbg:stack r0=0"}
+
+def test_format_methods():
+    block = "\n".join([
+        "1 100 0",
+        "2 240 2",
+        "5 999 1",
+        "dbg:ok methods",
+    ])
+    assert format_methods(block) == {1: (100, 0), 2: (240, 2), 5: (999, 1)}
+
+def test_format_methods_ignores_blank_and_nonmatching():
+    block = "\n".join([
+        "",
+        "7 12 3",
+        "garbage line",
+        "dbg:ok methods",
+    ])
+    assert format_methods(block) == {7: (12, 3)}
+
+def test_fifo_channel_roundtrip(tmp_path):
+    path = str(tmp_path / "cmd.fifo")
+    ch = FifoChannel(path)
+    try:
+        ch.send("dbg:continue")
+        assert next(ch.lines()) == "dbg:continue"
+    finally:
+        ch.close()
+    assert not os.path.exists(path)

--- a/tests/debugger/test_debug_session.py
+++ b/tests/debugger/test_debug_session.py
@@ -13,6 +13,54 @@ def _snapshot(tmp):
     return snap
 
 
+# Pinned, snapshot-specific constants for breaking inside `count-to`.
+#
+# Discovered once against the count_to.snapshot this test compiles, using
+#   `toit tool snapshot bytecodes count_to.snapshot`
+# and a `dbg:methods` dump (see .superpowers/sdd/task-4-report.md):
+#   - `count-to` (arity 1) compiles to a method whose program-relative entry bci
+#     is 285; `main` (arity 0) is at 263.
+#   - the `for` loop body `sum += i` begins at offset 10 from the entry
+#     (entry+10 = bci 295, the first `load local` of the body), so a breakpoint
+#     there fires once per iteration with the loop variable `i` taking the
+#     values 0,1,2,3,4.
+# We look the id up by entry bci (not a hard-coded id) so the test still finds
+# count-to if the dispatch-table numbering shifts, as long as the bytecode
+# layout is stable.
+COUNT_TO_ENTRY_BCI = 285
+COUNT_TO_SUM_OFF = 10
+
+
+def _count_to_id(methods):
+    for mid, (entry_bci, arity) in methods.items():
+        if entry_bci == COUNT_TO_ENTRY_BCI and arity == 1:
+            return mid
+    raise AssertionError(f"count-to (entry_bci={COUNT_TO_ENTRY_BCI}) not in registry: {methods}")
+
+
+def test_inspect_reads_live_locals(tmp_path):
+    snap = _snapshot(str(tmp_path))
+    from tools.debug.dbg_protocol import run_session
+    # Break at the `sum += i` site, then walk the loop: the first `continue`
+    # leaves the stop-at-entry pause; each following `inspect`/`continue` pair
+    # reads one iteration's frame and steps to the next. Five iterations cover
+    # i = 0,1,2,3,4; the final `continue` lets the program run to completion.
+    out = run_session(
+        TOIT, snap,
+        script_after_methods=lambda mid: (
+            [f"dbg:break {mid} {COUNT_TO_SUM_OFF}", "dbg:continue"]
+            + ["dbg:inspect", "dbg:continue"] * 5),
+        method_picker=_count_to_id)
+    stacks = [p for p in out if p["kind"] == "stack"]
+    assert len(stacks) == 5, out
+    # i = 0,1,2,3,4 (and sum = 0,0,1,3,6) are live frame locals we read back, so
+    # the extremes must show up as some register value across the iterations.
+    assert any("0" in s["regs"].values() for s in stacks), stacks
+    assert any("4" in s["regs"].values() for s in stacks), stacks
+    # Clean resume: the app still prints its result after the final continue.
+    assert any(p.get("text") == "result=10" for p in out), out
+
+
 def test_breakpoint_parks_then_resumes(tmp_path):
     snap = _snapshot(str(tmp_path))
     # Drive with the debug session: set a breakpoint that exists, continue once

--- a/tests/debugger/test_debug_session.py
+++ b/tests/debugger/test_debug_session.py
@@ -25,3 +25,32 @@ def test_breakpoint_parks_then_resumes(tmp_path):
     assert any(p["kind"] == "ready" for p in out), out
     assert any(p["kind"] == "paused" for p in out), out
     assert any(p.get("text") == "result=10" for p in out), out
+
+
+def test_methods_registry_and_break_by_id(tmp_path):
+    snap = _snapshot(str(tmp_path))
+    from tools.debug.dbg_protocol import run_session
+    out = run_session(TOIT, snap, script_after_methods=lambda mid: [f"dbg:break {mid} 0", "dbg:continue", "dbg:continue"])
+    # registry must include the count-to method with a numeric id
+    assert any(p["kind"] == "ok" and p["verb"] == "methods" for p in out)
+    assert any(p["kind"] == "ok" and p["verb"] == "break" for p in out)
+    assert any(p["kind"] == "paused" and p["mode"] == "break" for p in out)
+
+
+def test_break_unknown_id_errors_and_clear_is_acknowledged(tmp_path):
+    snap = _snapshot(str(tmp_path))
+    from tools.debug.dbg_protocol import run_session
+    out = run_session(
+        TOIT, snap,
+        script_after_methods=lambda mid: [
+            "dbg:break 99999 0",      # id not in the registry
+            f"dbg:break {mid} 0",     # valid id
+            f"dbg:clear {mid} 0",     # remove it again
+            "dbg:continue", "dbg:continue"])
+    # Unknown method id is rejected, not silently dropped.
+    assert any(p["kind"] == "error" and p["msg"] == "no-method" for p in out), out
+    # break/clear of a real id are both acknowledged.
+    assert any(p["kind"] == "ok" and p["verb"] == "break" for p in out), out
+    assert any(p["kind"] == "ok" and p["verb"] == "clear" for p in out), out
+    # Cleared breakpoint means the app still runs to completion.
+    assert any(p.get("text") == "result=10" for p in out), out

--- a/tests/debugger/test_debug_session.py
+++ b/tests/debugger/test_debug_session.py
@@ -29,6 +29,24 @@ def _snapshot(tmp):
 # layout is stable.
 COUNT_TO_ENTRY_BCI = 285
 COUNT_TO_SUM_OFF = 10
+# `main` (arity 0) compiles to entry bci 263; it is the frame that calls
+# `count-to`, so a `dbg:out` from inside `count-to` lands back here.
+MAIN_ENTRY_BCI = 263
+
+# Pinned step/over/out landing sites, discovered empirically (like the ns-oevm
+# `assert_over`/`assert_out` harness) by scripting a session and reading the
+# actual `dbg:paused step <id> <off>` lines the VM emits. The session breaks at
+# the `sum += i` site (off 10), clears the breakpoint, then issues one
+# step/over/out and observes where it re-parks:
+#   - step: the very next bytecode in `count-to`            -> off 11 (same method)
+#   - over: the `sum += i` site makes no Toit call, so over
+#           behaves like step here: the next bytecode        -> off 11 (same method)
+#   - out:  runs the rest of `count-to` and returns to the
+#           caller `main`                                    -> main, off 5
+# Re-pin these if the count_to.snapshot bytecode layout changes.
+STEP_LANDING_OFF = 11
+OVER_LANDING_OFF = 11
+OUT_LANDING_OFF = 5
 
 
 def _count_to_id(methods):
@@ -36,6 +54,13 @@ def _count_to_id(methods):
         if entry_bci == COUNT_TO_ENTRY_BCI and arity == 1:
             return mid
     raise AssertionError(f"count-to (entry_bci={COUNT_TO_ENTRY_BCI}) not in registry: {methods}")
+
+
+def _main_id(methods):
+    for mid, (entry_bci, arity) in methods.items():
+        if entry_bci == MAIN_ENTRY_BCI and arity == 0:
+            return mid
+    raise AssertionError(f"main (entry_bci={MAIN_ENTRY_BCI}) not in registry: {methods}")
 
 
 def test_inspect_reads_live_locals(tmp_path):
@@ -101,4 +126,67 @@ def test_break_unknown_id_errors_and_clear_is_acknowledged(tmp_path):
     assert any(p["kind"] == "ok" and p["verb"] == "break" for p in out), out
     assert any(p["kind"] == "ok" and p["verb"] == "clear" for p in out), out
     # Cleared breakpoint means the app still runs to completion.
+    assert any(p.get("text") == "result=10" for p in out), out
+
+
+def _run_step_session(tmp_path, verb):
+    """Break inside `count-to`, clear the breakpoint, then issue one step verb.
+
+    Returns ``(out, count_to_id, main_id)``. The breakpoint is cleared before
+    the step so the only remaining pause is the step landing (the loop would
+    otherwise re-hit the breakpoint before an `out`/`over` completes).
+    """
+    snap = _snapshot(str(tmp_path))
+    from tools.debug.dbg_protocol import run_session
+    ids = {}
+
+    def picker(methods):
+        ids["count_to"] = _count_to_id(methods)
+        ids["main"] = _main_id(methods)
+        return ids["count_to"]
+
+    out = run_session(
+        TOIT, snap,
+        script_after_methods=lambda mid: [
+            f"dbg:break {mid} {COUNT_TO_SUM_OFF}", "dbg:continue",
+            f"dbg:clear {mid} {COUNT_TO_SUM_OFF}", f"dbg:{verb}", "dbg:continue"],
+        method_picker=picker)
+    return out, ids["count_to"], ids["main"]
+
+
+def test_step_advances_within_same_method(tmp_path):
+    out, count_to_id, _ = _run_step_session(tmp_path, "step")
+    assert any(p["kind"] == "ok" and p["verb"] == "step" for p in out), out
+    steps = [p for p in out if p["kind"] == "paused" and p["mode"] == "step"]
+    # A single step pauses exactly once, on the next bytecode of `count-to`
+    # (same method id, off advanced past the breakpoint's off 10).
+    assert len(steps) == 1, out
+    assert steps[0]["id"] == count_to_id, out
+    assert steps[0]["off"] == STEP_LANDING_OFF, out
+    assert steps[0]["off"] > COUNT_TO_SUM_OFF, out
+    # Clean resume to completion.
+    assert any(p.get("text") == "result=10" for p in out), out
+
+
+def test_over_stays_within_method(tmp_path):
+    out, count_to_id, _ = _run_step_session(tmp_path, "over")
+    assert any(p["kind"] == "ok" and p["verb"] == "over" for p in out), out
+    steps = [p for p in out if p["kind"] == "paused" and p["mode"] == "step"]
+    assert len(steps) == 1, out
+    # `over` does not descend into callees: it stays inside `count-to`.
+    assert steps[0]["id"] == count_to_id, out
+    assert steps[0]["off"] == OVER_LANDING_OFF, out
+    assert any(p.get("text") == "result=10" for p in out), out
+
+
+def test_out_returns_to_caller(tmp_path):
+    out, count_to_id, main_id = _run_step_session(tmp_path, "out")
+    assert any(p["kind"] == "ok" and p["verb"] == "out" for p in out), out
+    steps = [p for p in out if p["kind"] == "paused" and p["mode"] == "step"]
+    assert len(steps) == 1, out
+    # `out` runs until `count-to` returns: the landing is in the caller `main`,
+    # a shallower frame, NOT inside count-to.
+    assert steps[0]["id"] == main_id, out
+    assert steps[0]["id"] != count_to_id, out
+    assert steps[0]["off"] == OUT_LANDING_OFF, out
     assert any(p.get("text") == "result=10" for p in out), out

--- a/tests/debugger/test_debug_session.py
+++ b/tests/debugger/test_debug_session.py
@@ -1,0 +1,27 @@
+import os, subprocess, sys, tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+sys.path.insert(0, ROOT)
+TOIT = os.path.join(ROOT, "build/host/sdk/bin/toit")
+TARGET = os.path.join(HERE, "targets/count_to.toit")
+
+
+def _snapshot(tmp):
+    snap = os.path.join(tmp, "count_to.snapshot")
+    subprocess.run([TOIT, "compile", "-s", "-o", snap, TARGET], check=True)
+    return snap
+
+
+def test_breakpoint_parks_then_resumes(tmp_path):
+    snap = _snapshot(str(tmp_path))
+    # Drive with the debug session: set a breakpoint that exists, continue once
+    # per loop iteration, then let it finish. Asserts the app still prints 10
+    # (clean resume) AND that we paused at least once.
+    from tools.debug.dbg_protocol import run_session
+    out = run_session(
+        TOIT, snap,
+        script_after_methods=lambda mid: [f"dbg:break {mid} 0"] + ["dbg:continue"] * 6)
+    assert any(p["kind"] == "ready" for p in out), out
+    assert any(p["kind"] == "paused" for p in out), out
+    assert any(p.get("text") == "result=10" for p in out), out

--- a/tests/debugger/test_debug_session.py
+++ b/tests/debugger/test_debug_session.py
@@ -48,6 +48,36 @@ STEP_LANDING_OFF = 11
 OVER_LANDING_OFF = 11
 OUT_LANDING_OFF = 5
 
+# A second target whose loop body invokes a *real* Toit method (`helper`), so a
+# step at the call site has a genuine callee frame to either descend into
+# (`step`) or skip (`over`). count_to.toit cannot exercise this: its `sum += i`
+# lowers to smi intrinsics with no Toit call frame.
+CALL_TARGET = os.path.join(HERE, "targets/call_in_loop.toit")
+
+# Pinned call_in_loop.toit constants, discovered with
+#   toit tool snapshot bytecodes <snap> run-loop   (and helper)
+# where each method's entry bci is the `0/<bci>` line of its dump:
+#   - run-loop (arity 1) entry bci 299; its loop body invokes `helper` via
+#     `invoke static` at off 12 (bci 311); the next bytecode, reached when the
+#     call returns, is off 15 (bci 314, `invoke add`).
+#   - helper   (arity 1) entry bci 285; its first bytecode is off 0.
+# Verified empirically by breaking at run-loop off 12 and issuing each verb:
+#   `over` re-parks at run-loop off 15 (callee skipped); `step` descends to
+#   helper off 0. Re-pin if the call_in_loop.snapshot bytecode layout changes.
+RUNLOOP_ENTRY_BCI = 299
+HELPER_ENTRY_BCI = 285
+CALL_SITE_OFF = 12
+OVER_AFTER_CALL_OFF = 15
+STEP_INTO_HELPER_OFF = 0
+
+
+def _id_by_entry(methods, entry_bci, arity):
+    for mid, (e, a) in methods.items():
+        if e == entry_bci and a == arity:
+            return mid
+    raise AssertionError(
+        f"method (entry_bci={entry_bci}, arity={arity}) not in registry: {methods}")
+
 
 def _count_to_id(methods):
     for mid, (entry_bci, arity) in methods.items():
@@ -190,3 +220,59 @@ def test_out_returns_to_caller(tmp_path):
     assert steps[0]["id"] != count_to_id, out
     assert steps[0]["off"] == OUT_LANDING_OFF, out
     assert any(p.get("text") == "result=10" for p in out), out
+
+
+def _run_call_loop_session(tmp_path, verb):
+    """Break at the `helper` call site inside `run-loop`, clear it, then step.
+
+    Returns ``(out, run_loop_id, helper_id)``. Breaking at run-loop off 12 (the
+    `invoke static helper`) gives a real callee frame; the breakpoint is cleared
+    before the verb so the only remaining pause is the step landing.
+    """
+    snap = os.path.join(str(tmp_path), "call_in_loop.snapshot")
+    subprocess.run([TOIT, "compile", "-s", "-o", snap, CALL_TARGET], check=True)
+    from tools.debug.dbg_protocol import run_session
+    ids = {}
+
+    def picker(methods):
+        ids["run_loop"] = _id_by_entry(methods, RUNLOOP_ENTRY_BCI, 1)
+        ids["helper"] = _id_by_entry(methods, HELPER_ENTRY_BCI, 1)
+        return ids["run_loop"]
+
+    out = run_session(
+        TOIT, snap,
+        script_after_methods=lambda mid: [
+            f"dbg:break {mid} {CALL_SITE_OFF}", "dbg:continue",
+            f"dbg:clear {mid} {CALL_SITE_OFF}", f"dbg:{verb}", "dbg:continue"],
+        method_picker=picker)
+    return out, ids["run_loop"], ids["helper"]
+
+
+def test_over_skips_callee_frame(tmp_path):
+    # The defining behavior of `over`: at a call site it executes the callee
+    # without descending. Contrast with test_step_descends_into_callee_frame.
+    out, run_loop_id, helper_id = _run_call_loop_session(tmp_path, "over")
+    assert any(p["kind"] == "ok" and p["verb"] == "over" for p in out), out
+    steps = [p for p in out if p["kind"] == "paused" and p["mode"] == "step"]
+    assert len(steps) == 1, out
+    # over never pauses inside `helper`; it re-parks in `run-loop` just after
+    # the call returns (same frame depth, off advanced past the call).
+    assert steps[0]["id"] == run_loop_id, out
+    assert steps[0]["id"] != helper_id, out
+    assert steps[0]["off"] == OVER_AFTER_CALL_OFF, out
+    assert steps[0]["off"] > CALL_SITE_OFF, out
+    assert any(p.get("text") == "result=6" for p in out), out
+
+
+def test_step_descends_into_callee_frame(tmp_path):
+    # The contrast to `over`: at the same call site, `step` descends into the
+    # callee. Together these two tests prove over != step across a call frame.
+    out, run_loop_id, helper_id = _run_call_loop_session(tmp_path, "step")
+    assert any(p["kind"] == "ok" and p["verb"] == "step" for p in out), out
+    steps = [p for p in out if p["kind"] == "paused" and p["mode"] == "step"]
+    assert len(steps) == 1, out
+    # step descends into `helper`, a deeper frame (its entry, off 0).
+    assert steps[0]["id"] == helper_id, out
+    assert steps[0]["id"] != run_loop_id, out
+    assert steps[0]["off"] == STEP_INTO_HELPER_OFF, out
+    assert any(p.get("text") == "result=6" for p in out), out

--- a/tests/debugger/test_driver_smoke.py
+++ b/tests/debugger/test_driver_smoke.py
@@ -39,6 +39,9 @@ def test_driver_smoke_named_pause(tmp_path):
     assert result.returncode == 0, (
         f"driver exited {result.returncode}\n--- stdout ---\n{result.stdout}\n"
         f"--- stderr ---\n{result.stderr}")
-    # Name resolution must have produced a human-readable pause line.
-    assert "count-to" in transcript, (
-        f"expected 'count-to' in transcript, got:\n{transcript}")
+    # Name resolution must have produced a human-readable *pause* line — not
+    # merely list count-to in the methods registry. Asserting on the actual
+    # "paused in count-to" line means the test fails if the paused-line name
+    # resolution regresses (the registry listing alone would not catch that).
+    assert "paused in count-to" in transcript, (
+        f"expected 'paused in count-to' in transcript, got:\n{transcript}")

--- a/tests/debugger/test_driver_smoke.py
+++ b/tests/debugger/test_driver_smoke.py
@@ -1,0 +1,44 @@
+"""Smoke test for tools/debug/debug_driver.py.
+
+Runs the driver in scripted mode against tests/debugger/targets/count_to.toit
+through the full flow: methods → break count-to → continue → inspect → step
+sequences.  Asserts exit 0 and that the transcript contains the method name
+``count-to`` in a paused-pause line (i.e. name resolution actually worked).
+"""
+
+import os, subprocess, sys, textwrap
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+TARGET = os.path.join(HERE, "targets", "count_to.toit")
+DRIVER = os.path.join(ROOT, "tools", "debug", "debug_driver.py")
+
+
+def test_driver_smoke_named_pause(tmp_path):
+    """Driver reports a named pause (count-to) and exits 0."""
+    script = tmp_path / "cmds.txt"
+    script.write_text(textwrap.dedent("""\
+        methods
+        break count-to 10
+        continue
+        inspect
+        continue
+        continue
+        continue
+        continue
+        continue
+    """))
+    result = subprocess.run(
+        [sys.executable, DRIVER, "--script", str(script), TARGET],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=ROOT,
+    )
+    transcript = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        f"driver exited {result.returncode}\n--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}")
+    # Name resolution must have produced a human-readable pause line.
+    assert "count-to" in transcript, (
+        f"expected 'count-to' in transcript, got:\n{transcript}")

--- a/tools/debug/dbg_protocol.py
+++ b/tools/debug/dbg_protocol.py
@@ -160,7 +160,8 @@ class _Reader:
                     return
 
 
-def run_session(toit, snap, script_after_methods, timeout=20.0):
+def run_session(toit, snap, script_after_methods, timeout=20.0,
+                method_picker=lambda methods: min(methods) if methods else 1):
     """Drive a full debug session against a snapshot and return parsed lines.
 
     Launches ``toit.run --debug <snap>`` with stdin wired to a pipe and stdout
@@ -168,6 +169,11 @@ def run_session(toit, snap, script_after_methods, timeout=20.0):
     method registry to find the target method id, then issues the scripted
     follow-up commands (pacing each so the VM settles), and finally returns the
     list of parsed VM stdout lines (via :func:`parse_line`).
+
+    ``method_picker`` selects which method id is handed to ``script_after_methods``
+    from the parsed ``{id: (entry_bci, arity)}`` registry. It defaults to the
+    smallest id (a stable library method), but a test that must break inside a
+    specific method passes its own picker (e.g. look the id up by entry bci).
     """
     inner = _inner_toit_run(toit)
     proc = subprocess.Popen(
@@ -199,7 +205,7 @@ def run_session(toit, snap, script_after_methods, timeout=20.0):
         reader.settle()
 
         methods = format_methods("\n".join(reader.lines))
-        mid = min(methods) if methods else 1
+        mid = method_picker(methods)
 
         for cmd in script_after_methods(mid):
             send(cmd)

--- a/tools/debug/dbg_protocol.py
+++ b/tools/debug/dbg_protocol.py
@@ -10,9 +10,13 @@ def parse_line(line: str) -> dict:
     if m:
         return {"kind": "paused", "mode": m.group(1), "id": int(m.group(2)), "off": int(m.group(3))}
     if s.startswith("dbg:stack off="):
-        off = int(re.search(r"off=(\d+)", s).group(1))
-        regs = {int(k): v for k, v in re.findall(r"r(\d+)=(\S+)", s)}
-        return {"kind": "stack", "off": off, "regs": regs}
+        # Guard against a malformed stack line: fall through to "other" rather
+        # than raising AttributeError on .group() of a failed search.
+        off_match = re.search(r"off=(\d+)", s)
+        if off_match:
+            off = int(off_match.group(1))
+            regs = {int(k): v for k, v in re.findall(r"r(\d+)=(\S+)", s)}
+            return {"kind": "stack", "off": off, "regs": regs}
     if s.startswith("dbg:ok "):
         return {"kind": "ok", "verb": s[len("dbg:ok "):]}
     if s.startswith("dbg:error "):
@@ -20,15 +24,63 @@ def parse_line(line: str) -> dict:
     return {"kind": "other", "text": s}
 
 
+def format_methods(block: str) -> dict[int, tuple[int, int]]:
+    """Parse a method-registry text block into {id: (entry_bci, arity)}.
+
+    The VM emits one ``<id> <entry_bci> <arity>`` line per method, followed by
+    a ``dbg:ok methods`` terminator. Parsing is tolerant: any line that is not
+    exactly three whitespace-separated integers (blank lines, the ``dbg:ok``
+    terminator, etc.) is skipped.
+    """
+    methods: dict[int, tuple[int, int]] = {}
+    for line in block.splitlines():
+        m = re.match(r"^\s*(\d+)\s+(\d+)\s+(\d+)\s*$", line)
+        if m:
+            mid, entry_bci, arity = int(m.group(1)), int(m.group(2)), int(m.group(3))
+            methods[mid] = (entry_bci, arity)
+    return methods
+
+
 class FifoChannel:
+    """A held-open FIFO used to push commands to the VM.
+
+    The fd is opened ``O_RDWR`` so the reader (the VM) never sees EOF between
+    commands. ``O_NONBLOCK`` makes both the open and subsequent reads/writes
+    non-blocking, so ``lines()`` can drain whatever is currently buffered and
+    return instead of hanging when no data is available.
+    """
+
     def __init__(self, path: str):
         os.mkfifo(path)
-        # Hold a read/write fd so the reader (VM) never gets EOF between commands.
+        # O_RDWR: hold the write end open so the VM reader never gets EOF.
+        # O_NONBLOCK: non-blocking reads let lines() stop at end-of-buffer.
         self._fd = os.open(path, os.O_RDWR | os.O_NONBLOCK)
         self.path = path
+        self._buf = b""
 
     def send(self, cmd: str):
         os.write(self._fd, (cmd.rstrip("\n") + "\n").encode())
+
+    def lines(self):
+        """Yield decoded, newline-stripped lines currently readable on the fd.
+
+        Because the fd is O_RDWR, this is a loopback over the FIFO: it yields
+        back the lines written via send(). Later tasks replace this with the
+        real VM-stdout transport; the line-buffering contract stays the same.
+        Reads are non-blocking, so the generator stops once the buffer is
+        drained (read returns empty or would block).
+        """
+        while True:
+            try:
+                chunk = os.read(self._fd, 4096)
+            except BlockingIOError:
+                chunk = b""
+            if not chunk:
+                break
+            self._buf += chunk
+            while b"\n" in self._buf:
+                raw, self._buf = self._buf.split(b"\n", 1)
+                yield raw.decode()
 
     def close(self):
         os.close(self._fd)

--- a/tools/debug/dbg_protocol.py
+++ b/tools/debug/dbg_protocol.py
@@ -1,4 +1,4 @@
-import os, re
+import os, re, subprocess, threading, time
 
 def parse_line(line: str) -> dict:
     s = line.rstrip("\n")
@@ -85,3 +85,139 @@ class FifoChannel:
     def close(self):
         os.close(self._fd)
         os.unlink(self.path)
+
+
+def _inner_toit_run(toit_path: str) -> str:
+    """Locate the inner ``toit.run`` executable next to the ``toit`` launcher.
+
+    ``<sdk>/bin/toit`` is the multiplexer CLI; the actual snapshot runner is
+    ``<sdk>/lib/toit/bin/toit.run``. We launch the inner runner directly so the
+    debugger activates in exactly one VM (the application's). Going through the
+    multiplexer would activate the debugger in the *launcher* VM too, since the
+    activation condition is inherited via the environment.
+    """
+    sdk = os.path.dirname(os.path.dirname(os.path.abspath(toit_path)))
+    inner = os.path.join(sdk, "lib", "toit", "bin", "toit.run")
+    if os.name == "nt":
+        inner += ".exe"
+    return inner
+
+
+class _Reader:
+    """Background thread that drains a process' stdout into a line buffer.
+
+    Synchronization strategy: a single reader thread blocks on ``readline`` and
+    appends each decoded line to a shared list under a lock, pulsing a condition
+    variable. The driver thread paces commands by waiting for the buffer to go
+    *quiet* (no new line for ``quiet`` seconds) after each send, which lets the
+    VM settle (re-park on a breakpoint or run to completion) before the next
+    command is issued. This avoids racing the controller thread with a flood of
+    commands while staying robust to the interleaving of app output and ``dbg:``
+    responses on the shared stdout.
+    """
+
+    def __init__(self, stream):
+        self._stream = stream
+        self.lines = []
+        self._cond = threading.Condition()
+        self.eof = False
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self):
+        for raw in self._stream:
+            with self._cond:
+                self.lines.append(raw.rstrip("\n"))
+                self._cond.notify_all()
+        with self._cond:
+            self.eof = True
+            self._cond.notify_all()
+
+    def wait_for(self, pred, timeout):
+        """Block until ``pred(lines)`` is true or timeout/EOF; return success."""
+        deadline = time.monotonic() + timeout
+        with self._cond:
+            while True:
+                if pred(self.lines):
+                    return True
+                if self.eof:
+                    return pred(self.lines)
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return pred(self.lines)
+                self._cond.wait(remaining)
+
+    def settle(self, quiet=0.4, maxwait=5.0):
+        """Wait until no new output has arrived for ``quiet`` seconds."""
+        deadline = time.monotonic() + maxwait
+        with self._cond:
+            while time.monotonic() < deadline:
+                n = len(self.lines)
+                if self.eof:
+                    return
+                self._cond.wait(quiet)
+                if len(self.lines) == n:
+                    return
+
+
+def run_session(toit, snap, script_after_methods, timeout=20.0):
+    """Drive a full debug session against a snapshot and return parsed lines.
+
+    Launches ``toit.run --debug <snap>`` with stdin wired to a pipe and stdout
+    captured, waits for ``dbg:ready``, sends ``dbg:methods`` and parses the
+    method registry to find the target method id, then issues the scripted
+    follow-up commands (pacing each so the VM settles), and finally returns the
+    list of parsed VM stdout lines (via :func:`parse_line`).
+    """
+    inner = _inner_toit_run(toit)
+    proc = subprocess.Popen(
+        [inner, "--debug", snap],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+        bufsize=1)
+    reader = _Reader(proc.stdout)
+
+    def send(cmd):
+        # The VM may have already finished and exited (e.g. surplus `continue`
+        # commands after the program ran to completion); tolerate a closed pipe.
+        try:
+            proc.stdin.write(cmd.rstrip("\n") + "\n")
+            proc.stdin.flush()
+        except (BrokenPipeError, ValueError):
+            pass
+
+    try:
+        reader.wait_for(
+            lambda ls: any(parse_line(l)["kind"] == "ready" for l in ls),
+            timeout)
+
+        send("dbg:methods")
+        reader.wait_for(
+            lambda ls: any(parse_line(l) == {"kind": "ok", "verb": "methods"} for l in ls),
+            timeout)
+        reader.settle()
+
+        methods = format_methods("\n".join(reader.lines))
+        mid = min(methods) if methods else 1
+
+        for cmd in script_after_methods(mid):
+            send(cmd)
+            reader.settle()
+
+        # Give the program a chance to run to completion after the last resume.
+        reader.wait_for(
+            lambda ls: any(parse_line(l).get("text") == "result=10" for l in ls),
+            timeout)
+    finally:
+        try:
+            proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=timeout)
+        except Exception:
+            proc.kill()
+
+    return [parse_line(l) for l in reader.lines]
+

--- a/tools/debug/dbg_protocol.py
+++ b/tools/debug/dbg_protocol.py
@@ -1,0 +1,35 @@
+import os, re
+
+def parse_line(line: str) -> dict:
+    s = line.rstrip("\n")
+    if not s.startswith("dbg:"):
+        return {"kind": "app", "text": s}
+    if s == "dbg:ready":
+        return {"kind": "ready"}
+    m = re.match(r"dbg:paused (break|step) (-?\d+) (\d+)$", s)
+    if m:
+        return {"kind": "paused", "mode": m.group(1), "id": int(m.group(2)), "off": int(m.group(3))}
+    if s.startswith("dbg:stack off="):
+        off = int(re.search(r"off=(\d+)", s).group(1))
+        regs = {int(k): v for k, v in re.findall(r"r(\d+)=(\S+)", s)}
+        return {"kind": "stack", "off": off, "regs": regs}
+    if s.startswith("dbg:ok "):
+        return {"kind": "ok", "verb": s[len("dbg:ok "):]}
+    if s.startswith("dbg:error "):
+        return {"kind": "error", "msg": s[len("dbg:error "):]}
+    return {"kind": "other", "text": s}
+
+
+class FifoChannel:
+    def __init__(self, path: str):
+        os.mkfifo(path)
+        # Hold a read/write fd so the reader (VM) never gets EOF between commands.
+        self._fd = os.open(path, os.O_RDWR | os.O_NONBLOCK)
+        self.path = path
+
+    def send(self, cmd: str):
+        os.write(self._fd, (cmd.rstrip("\n") + "\n").encode())
+
+    def close(self):
+        os.close(self._fd)
+        os.unlink(self.path)

--- a/tools/debug/dbg_protocol.py
+++ b/tools/debug/dbg_protocol.py
@@ -160,6 +160,60 @@ class _Reader:
                     return
 
 
+def build_name_map(toit: str, snap: str) -> tuple:
+    """Build name↔entry_bci maps by parsing ``toit tool snapshot bytecodes``.
+
+    Returns ``(name_to_entry, entry_to_name)`` where *entry_bci* is the
+    absolute bytecode position of the first instruction of each method.
+
+    Approach: ``toit tool snapshot bytecodes <snap>`` (no filter) emits one
+    method block per method.  Each block starts with a header line:
+
+        <dispatch_idx>: <name> <file>:<line>:<col>
+
+    followed immediately by bytecode lines indented with spaces:
+
+        <space>+<offset>/ <absolute_bci> [<opcode>] - …
+
+    The first bytecode (offset 0) carries the entry bci.  Because header
+    lines start with a digit while bytecode lines are indented, the two
+    patterns are unambiguous.
+
+    This is Approach 1 from the plan (CLI tooling); no snapshot-bundle
+    binary parsing is needed.  The entry_bci values produced here can be
+    cross-checked with the numeric method registry from ``dbg:methods`` by
+    matching on entry_bci (the pinned COUNT_TO_ENTRY_BCI=285 sanity anchor
+    confirms the cross-check works).
+    """
+    result = subprocess.run(
+        [toit, "tool", "snapshot", "bytecodes", snap],
+        capture_output=True, text=True, check=True)
+    name_to_entry: dict = {}
+    entry_to_name: dict = {}
+    current_name = None
+    for line in result.stdout.splitlines():
+        # Method-header lines start with "<idx>: " (no leading whitespace).
+        # Bytecode lines are indented, so this guard is unambiguous.
+        if re.match(r'^\d+: ', line):
+            # The trailing source-location token (<path>:<line>:<col>) is the
+            # last whitespace-separated field.  Strip it and parse the name.
+            parts = line.rsplit(None, 1)
+            if len(parts) == 2 and re.match(r'.+:\d+:\d+$', parts[1]):
+                m = re.match(r'^\d+: (.+)$', parts[0])
+                if m:
+                    current_name = m.group(1).strip()
+                    continue
+        # First bytecode of the current method: "  0/ <entry_bci> [...]"
+        if current_name is not None:
+            bm = re.match(r'^\s+0/\s*(\d+)\s+\[', line)
+            if bm:
+                entry_bci = int(bm.group(1))
+                name_to_entry[current_name] = entry_bci
+                entry_to_name[entry_bci] = current_name
+                current_name = None
+    return name_to_entry, entry_to_name
+
+
 def run_session(toit, snap, script_after_methods, timeout=20.0,
                 method_picker=lambda methods: min(methods) if methods else 1):
     """Drive a full debug session against a snapshot and return parsed lines.

--- a/tools/debug/debug_driver.py
+++ b/tools/debug/debug_driver.py
@@ -180,9 +180,6 @@ def run_driver(source: str, commands_iter, timeout: float = 30.0):
             # ------------------------------------------------------------------
             for raw_line in commands_iter:
                 raw_line = raw_line.rstrip("\n")
-                # Interactive prompt (only when reading from a tty).
-                if hasattr(commands_iter, '__self__'):
-                    pass  # file object — no prompt needed
                 cmd_line = raw_line.strip()
                 if not cmd_line or cmd_line.startswith("#"):
                     continue
@@ -270,7 +267,10 @@ def main():
             rc = run_driver(args.source, fh)
     else:
         # Interactive: read from stdin with a prompt.
-        import readline  # noqa: F401 — enables line editing on POSIX
+        try:
+            import readline  # noqa: F401 — enables line editing on POSIX
+        except ImportError:
+            pass  # readline is unavailable on some platforms; not required.
         def _prompt_iter():
             while True:
                 try:

--- a/tools/debug/debug_driver.py
+++ b/tools/debug/debug_driver.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Operator debug driver — the local porta stand-in for the Toit host debugger.
+
+Usage:
+    debug_driver.py [--script <cmds.txt>] <source.toit>
+
+The driver:
+  1. Compiles <source.toit> to a snapshot via ``toit compile -s``.
+  2. Builds a name↔entry_bci map from ``toit tool snapshot bytecodes`` (offline,
+     no VM change needed — see dbg_protocol.build_name_map).
+  3. Launches ``toit.run --debug <snap>`` with stdin wired to a pipe and stdout
+     captured (reuses _inner_toit_run + _Reader from dbg_protocol).
+  4. Fetches the method registry via ``dbg:methods`` and cross-references
+     entry_bci values to resolve numeric ids to names.
+  5. Runs a command loop (interactive stdin or --script file):
+
+     methods              — print the method registry with resolved names
+     break <name|id> [off]— set a breakpoint (name is resolved to id)
+     clear <name|id> [off]— clear a breakpoint
+     continue             — resume execution
+     inspect [frame]      — read a stack frame
+     step                 — step to the next bytecode
+     over                 — step over (skip callees)
+     out                  — run until the current frame returns
+
+  Pretty-prints ``dbg:paused`` and ``dbg:stack`` with resolved method names.
+"""
+
+import argparse, os, re, subprocess, sys, tempfile
+
+# Make ``tools.debug.dbg_protocol`` importable when the driver is invoked
+# directly (python3 tools/debug/debug_driver.py …) from any cwd.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.abspath(os.path.join(_HERE, "..", ".."))
+sys.path.insert(0, _ROOT)
+
+from tools.debug.dbg_protocol import (
+    parse_line, format_methods, build_name_map,
+    _inner_toit_run, _Reader)
+
+TOIT = os.path.join(_ROOT, "build", "host", "sdk", "bin", "toit")
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+def _fmt(p: dict, id_to_name: dict) -> str:
+    """Return a human-readable string for a parsed VM output line."""
+    k = p["kind"]
+    if k == "ready":
+        return "VM ready"
+    if k == "paused":
+        name = id_to_name.get(p["id"], f"#{p['id']}")
+        return f"paused in {name} at off {p['off']} (mode: {p['mode']})"
+    if k == "stack":
+        regs = " ".join(f"r{r}={v}" for r, v in sorted(p["regs"].items()))
+        return f"stack off={p['off']}{' ' + regs if regs else ''}"
+    if k == "ok":
+        return f"ok: {p['verb']}"
+    if k == "error":
+        return f"error: {p['msg']}"
+    if k == "app":
+        return p["text"]
+    return p.get("text", str(p))
+
+
+# ---------------------------------------------------------------------------
+# Name/id resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_to_id(token: str, name_to_id: dict) -> int:
+    """Resolve a name or numeric id string to an integer method id.
+
+    Accepts a bare integer (passed through) or a method name looked up in
+    *name_to_id*.  Raises ``ValueError`` for unknown names.
+    """
+    if re.match(r'^-?\d+$', token):
+        return int(token)
+    if token in name_to_id:
+        return name_to_id[token]
+    raise ValueError(f"unknown method name: {token!r}  (known: {sorted(name_to_id)})")
+
+
+# ---------------------------------------------------------------------------
+# Core driver
+# ---------------------------------------------------------------------------
+
+def run_driver(source: str, commands_iter, timeout: float = 30.0):
+    """Compile *source*, launch the VM in debug mode, and run *commands_iter*.
+
+    Returns the exit code: 0 on clean completion, 1 on errors.
+    """
+    # ------------------------------------------------------------------
+    # Step 1: compile
+    # ------------------------------------------------------------------
+    with tempfile.TemporaryDirectory() as tmpdir:
+        snap = os.path.join(tmpdir, "prog.snapshot")
+        try:
+            subprocess.run(
+                [TOIT, "compile", "-s", "-o", snap, source],
+                check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"compile failed: {e}", file=sys.stderr)
+            return 1
+
+        # ------------------------------------------------------------------
+        # Step 2: build offline name map (Approach 1 — CLI tooling)
+        # ------------------------------------------------------------------
+        try:
+            name_to_entry, entry_to_name = build_name_map(TOIT, snap)
+        except subprocess.CalledProcessError as e:
+            print(f"bytecodes query failed: {e}", file=sys.stderr)
+            return 1
+
+        # ------------------------------------------------------------------
+        # Step 3: launch VM in debug mode
+        # ------------------------------------------------------------------
+        inner = _inner_toit_run(TOIT)
+        proc = subprocess.Popen(
+            [inner, "--debug", snap],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+            bufsize=1)
+        reader = _Reader(proc.stdout)
+
+        def send(cmd: str):
+            try:
+                proc.stdin.write(cmd.rstrip("\n") + "\n")
+                proc.stdin.flush()
+            except (BrokenPipeError, ValueError):
+                pass
+
+        # State: index of the next unprinted line in reader.lines.
+        printed = [0]
+        id_to_name: dict = {}
+        name_to_id: dict = {}
+
+        def flush_output():
+            while printed[0] < len(reader.lines):
+                line = reader.lines[printed[0]]
+                printed[0] += 1
+                p = parse_line(line)
+                print(_fmt(p, id_to_name))
+
+        exit_code = 0
+        try:
+            # Wait for dbg:ready.
+            reader.wait_for(
+                lambda ls: any(parse_line(l)["kind"] == "ready" for l in ls),
+                timeout)
+            reader.settle(quiet=0.3, maxwait=4.0)
+            flush_output()
+
+            # ------------------------------------------------------------------
+            # Step 4: fetch method registry and build id↔name maps
+            # ------------------------------------------------------------------
+            send("dbg:methods")
+            reader.wait_for(
+                lambda ls: any(
+                    parse_line(l) == {"kind": "ok", "verb": "methods"}
+                    for l in ls),
+                timeout)
+            reader.settle(quiet=0.3, maxwait=4.0)
+
+            registry = format_methods("\n".join(reader.lines))
+            # Suppress raw registry lines; jump past them.
+            printed[0] = len(reader.lines)
+
+            # Cross-reference entry_bci to build id↔name maps.
+            for mid, (entry_bci, _arity) in registry.items():
+                name = entry_to_name.get(entry_bci)
+                if name:
+                    id_to_name[mid] = name
+                    name_to_id[name] = mid
+
+            # ------------------------------------------------------------------
+            # Step 5: command loop
+            # ------------------------------------------------------------------
+            for raw_line in commands_iter:
+                raw_line = raw_line.rstrip("\n")
+                # Interactive prompt (only when reading from a tty).
+                if hasattr(commands_iter, '__self__'):
+                    pass  # file object — no prompt needed
+                cmd_line = raw_line.strip()
+                if not cmd_line or cmd_line.startswith("#"):
+                    continue
+
+                parts = cmd_line.split()
+                verb = parts[0]
+
+                # --- operator commands ---
+                if verb == "methods":
+                    # Print the registry with resolved names.
+                    print(f"Methods ({len(registry)} registered):")
+                    for mid, (entry_bci, arity) in sorted(registry.items()):
+                        name = id_to_name.get(mid, f"#{mid}")
+                        print(f"  {mid:4d}  entry_bci={entry_bci}  arity={arity}  {name}")
+                    continue
+
+                if verb in ("break", "clear"):
+                    if len(parts) < 2:
+                        print(f"usage: {verb} <name|id> [off]")
+                        continue
+                    try:
+                        mid = _resolve_to_id(parts[1], name_to_id)
+                    except ValueError as exc:
+                        print(f"error: {exc}")
+                        continue
+                    off = int(parts[2]) if len(parts) > 2 else 0
+                    send(f"dbg:{verb} {mid} {off}")
+
+                elif verb == "continue":
+                    send("dbg:continue")
+
+                elif verb == "inspect":
+                    if len(parts) > 1:
+                        send(f"dbg:inspect {parts[1]}")
+                    else:
+                        send("dbg:inspect")
+
+                elif verb in ("step", "over", "out"):
+                    send(f"dbg:{verb}")
+
+                else:
+                    print(f"unknown command: {verb!r}")
+                    continue
+
+                reader.settle(quiet=0.4, maxwait=6.0)
+                flush_output()
+
+            # Give the VM time to run to completion after the last command.
+            reader.wait_for(lambda ls: reader.eof, timeout=timeout)
+            reader.settle(quiet=0.3, maxwait=4.0)
+            flush_output()
+
+        except Exception as exc:
+            print(f"driver error: {exc}", file=sys.stderr)
+            exit_code = 1
+
+        finally:
+            try:
+                proc.stdin.close()
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=10.0)
+            except Exception:
+                proc.kill()
+
+    return exit_code
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Toit host debug driver (porta stand-in)")
+    parser.add_argument("source", help="Toit source file to compile and debug")
+    parser.add_argument(
+        "--script", metavar="FILE",
+        help="Read commands from FILE instead of interactive stdin")
+    args = parser.parse_args()
+
+    if args.script:
+        with open(args.script) as fh:
+            rc = run_driver(args.source, fh)
+    else:
+        # Interactive: read from stdin with a prompt.
+        import readline  # noqa: F401 — enables line editing on POSIX
+        def _prompt_iter():
+            while True:
+                try:
+                    line = input("dbg> ")
+                except EOFError:
+                    break
+                yield line
+        rc = run_driver(args.source, _prompt_iter())
+
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/toitp.toit
+++ b/tools/toitp.toit
@@ -111,6 +111,10 @@ print-positions program/Program:
       opcode := method.bytecodes[index]
       index += BYTE-CODES[opcode].size
 
+print-class-names program/Program:
+  program.class-tags.size.repeat: | id/int |
+    print "$id $(program.class-name-for id)"
+
 has-call program/Program method/ToitMethod:
   method.do-calls program: if matching it: return true
   return false
@@ -338,6 +342,26 @@ build-command -> cli.Command:
           with-filtered-cli-program invocation: | program/Program |
             print-positions program
   snapshot-command.add positions-command
+
+  class-names-command := cli.Command "class-names"
+      --help="""
+          Print the name of every class, one line per class id:
+          <class_id> <name>.
+
+          Used by 'jag debug --web' to resolve the numeric class ids that the
+          debugger emits for heap-object registers (<obj:<class_id>>) into
+          class names.
+          """
+      --rest=[snapshot-option]
+      --examples=[
+        cli.Example "Print class names for snapshot 'foo.snapshot':"
+            --arguments="foo.snapshot",
+      ]
+      --run=:: | invocation/cli.Invocation |
+          snapshot := SnapshotBundle.from-file invocation["snapshot"]
+          program := snapshot.decode
+          print-class-names program
+  snapshot-command.add class-names-command
 
   uuid-command := cli.Command "uuid"
       --help="Print the UUID of the snapshot."

--- a/tools/toitp.toit
+++ b/tools/toitp.toit
@@ -98,6 +98,19 @@ print-bytecodes program/Program:
   print
   methods.do: it.output program
 
+print-positions program/Program:
+  program.methods.do: | method/ToitMethod |
+    info := program.method-info-for method.id
+    path := info.error-path
+    index := 0
+    length := method.bytecodes.size
+    while index < length:
+      absolute-bci := method.absolute-bci-from-bci index
+      pos/Position := info.position index
+      print "$absolute-bci $path $pos.line $pos.column"
+      opcode := method.bytecodes[index]
+      index += BYTE-CODES[opcode].size
+
 has-call program/Program method/ToitMethod:
   method.do-calls program: if matching it: return true
   return false
@@ -307,6 +320,24 @@ build-command -> cli.Command:
           with-filtered-cli-program invocation: | program/Program |
             print-bytecodes program
   snapshot-command.add bytecodes-command
+
+  positions-command := cli.Command "positions"
+      --help="""
+          Print the source position of every bytecode, one line per bytecode:
+          <absolute_bci> <error_path> <line> <col>.
+
+          Used by 'jag debug --web' to map a paused (method, offset) to a
+          source line. $filter-help
+          """
+      --rest=[snapshot-option, filter-option]
+      --examples=[
+        cli.Example "Print bytecode positions for snapshot 'foo.snapshot':"
+            --arguments="foo.snapshot",
+      ]
+      --run=:: | invocation/cli.Invocation |
+          with-filtered-cli-program invocation: | program/Program |
+            print-positions program
+  snapshot-command.add positions-command
 
   uuid-command := cli.Command "uuid"
       --help="Print the UUID of the snapshot."


### PR DESCRIPTION
## What

Adds an in-image **bytecode debugger** to the host (POSIX) Toit VM: a breakpoint /
single-step mechanism in the interpreter plus a controller thread that speaks the
line-based `dbg:` protocol over stdin/stdout. An operator can set breakpoints,
step (into/over/out), and inspect live frame registers of a program running under
`toit.run --debug <snapshot>`.

See **[`docs/debugger.md`](docs/debugger.md)** for the full design and the `dbg:`
protocol reference.

## Highlights

- **Zero overhead when off** — the per-bytecode hook is a single predicted-not-taken
  branch on a flag that is false unless `--debug` / `OEVM_DEBUG` is set.
- **Park, don't block** — a hit returns `Result::DEBUG_PAUSED`; the scheduler parks
  the target while a dedicated controller thread (not a scheduler worker, so it may
  block on stdin) drives the `dbg:` channel. Capped to one worker thread under debug.
- **Snapshot-relative breakpoints** keyed on `(program, method-id, offset)`.
- Verbs: `dbg:methods` / `break` / `clear` / `continue` / `step` / `over` / `out` /
  `inspect`. The VM emits **numeric ids only**; names, source positions, and class
  names are resolved offline from the snapshot.
- **Typed register values** (`inspect`): `null`/`true`/`false`, integers, doubles,
  quoted/escaped strings, and `<obj:<class_id>>` for heap objects.
- **Offline snapshot dumps** in `tools/toitp.toit`: `positions`
  (`absolute_bci → file:line`) and `class-names` (`class_id → name`), beside the
  existing `bytecodes` dump.

## Operator tooling

The operator-facing CLI + browser UI is the companion PR toitlang/jaguar#695
(`jag debug` / `jag debug --web`). This PR is the VM-side prerequisite. A throwaway
Python proof-of-concept driver lives in `tools/debug/`.

## Testing

13 commits; built on the host (`cd build/host && ninja sdk/bin/toit`) with
integration coverage in `tests/debugger/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
