### PR TITLE
Add shell completion suggestions to the pkg commands.

### DIFF
--- a/src/resources/pipe_win.cc
+++ b/src/resources/pipe_win.cc
@@ -510,71 +510,6 @@ bool is_inherited(Object* object) {
 }
 const int MAX_COMMAND_LINE_LENGTH = 32768;
 
-// Appends a single wide character to `command_line`, returning false if that
-// would overflow the `capacity` (excluding the terminating null).
-static bool append_wchar(wchar_t* command_line, int* pos, int capacity, wchar_t c) {
-  if (*pos >= capacity) return false;
-  command_line[(*pos)++] = c;
-  return true;
-}
-
-// Appends `argument` to `command_line`, quoting it following the rules that
-// 'CommandLineToArgvW' reverses. We parse our own command line with that
-// function (see main_utf_8_helper.cc), so this quoting ensures that empty
-// arguments and arguments containing spaces or quotes survive the round-trip.
-// Returns false if the buffer would overflow.
-// See https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
-static bool append_quoted_argument(wchar_t* command_line, int* pos, int capacity, const wchar_t* argument) {
-  size_t length = wcslen(argument);
-
-  // An argument only needs quoting if it is empty or contains a character that
-  // 'CommandLineToArgvW' would otherwise treat as a separator or metacharacter.
-  bool needs_quotes = (length == 0);
-  for (size_t i = 0; !needs_quotes && i < length; i++) {
-    wchar_t c = argument[i];
-    needs_quotes = (c == L' ' || c == L'\t' || c == L'\n' || c == L'\v' || c == L'"');
-  }
-
-  if (!needs_quotes) {
-    for (size_t i = 0; i < length; i++) {
-      if (!append_wchar(command_line, pos, capacity, argument[i])) return false;
-    }
-    return true;
-  }
-
-  if (!append_wchar(command_line, pos, capacity, L'"')) return false;
-  size_t i = 0;
-  while (true) {
-    int backslashes = 0;
-    while (i < length && argument[i] == L'\\') {
-      i++;
-      backslashes++;
-    }
-    if (i == length) {
-      // Escape all backslashes, but let the terminating quote we add below be
-      // interpreted as a metacharacter.
-      for (int b = 0; b < backslashes * 2; b++) {
-        if (!append_wchar(command_line, pos, capacity, L'\\')) return false;
-      }
-      break;
-    } else if (argument[i] == L'"') {
-      // Escape all backslashes and the following quote.
-      for (int b = 0; b < backslashes * 2 + 1; b++) {
-        if (!append_wchar(command_line, pos, capacity, L'\\')) return false;
-      }
-      if (!append_wchar(command_line, pos, capacity, argument[i])) return false;
-    } else {
-      // Backslashes aren't special here.
-      for (int b = 0; b < backslashes; b++) {
-        if (!append_wchar(command_line, pos, capacity, L'\\')) return false;
-      }
-      if (!append_wchar(command_line, pos, capacity, argument[i])) return false;
-    }
-    i++;
-  }
-  return append_wchar(command_line, pos, capacity, L'"');
-}
-
 // Forks and execs a program (optionally found using the PATH environment
 // variable.  The given file descriptors should be open file descriptors.  They
 // are attached to the stdin, stdout and stderr of the launched program, and
@@ -627,6 +562,7 @@ static Object* fork_helper(
 
   int pos = 0;
   for (int i = 0; i < arguments->length(); i++) {
+    const wchar_t* format = (i != arguments->length() - 1) ? L"%ls " : L"%ls";
     Blob argument;
     if (!arguments->at(i)->byte_content(process->program(), &argument, STRINGS_ONLY)) {
       FAIL(WRONG_OBJECT_TYPE);
@@ -634,15 +570,15 @@ static Object* fork_helper(
     WideCharAllocationManager allocation(process);
     auto utf_16_argument = allocation.to_wcs(&argument);
 
-    // Separate arguments with a space.
-    if (i != 0 && !append_wchar(command_line, &pos, MAX_COMMAND_LINE_LENGTH, L' ')) {
-      FAIL(OUT_OF_BOUNDS);
-    }
-    if (!append_quoted_argument(command_line, &pos, MAX_COMMAND_LINE_LENGTH, utf_16_argument)) {
-      FAIL(OUT_OF_BOUNDS);
-    }
+    // The caller (pipe.toit's windows-escape_) already quotes arguments that
+    // contain spaces or quotes, but passes an empty argument through unchanged.
+    // Emit it as "" so it survives as a distinct argument instead of vanishing
+    // when the arguments are joined with spaces.
+    if (argument.length() == 0) utf_16_argument = const_cast<wchar_t*>(L"\"\"");
+
+    if (pos + wcslen(utf_16_argument) + wcslen(format) - 3 >= MAX_COMMAND_LINE_LENGTH) FAIL(OUT_OF_BOUNDS);
+    pos += snwprintf(command_line + pos, MAX_COMMAND_LINE_LENGTH - pos, format, utf_16_argument);
   }
-  command_line[pos] = L'\0';
 
   // We allocate memory for the SubprocessResource early here so we can handle failure
   // and restart the primitive.  If we wait until after the fork, the

--- a/src/resources/pipe_win.cc
+++ b/src/resources/pipe_win.cc
@@ -510,6 +510,71 @@ bool is_inherited(Object* object) {
 }
 const int MAX_COMMAND_LINE_LENGTH = 32768;
 
+// Appends a single wide character to `command_line`, returning false if that
+// would overflow the `capacity` (excluding the terminating null).
+static bool append_wchar(wchar_t* command_line, int* pos, int capacity, wchar_t c) {
+  if (*pos >= capacity) return false;
+  command_line[(*pos)++] = c;
+  return true;
+}
+
+// Appends `argument` to `command_line`, quoting it following the rules that
+// 'CommandLineToArgvW' reverses. We parse our own command line with that
+// function (see main_utf_8_helper.cc), so this quoting ensures that empty
+// arguments and arguments containing spaces or quotes survive the round-trip.
+// Returns false if the buffer would overflow.
+// See https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
+static bool append_quoted_argument(wchar_t* command_line, int* pos, int capacity, const wchar_t* argument) {
+  size_t length = wcslen(argument);
+
+  // An argument only needs quoting if it is empty or contains a character that
+  // 'CommandLineToArgvW' would otherwise treat as a separator or metacharacter.
+  bool needs_quotes = (length == 0);
+  for (size_t i = 0; !needs_quotes && i < length; i++) {
+    wchar_t c = argument[i];
+    needs_quotes = (c == L' ' || c == L'\t' || c == L'\n' || c == L'\v' || c == L'"');
+  }
+
+  if (!needs_quotes) {
+    for (size_t i = 0; i < length; i++) {
+      if (!append_wchar(command_line, pos, capacity, argument[i])) return false;
+    }
+    return true;
+  }
+
+  if (!append_wchar(command_line, pos, capacity, L'"')) return false;
+  size_t i = 0;
+  while (true) {
+    int backslashes = 0;
+    while (i < length && argument[i] == L'\\') {
+      i++;
+      backslashes++;
+    }
+    if (i == length) {
+      // Escape all backslashes, but let the terminating quote we add below be
+      // interpreted as a metacharacter.
+      for (int b = 0; b < backslashes * 2; b++) {
+        if (!append_wchar(command_line, pos, capacity, L'\\')) return false;
+      }
+      break;
+    } else if (argument[i] == L'"') {
+      // Escape all backslashes and the following quote.
+      for (int b = 0; b < backslashes * 2 + 1; b++) {
+        if (!append_wchar(command_line, pos, capacity, L'\\')) return false;
+      }
+      if (!append_wchar(command_line, pos, capacity, argument[i])) return false;
+    } else {
+      // Backslashes aren't special here.
+      for (int b = 0; b < backslashes; b++) {
+        if (!append_wchar(command_line, pos, capacity, L'\\')) return false;
+      }
+      if (!append_wchar(command_line, pos, capacity, argument[i])) return false;
+    }
+    i++;
+  }
+  return append_wchar(command_line, pos, capacity, L'"');
+}
+
 // Forks and execs a program (optionally found using the PATH environment
 // variable.  The given file descriptors should be open file descriptors.  They
 // are attached to the stdin, stdout and stderr of the launched program, and
@@ -562,7 +627,6 @@ static Object* fork_helper(
 
   int pos = 0;
   for (int i = 0; i < arguments->length(); i++) {
-    const wchar_t* format = (i != arguments->length() - 1) ? L"%ls " : L"%ls";
     Blob argument;
     if (!arguments->at(i)->byte_content(process->program(), &argument, STRINGS_ONLY)) {
       FAIL(WRONG_OBJECT_TYPE);
@@ -570,9 +634,15 @@ static Object* fork_helper(
     WideCharAllocationManager allocation(process);
     auto utf_16_argument = allocation.to_wcs(&argument);
 
-    if (pos + wcslen(utf_16_argument) + wcslen(format) - 3 >= MAX_COMMAND_LINE_LENGTH) FAIL(OUT_OF_BOUNDS);
-    pos += snwprintf(command_line + pos, MAX_COMMAND_LINE_LENGTH - pos, format, utf_16_argument);
+    // Separate arguments with a space.
+    if (i != 0 && !append_wchar(command_line, &pos, MAX_COMMAND_LINE_LENGTH, L' ')) {
+      FAIL(OUT_OF_BOUNDS);
+    }
+    if (!append_quoted_argument(command_line, &pos, MAX_COMMAND_LINE_LENGTH, utf_16_argument)) {
+      FAIL(OUT_OF_BOUNDS);
+    }
   }
+  command_line[pos] = L'\0';
 
   // We allocate memory for the SubprocessResource early here so we can handle failure
   // and restart the primitive.  If we wait until after the fork, the

--- a/tests/pkg/assets/completion/gold/10-unsynced.gold
+++ b/tests/pkg/assets/completion/gold/10-unsynced.gold
@@ -1,0 +1,14 @@
+// Completions must never go to the network:
+==================
+// an unsynced registry doesn't produce any candidates.
+==================
+[complete, install, ]
+:4
+Exit Code: 0
+==================
+// The registry names come from the local configuration and are still completed.
+==================
+[complete, registry, remove, ]
+git-pkgs	http://localhost:<[*PORT*]>/registry/git-pkgs (git)
+:1
+Exit Code: 0

--- a/tests/pkg/assets/completion/gold/20-packages.gold
+++ b/tests/pkg/assets/completion/gold/20-packages.gold
@@ -1,0 +1,49 @@
+OK
+[pkg, sync]
+==================
+// After a sync the registry is cached and produces candidates.
+==================
+[complete, install, ]
+localhost:<[*PORT*]>/pkg/pkg1	git-package 1
+localhost:<[*PORT*]>/pkg/pkg2	git-package 2
+localhost:<[*PORT*]>/pkg/pkg3	git-package 3
+localhost:<[*PORT*]>/pkg/pkg4	git-package 4
+pkg1	git-package 1
+pkg2	git-package 2
+pkg3	git-package 3
+pkg4	git-package 4
+:4
+Exit Code: 0
+==================
+// A '@' in the prefix completes the version part.
+==================
+[complete, install, pkg2@]
+pkg2@2.4.2
+pkg2@1.0.0
+:4
+Exit Code: 0
+==================
+// With '--local' no candidates are produced; the shell falls back to file completion.
+==================
+[complete, install, --local, ]
+:4
+Exit Code: 0
+==================
+// Option names are completed as well.
+==================
+[complete, install, --]
+--auto-sync	Automatically synchronize registries.
+--no-auto-sync	Automatically synchronize registries.
+--sdk-version	Specify the SDK version.
+--output-format	Specify the format used when printing to the console.
+--verbose	Enable verbose output. Shorthand for --verbosity-level=verbose.
+--no-verbose	Enable verbose output. Shorthand for --verbosity-level=verbose.
+--verbosity-level	Specify the verbosity level.
+--local	Treat package argument as local path.
+--no-local	Treat package argument as local path.
+--prefix	The prefix used for the 'import' clause.
+--recompute	Recompute dependencies.
+--no-recompute	Recompute dependencies.
+--help	Show help for this command.
+:1
+Exit Code: 0

--- a/tests/pkg/assets/completion/gold/30-describe.gold
+++ b/tests/pkg/assets/completion/gold/30-describe.gold
@@ -1,0 +1,21 @@
+[complete, describe, ]
+localhost:<[*PORT*]>/pkg/pkg1	git-package 1
+localhost:<[*PORT*]>/pkg/pkg2	git-package 2
+localhost:<[*PORT*]>/pkg/pkg3	git-package 3
+localhost:<[*PORT*]>/pkg/pkg4	git-package 4
+:4
+Exit Code: 0
+==================
+// The version argument completes the versions of the package given as first argument.
+==================
+[complete, describe, localhost:<[*PORT*]>/pkg/pkg2, ]
+2.4.2
+1.0.0
+:1
+Exit Code: 0
+==================
+[complete, describe, pkg2, ]
+2.4.2
+1.0.0
+:1
+Exit Code: 0

--- a/tests/pkg/assets/completion/gold/40-uninstall.gold
+++ b/tests/pkg/assets/completion/gold/40-uninstall.gold
@@ -1,0 +1,18 @@
+OK
+[pkg, init]
+==================
+OK
+[pkg, install, pkg1]
+Package 'localhost:<[*PORT*]>/pkg/pkg1@1.0.0' installed with prefix 'pkg1'.
+==================
+OK
+[pkg, install, --prefix=other, pkg3]
+Package 'localhost:<[*PORT*]>/pkg/pkg3@3.1.2' installed with prefix 'other'.
+==================
+// Uninstall completes the prefixes of the installed packages.
+==================
+[complete, uninstall, ]
+pkg1	localhost:<[*PORT*]>/pkg/pkg1
+other	localhost:<[*PORT*]>/pkg/pkg3
+:1
+Exit Code: 0

--- a/tests/pkg/assets/completion/gold/50-misc.gold
+++ b/tests/pkg/assets/completion/gold/50-misc.gold
@@ -1,0 +1,38 @@
+// Subcommands are completed.
+==================
+[complete, ]
+clean	Removes unnecessary packages.
+describe	Generates a description of the given package.
+init	Initializes the current directory as the root of the project.
+install	Installs a package in the current project, or downloads all dependencies.
+list	Lists all packages.
+registry	Manages registries.
+search	Searches for the given name in all packages.
+sync	Synchronizes all registries.
+uninstall	Uninstalls the package with the given name.
+update	Updates all packages to their newest compatible version.
+version	Prints the version of the package manager
+completion	Generate shell completion scripts.
+help	Show help for a command.
+:1
+Exit Code: 0
+==================
+[complete, registry, ]
+add	Adds a registry.
+remove	Removes a registry.
+list	List registries
+sync	Synchronizes all registries.
+:1
+Exit Code: 0
+==================
+// Registry names for list and sync.
+==================
+[complete, list, ]
+git-pkgs	http://localhost:<[*PORT*]>/registry/git-pkgs (git)
+:4
+Exit Code: 0
+==================
+[complete, registry, sync, ]
+git-pkgs	http://localhost:<[*PORT*]>/registry/git-pkgs (git)
+:1
+Exit Code: 0

--- a/tests/pkg/completion-gold-test.toit
+++ b/tests/pkg/completion-gold-test.toit
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import .gold-tester
+
+main args:
+  with-gold-tester --with-git-pkg-registry args: test it
+
+test tester/GoldTester:
+  tester.gold "10-unsynced" [
+    ["// Completions must never go to the network:"],
+    ["// an unsynced registry doesn't produce any candidates."],
+    ["complete", "install", ""],
+    ["// The registry names come from the local configuration and are still completed."],
+    ["complete", "registry", "remove", ""],
+  ]
+
+  tester.gold "20-packages" [
+    ["pkg", "sync"],
+    ["// After a sync the registry is cached and produces candidates."],
+    ["complete", "install", ""],
+    ["// A '@' in the prefix completes the version part."],
+    ["complete", "install", "pkg2@"],
+    ["// With '--local' no candidates are produced; the shell falls back to file completion."],
+    ["complete", "install", "--local", ""],
+    ["// Option names are completed as well."],
+    ["complete", "install", "--"],
+  ]
+
+  tester.gold "30-describe" [
+    ["complete", "describe", ""],
+    ["// The version argument completes the versions of the package given as first argument."],
+    ["complete", "describe", "localhost:$tester.port/pkg/pkg2", ""],
+    ["complete", "describe", "pkg2", ""],
+  ]
+
+  tester.gold "40-uninstall" [
+    ["pkg", "init"],
+    ["pkg", "install", "pkg1"],
+    ["pkg", "install", "--prefix=other", "pkg3"],
+    ["// Uninstall completes the prefixes of the installed packages."],
+    ["complete", "uninstall", ""],
+  ]
+
+  tester.gold "50-misc" [
+    ["// Subcommands are completed."],
+    ["complete", ""],
+    ["complete", "registry", ""],
+    ["// Registry names for list and sync."],
+    ["complete", "list", ""],
+    ["complete", "registry", "sync", ""],
+  ]

--- a/tests/pkg/gold-tester.toit
+++ b/tests/pkg/gold-tester.toit
@@ -65,6 +65,7 @@ class GoldTester:
   gold-dir_/string
   working-dir_/string
   toit-exec_/string
+  pkg-entry_/string
   should-update_/bool
   port_/int
   registry-cache-dir_/string
@@ -72,6 +73,7 @@ class GoldTester:
 
   constructor
       --toit-exe/string
+      --pkg-entry/string
       --gold-dir/string
       --working-dir/string
       --registry-cache-dir/string
@@ -79,6 +81,7 @@ class GoldTester:
       --port/int
       --git-roots/Map:
     toit-exec_ = toit-exe
+    pkg-entry_ = pkg-entry
     gold-dir_ = gold-dir
     working-dir_ = working-dir
     registry-cache-dir_ = registry-cache-dir
@@ -196,6 +199,17 @@ class GoldTester:
           json-content := file.read-contents contents-path
           as-yaml := yaml.stringify (json.decode json-content)
           outputs.add "== contents.json\n$as-yaml"
+      else if command == "complete":
+        // Asks the pkg tool for shell completions.
+        // The words after "complete" are the words on the (virtual) command
+        // line, where the last one is the word that is being completed.
+        // Runs in a separate process, since the completion candidates are
+        // printed directly to stdout and not through the UI.
+        words := command-line[1..]
+        if set-project-root:
+          words = ["--project-root=$working-dir_"] + words
+        run-result := toit "run" ([pkg-entry_, "__complete", "--"] + words)
+        outputs.add "$command-line\n$run-result.full-output"
       else if command == "pkg":
         pkg-args := command-line[1..]  // Drop the "pkg"
         has-project-root := pkg-args.any: | arg/string | arg.starts-with "--project-root"
@@ -505,6 +519,7 @@ with-gold-tester args/List
   source-location := system.program-path
   source-dir := fs.dirname source-location
   source-name := (fs.basename source-location).trim --right "-gold-test.toit"
+  pkg-entry := fs.to-absolute (fs.join [source-dir, "..", "..", "tools", "pkg", "pkg.toit"])
   shared-dir := "$source-dir/assets/shared"
   assets-dir := "$source-dir/assets/$source-name"
   gold-dir := "$assets-dir/gold"
@@ -541,6 +556,7 @@ with-gold-tester args/List
       tester := GoldTester
           --port=port
           --toit-exe=toit-exe
+          --pkg-entry=pkg-entry
           --gold-dir=gold-dir
           --working-dir=tmp-dir
           --registry-cache-dir=registry-cache-dir

--- a/tests/pkg/solver-test.toit
+++ b/tests/pkg/solver-test.toit
@@ -62,6 +62,7 @@ class TestRegistry extends reg.Registry:
   content -> FileSystemView: unreachable
   to-map -> Map: unreachable
   sync --clear-cache/bool: // Do nothing.
+  is-cached -> bool: return true
   stringify -> string: return "test-reg"
   to-string -> string: return "test-reg"
 

--- a/tools/pkg/commands/completions_.toit
+++ b/tools/pkg/commands/completions_.toit
@@ -1,0 +1,249 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+import cli
+import encoding.yaml
+import fs
+import host.file
+
+import ..project.specification
+import ..registry
+import ..registry.description
+
+/**
+Completion callbacks for the pkg commands.
+
+Completion callbacks run while the user is waiting for the shell to
+  react to a tab-press. Shells don't interrupt slow completion commands,
+  so callbacks must be fast, and they must be silent, since stdout is
+  reserved for the completion protocol.
+
+Most importantly, callbacks must never go to the network: only registry
+  data that is already available locally is used. If no local data is
+  available, no candidates are produced.
+
+Any error simply leads to an empty candidate list.
+*/
+
+/**
+The maximum time a completion callback may take.
+
+If a callback exceeds this limit, the completion is abandoned and no
+  candidates are produced. This way a bug in a callback (like an
+  accidental network access) blocks the user's prompt for a bounded
+  time instead of requiring a ctrl-c.
+
+The limit is generous: loading the description cache of a big registry
+  can take more than a second on slow machines, and slow-but-successful
+  completions are still better than none.
+*/
+COMPLETION-TIMEOUT-MS_ ::= 5_000
+
+/**
+Runs the $block and returns its result.
+
+Returns an empty list if the block throws or takes longer than
+  $COMPLETION-TIMEOUT-MS_.
+*/
+guarded_ [block] -> List:
+  result := []
+  catch:
+    with-timeout --ms=COMPLETION-TIMEOUT-MS_:
+      result = block.call
+  return result
+
+/**
+Loads the registries for completion purposes.
+
+The registries are never synchronized, and all output is suppressed.
+*/
+completion-registries_ -> Registries:
+  ui := cli.Ui.human --level=cli.Ui.SILENT-LEVEL
+  return Registries --ui=ui --no-auto-sync
+
+/**
+Returns a map from package URL to the cached $Description with the
+  highest version for that URL.
+
+Registries that are not cached locally are skipped: loading them would
+  need to go to the network.
+*/
+cached-latest-descriptions_ registries/Registries -> Map:
+  result := {:}
+  registries.registries.do --values: | registry/Registry |
+    if not registry.is-cached: continue.do
+    registry.list-all-descriptions.do: | description/Description |
+      existing/Description? := result.get description.url
+      if not existing or existing.version < description.version:
+        result[description.url] = description
+  return result
+
+/**
+Returns the URLs of the cached packages that the given $name-or-url
+  identifies.
+
+Uses the same matching rules as 'pkg install': a package matches if its
+  name is equal to $name-or-url, or if its URL is equal to, or ends
+  with "/$name-or-url".
+*/
+matching-urls_ registries/Registries name-or-url/string -> List:
+  result := []
+  (cached-latest-descriptions_ registries).do: | url/string description/Description |
+    if description.name == name-or-url or url == name-or-url or url.ends-with "/$name-or-url":
+      result.add url
+  return result
+
+/**
+Returns the sorted version strings of all cached descriptions for the
+  given $url, highest version first.
+*/
+cached-versions_ registries/Registries url/string -> List:
+  versions := {}
+  registries.registries.do --values: | registry/Registry |
+    if not registry.is-cached: continue.do
+    if registry-versions := registry.retrieve-versions url:
+      versions.add-all registry-versions
+  sorted := List.from versions
+  sorted.sort --in-place
+  result := []
+  sorted.do --reversed: result.add "$it"
+  return result
+
+/**
+Returns a single-line variant of the given description $text suitable
+  as completion-candidate description.
+
+The completion protocol is line-based and uses tabs as separators, so
+  the result must not contain newlines or tabs. Shells show the
+  description next to the candidate, so only the beginning is useful.
+*/
+short-description_ text/string? -> string?:
+  if not text: return null
+  newline-index := text.index-of "\n"
+  if newline-index >= 0: text = text[..newline-index]
+  text = text.replace --all "\t" " "
+  text = text.trim
+  MAX ::= 80
+  if text.size > MAX:
+    // Don't cut into the middle of a UTF-8 sequence.
+    cut := MAX - 3
+    while cut > 0 and (text.at --raw cut) & 0b1100_0000 == 0b1000_0000: cut--
+    text = "$(text[..cut])..."
+  return text.is-empty ? null : text
+
+/**
+Completes package names and URLs for commands that take a package
+  identifier, like 'pkg install'.
+
+If the prefix already contains a '@', completes the version part
+  instead.
+
+If the $skip-if-flag option has been provided on the command line, no
+  candidates are produced. This is used by 'pkg install' to fall back
+  to the shell's file completion when '--local' was given.
+*/
+complete-packages context/cli.CompletionContext --skip-if-flag/string?=null -> List:
+  return guarded_:
+    complete-packages_ context --skip-if-flag=skip-if-flag
+
+complete-packages_ context/cli.CompletionContext --skip-if-flag/string? -> List:
+  if skip-if-flag and (context.seen-options.contains skip-if-flag): return []
+
+  registries := completion-registries_
+
+  at-index := context.prefix.index-of "@"
+  if at-index >= 0:
+    // Complete 'name@version'.
+    name := context.prefix[..at-index]
+    result := []
+    (matching-urls_ registries name).do: | url/string |
+      (cached-versions_ registries url).do: | version/string |
+        result.add (cli.CompletionCandidate "$name@$version")
+    return result
+
+  result := []
+  names := {:}  // Package name to list of URLs.
+  latest := cached-latest-descriptions_ registries
+  latest.do: | url/string description/Description |
+    result.add (cli.CompletionCandidate url --description=(short-description_ description.description))
+    (names.get description.name --init=: []).add url
+  names.do: | name/string urls/List |
+    if urls.size != 1:
+      // The name is ambiguous; the URL candidates are the only way to
+      // uniquely identify these packages.
+      continue.do
+    description/Description := latest[urls[0]]
+    result.add (cli.CompletionCandidate name --description=(short-description_ description.description))
+  return result
+
+/**
+Completes package URLs, like for 'pkg describe'.
+*/
+complete-package-urls context/cli.CompletionContext -> List:
+  return guarded_:
+    result := []
+    (cached-latest-descriptions_ completion-registries_).do: | url/string description/Description |
+      result.add (cli.CompletionCandidate url --description=(short-description_ description.description))
+    result
+
+/**
+Completes the versions of the package that was given as value for the
+  rest option $url-option earlier on the command line.
+*/
+complete-package-versions context/cli.CompletionContext --url-option/string -> List:
+  return guarded_:
+    seen/List? := context.seen-options.get url-option
+    if not seen or seen.is-empty: continue.guarded_ []
+    registries := completion-registries_
+    urls := matching-urls_ registries seen.last
+    result := []
+    urls.do: | url/string |
+      (cached-versions_ registries url).do: | version/string |
+        result.add (cli.CompletionCandidate version)
+    result
+
+/**
+Completes the names of the configured registries.
+*/
+complete-registry-names context/cli.CompletionContext -> List:
+  return guarded_:
+    result := []
+    completion-registries_.registries.do: | name/string registry/Registry |
+      result.add (cli.CompletionCandidate name --description=registry.to-string)
+    result
+
+/**
+Completes the prefixes of the packages that are installed in the
+  current project, like for 'pkg uninstall'.
+
+The project root is taken from the $project-root-option if it was
+  provided on the command line, and defaults to the current directory.
+*/
+complete-dependency-prefixes context/cli.CompletionContext --project-root-option/string -> List:
+  return guarded_:
+    roots/List? := context.seen-options.get project-root-option
+    root := (roots and not roots.is-empty) ? roots.last : "."
+    contents := file.read-contents (fs.join root Specification.FILE-NAME)
+    decoded := yaml.decode contents
+    if decoded is not Map: continue.guarded_ []
+    dependencies := decoded.get "dependencies"
+    if dependencies is not Map: continue.guarded_ []
+    result := []
+    dependencies.do: | prefix/string entry |
+      target := entry is Map
+          ? (entry.get "url" or entry.get "path")
+          : null
+      result.add (cli.CompletionCandidate "$prefix" --description=(target and "$target"))
+    result

--- a/tools/pkg/commands/describe.toit
+++ b/tools/pkg/commands/describe.toit
@@ -31,6 +31,7 @@ import ..file-system-view
 import ..semantic-version
 
 import .base_
+import .completions_
 import .list
 
 
@@ -230,16 +231,22 @@ class DescribeCommand extends PkgCommand:
                 directories to make the description path unique.
               """
           --rest=[
-              cli.Option URL-PATH-OPTION
+              // An OptionPath, so that the shell falls back to file completion
+              // when no package URL matches.
+              cli.OptionPath URL-PATH-OPTION
+                  --type="URL|path"
                   --help="The URL or path to the package."
-                  --required=false,
+                  --required=false
+                  --completion=:: complete-package-urls it,
 
               cli.Option VERSION-OPTION
                   --help="The version of the package."
-                  --required=false,
+                  --required=false
+                  --completion=:: complete-package-versions it --url-option=URL-PATH-OPTION,
             ]
           --options=[
-              cli.Option OUT-DIR-OPTION
+              cli.OptionPath OUT-DIR-OPTION
+                  --directory
                   --help="The directory to write the description file to."
                   --required=false,
 

--- a/tools/pkg/commands/install.toit
+++ b/tools/pkg/commands/install.toit
@@ -26,6 +26,7 @@ import ..registry
 import ..utils
 
 import .base_
+import .completions_
 import .utils_
 
 class InstallCommand extends PkgProjectCommand:
@@ -233,7 +234,11 @@ class InstallCommand extends PkgProjectCommand:
                   """,
           ]
           --rest=[
-              cli.Option --multi REST
+              // An OptionPath, so that the shell falls back to file completion
+              // when no package matches (for example for '--local' paths).
+              cli.OptionPath --multi REST
+                  --type="package|path"
+                  --completion=:: complete-packages it --skip-if-flag=LOCAL
           ]
           --options=[
               cli.Flag LOCAL

--- a/tools/pkg/commands/list.toit
+++ b/tools/pkg/commands/list.toit
@@ -27,6 +27,7 @@ import ..registry.description
 import ..registry.local
 
 import .base_
+import .completions_
 
 class ListCommand extends PkgCommand:
   name-or-path/string?
@@ -121,8 +122,12 @@ class ListCommand extends PkgCommand:
                 In that case only the packages from that registry are shown.
               """
           --rest=[
-              cli.Option NAME-OR-PATH-OPTION
+              // An OptionPath, so that the shell falls back to file completion
+              // when no registry name matches.
+              cli.OptionPath NAME-OR-PATH-OPTION
+                  --type="name|path"
                   --required=false
+                  --completion=:: complete-registry-names it
             ]
           --run=:: (ListCommand it).execute
 

--- a/tools/pkg/commands/registry.toit
+++ b/tools/pkg/commands/registry.toit
@@ -23,6 +23,7 @@ import ..registry
 import ..registry.local
 
 import .base_
+import .completions_
 
 class RegistryCommand extends PkgCommand:
   static LOCAL     ::= "local"
@@ -141,6 +142,7 @@ class RegistryCommand extends PkgCommand:
                         cli.Option "name"
                             --help="Name of the registry"
                             --required
+                            --completion=:: complete-registry-names it
                       ]
                     --run=:: (RegistryCommand.remove it).remove,
 
@@ -164,6 +166,7 @@ class RegistryCommand extends PkgCommand:
                         cli.Option "name"
                             --help="Name of the registry"
                             --required=false
+                            --completion=:: complete-registry-names it
                       ]
                     --run=:: (RegistryCommand.sync it).sync,
           ]

--- a/tools/pkg/commands/uninstall.toit
+++ b/tools/pkg/commands/uninstall.toit
@@ -21,6 +21,7 @@ import ..pkg
 import ..project
 
 import .base_
+import .completions_
 import .utils_
 
 class UninstallCommand extends PkgProjectCommand:
@@ -45,6 +46,7 @@ class UninstallCommand extends PkgProjectCommand:
               cli.Option NAME
                   --help="The name of the package to uninstall."
                   --required
+                  --completion=:: complete-dependency-prefixes it --project-root-option=OPTION-PROJECT-ROOT
           ]
           --run=:: (UninstallCommand it).execute
 

--- a/tools/pkg/pkg.toit
+++ b/tools/pkg/pkg.toit
@@ -29,8 +29,6 @@ import .commands.list
 import .commands.search
 import .commands.describe
 
-// TODO(florian): implement completion in the cli package
-
 build-command -> Command:
   return Command "pkg"
       --help="The Toit package manager"
@@ -52,7 +50,8 @@ build-command -> Command:
               --help="Automatically synchronize registries."
               --default=true,
 
-          Option OPTION-PROJECT-ROOT
+          OptionPath OPTION-PROJECT-ROOT
+              --directory
               --help="Specify the project root.",
 
           Option OPTION-SDK-VERSION

--- a/tools/pkg/registry/git.toit
+++ b/tools/pkg/registry/git.toit
@@ -48,6 +48,15 @@ class GitRegistry extends Registry:
 
   type -> string: return "git"
 
+  is-cached -> bool:
+    return cache.contains cache-key_
+
+  // The cache entry is a single AR file. The extension keeps it distinct from
+  // the old directory-based cache (which was stored at "registry/git/$url"),
+  // so existing users aren't hit by a "cache entry is a directory" error.
+  cache-key_ -> string:
+    return "registry/git/$(url).ar"
+
   content -> FileSystemView:
     if not content_: content_ = load_
     return content_
@@ -97,10 +106,7 @@ class GitRegistry extends Registry:
     store.save buffer.bytes
 
   load_ --sync/bool=false --clear-cache/bool=false -> FileSystemView:
-    // The cache entry is a single AR file. The extension keeps it distinct from
-    // the old directory-based cache (which was stored at "registry/git/$url"),
-    // so existing users aren't hit by a "cache entry is a directory" error.
-    key := "registry/git/$(url).ar"
+    key := cache-key_
 
     ar-contents/ByteArray := ?
     if sync or clear-cache:

--- a/tools/pkg/registry/local.toit
+++ b/tools/pkg/registry/local.toit
@@ -29,6 +29,9 @@ class LocalRegistry extends Registry:
 
   type -> string: return "local"
 
+  is-cached -> bool:
+    return file.is-directory path
+
   content -> FileSystemView:
     return FileSystemView_ path
 

--- a/tools/pkg/registry/registry.toit
+++ b/tools/pkg/registry/registry.toit
@@ -273,6 +273,13 @@ abstract class Registry:
   abstract sync --clear-cache/bool -> none
   abstract to-string -> string
 
+  /**
+  Whether the contents of this registry are available locally.
+
+  If false, accessing $content needs to go to the network.
+  */
+  abstract is-cached -> bool
+
   description-cache -> DescriptionUrlCache:
     if not description-cache_:
       description-cache_ = DescriptionUrlCache content --ui=ui_


### PR DESCRIPTION
The pkg commands now provide completion candidates through the cli
package's completion support:

- `pkg install` completes package names and URLs (with descriptions)
  from the locally cached registries. A '@' in the word completes the
  version part (`pkg install morse@<tab>`). Ambiguous names are only
  offered as URLs. With `--local` the shell falls back to file
  completion.
- `pkg uninstall` completes the prefixes of the installed packages,
  honoring `--project-root`.
- `pkg describe` completes package URLs, and completes the version
  argument with the versions of the package given as first argument.
- `pkg registry remove`, `pkg registry sync` and `pkg list` complete
  registry names.
- `--project-root` and describe's `--out-dir` complete directories.

Completion callbacks run while the user is waiting for the shell
prompt, so they never go to the network: registries whose content is
not cached locally are skipped (new `Registry.is-cached`), the
registries are never auto-synced, and any error or timeout results in
an empty candidate list.

The gold tester gained a `complete` command that runs
`pkg.toit __complete` in a subprocess, and a new completion gold test
covers the behavior, including that an unsynced registry produces no
candidates.