### PR TITLE
Add 'uart.Port.console' to read input from the console UART.

### DIFF
--- a/lib/uart.toit
+++ b/lib/uart.toit
@@ -154,6 +154,9 @@ class Port extends Object with io.InMixin implements reader.Reader:
     port: it continues to be written directly to the console. Data written
     to this port may thus interleave with system output.
 
+  Changing this port's baud rate also changes the baud rate used for system
+    output.
+
   Use $large-buffers to increase the receive buffer from 768 bytes to
     4096 bytes.
 

--- a/lib/uart.toit
+++ b/lib/uart.toit
@@ -141,6 +141,36 @@ class Port extends Object with io.InMixin implements reader.Reader:
     add-finalizer this:: close
 
   /**
+  Constructs a UART port for the console UART.
+
+  The console UART is the UART the system uses for logging and for the
+    output of $print. Opening it gives access to the data that is received
+    on that UART, which the system otherwise discards. This makes it
+    possible for a program to take input from the same serial connection
+    that shows its output.
+
+  The port keeps the configuration (such as the baud rate) that the console
+    was set up with during boot. System output is unaffected by opening the
+    port: it continues to be written directly to the console. Data written
+    to this port may thus interleave with system output.
+
+  Use $large-buffers to increase the receive buffer from 768 bytes to
+    4096 bytes.
+
+  Only one console port can be open at a time.
+
+  Only supported on ESP32 variants, and only if the console is on a UART
+    (the default). Throws "UNSUPPORTED" otherwise.
+  */
+  constructor.console --large-buffers/bool=false:
+    rx-buffer-size := large-buffers ? 4096 : 768
+    tx-buffer-size := 1024
+    uart_ = uart-create-console_ resource-group_ rx-buffer-size tx-buffer-size
+    state_ = ResourceState_ resource-group_ uart_
+
+    add-finalizer this:: close
+
+  /**
   Constructs a UART port using a $device path.
 
   This constructor does not work on embedded devices, such as the ESP32.
@@ -441,6 +471,9 @@ uart-create_ group tx rx rts cts baud-rate data-bits stop-bits parity tx-flags m
 
 uart-create-path_ resource-group device baud-rate data-bits stop-bits parity:
   #primitive.uart.create-path
+
+uart-create-console_ resource-group rx-buffer-size tx-buffer-size:
+  #primitive.uart.create-console
 
 uart-set-baud-rate_ uart baud:
   #primitive.uart.set-baud-rate

--- a/src/compiler/propagation/type_primitive_uart.cc
+++ b/src/compiler/propagation/type_primitive_uart.cc
@@ -32,6 +32,7 @@ TYPE_PRIMITIVE_ANY(wait_tx)
 TYPE_PRIMITIVE_ANY(set_control_flags)
 TYPE_PRIMITIVE_ANY(get_control_flags)
 TYPE_PRIMITIVE_INT(errors)
+TYPE_PRIMITIVE_ANY(create_console)
 
 }  // namespace toit::compiler
 }  // namespace toit

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -477,6 +477,7 @@ namespace toit {
   PRIMITIVE(set_control_flags, 2)            \
   PRIMITIVE(get_control_flags, 1)            \
   PRIMITIVE(errors, 1)                       \
+  PRIMITIVE(create_console, 3)               \
 
 #define MODULE_RMT(PRIMITIVE)                \
   PRIMITIVE(bytes_per_memory_block, 0)       \

--- a/src/resources/uart_esp32.cc
+++ b/src/resources/uart_esp32.cc
@@ -24,6 +24,7 @@
 #include "soc/uart_periph.h"
 #include "esp_log.h"
 #include "esp_rom_gpio.h"
+#include "esp_rom_uart.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 
@@ -88,6 +89,14 @@ static ResourcePool<uart_port_t, kInvalidUartPort> uart_ports(
 #endif
 );
 
+#ifdef CONFIG_ESP_CONSOLE_UART
+// The console UART is excluded from `uart_ports` above. It can only be
+// opened through the dedicated console primitive.
+static ResourcePool<uart_port_t, kInvalidUartPort> console_uart_port(
+    static_cast<uart_port_t>(CONFIG_ESP_CONSOLE_UART_NUM)
+);
+#endif
+
 class UartResourceGroup;
 
 class UartResource : public EventQueueResource {
@@ -150,6 +159,12 @@ class UartResourceGroup : public ResourceGroup {
 
   void on_unregister_resource(Resource* r) override {
     auto uart_res = reinterpret_cast<UartResource*>(r);
+#ifdef CONFIG_ESP_CONSOLE_UART
+    if (uart_res->port() == CONFIG_ESP_CONSOLE_UART_NUM) {
+      console_uart_port.put(uart_res->port());
+      return;
+    }
+#endif
     uart_ports.put(uart_res->port());
   }
 
@@ -496,6 +511,73 @@ PRIMITIVE(create) {
 
 PRIMITIVE(create_path) {
   FAIL(UNIMPLEMENTED);
+}
+
+PRIMITIVE(create_console) {
+#ifndef CONFIG_ESP_CONSOLE_UART
+  FAIL(UNSUPPORTED);
+#else
+  ARGS(UartResourceGroup, group, int, rx_buffer_size, int, tx_buffer_size)
+
+  uart_port_t port = static_cast<uart_port_t>(CONFIG_ESP_CONSOLE_UART_NUM);
+
+  // The driver requires the RX buffer to be bigger than the hardware FIFO.
+  if (rx_buffer_size <= UART_HW_FIFO_LEN(port) || rx_buffer_size > 32 * 1024) FAIL(INVALID_ARGUMENT);
+  if (tx_buffer_size < 0 || tx_buffer_size > 32 * 1024) FAIL(INVALID_ARGUMENT);
+
+  if (!console_uart_port.take(port)) FAIL(ALREADY_IN_USE);
+  // Whether the resource object has been created and is thus responsible
+  // for returning resources.
+  bool handed_to_resource = false;
+  Defer return_port { [&] { if (!handed_to_resource) console_uart_port.put(port); } };
+
+  ByteArray* proxy = process->object_heap()->allocate_proxy();
+  if (proxy == null) FAIL(ALLOCATION_FAILED);
+
+  // The console UART keeps the configuration (baud rate, pins, ...) it was
+  // given during boot; only the driver is installed, which makes RX
+  // interrupt driven. System output (logging, `print`) keeps going through
+  // the polling VFS path and thus doesn't need the driver.
+  // Installing the driver resets the TX FIFO, so drain in-flight output first.
+  esp_rom_output_tx_wait_idle(port);
+
+  esp_err_t err;
+  QueueHandle_t queue;
+  DriverArgs args = {
+    .port = port,
+    .rx_buffer_size = static_cast<uint16_t>(rx_buffer_size),
+    .tx_buffer_size = static_cast<uint16_t>(tx_buffer_size),
+    // Level 3 interrupts are problematic on some chips (see `create`), so
+    // stick to the levels that are safe everywhere.
+    .interrupt_flags = ESP_INTR_FLAG_SHARED | ESP_INTR_FLAG_LEVEL2 | ESP_INTR_FLAG_LEVEL1,
+    .queue = &queue,
+    .queue_size = UART_QUEUE_SIZE,
+  };
+  // Install the ISR on the SystemEventSource's main thread that runs on core 0,
+  // to allocate the interrupts on core 0.
+  SystemEventSource::instance()->run([&]() -> void {
+    err = uart_driver_install(args.port,
+                              args.rx_buffer_size,
+                              args.tx_buffer_size,
+                              args.queue_size,
+                              args.queue,
+                              args.interrupt_flags);
+  });
+  if (err != ESP_OK) return Primitive::os_error(err, process);
+  Defer uninstall_driver { [&] { if (!handed_to_resource) uart_driver_delete(port); } };
+
+  // Discard anything that was received before the port was opened.
+  err = uart_flush_input(port);
+  if (err != ESP_OK) return Primitive::os_error(err, process);
+
+  auto resource = _new UartResource(group, port, tx_buffer_size, queue);
+  if (!resource) FAIL(MALLOC_FAILED);
+  handed_to_resource = true;
+
+  group->register_resource(resource);
+  proxy->set_external_address(resource);
+  return proxy;
+#endif
 }
 
 PRIMITIVE(close) {

--- a/src/resources/uart_esp32.cc
+++ b/src/resources/uart_esp32.cc
@@ -24,7 +24,6 @@
 #include "soc/uart_periph.h"
 #include "esp_log.h"
 #include "esp_rom_gpio.h"
-#include "esp_rom_uart.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 
@@ -538,8 +537,6 @@ PRIMITIVE(create_console) {
   // given during boot; only the driver is installed, which makes RX
   // interrupt driven. System output (logging, `print`) keeps going through
   // the polling VFS path and thus doesn't need the driver.
-  // Installing the driver resets the TX FIFO, so drain in-flight output first.
-  esp_rom_output_tx_wait_idle(port);
 
   esp_err_t err;
   QueueHandle_t queue;

--- a/src/resources/uart_posix.cc
+++ b/src/resources/uart_posix.cc
@@ -279,6 +279,10 @@ PRIMITIVE(create) {
   FAIL(UNIMPLEMENTED);
 }
 
+PRIMITIVE(create_console) {
+  FAIL(UNIMPLEMENTED);
+}
+
 PRIMITIVE(create_path) {
   ARGS(UartResourceGroup, resource_group, cstring, path, int, baud_rate, int, data_bits, int, stop_bits, int, parity);
 

--- a/src/resources/uart_win.cc
+++ b/src/resources/uart_win.cc
@@ -220,6 +220,10 @@ PRIMITIVE(create) {
   FAIL(UNIMPLEMENTED);
 }
 
+PRIMITIVE(create_console) {
+  FAIL(UNIMPLEMENTED);
+}
+
 PRIMITIVE(create_path) {
   ARGS(UartResourceGroup, resource_group, cstring, path, int, baud_rate, int, data_bits, int, stop_bits, int, parity);
 

--- a/tests/hw/esp-tester/shared.toit
+++ b/tests/hw/esp-tester/shared.toit
@@ -10,3 +10,7 @@ RUNNING-CONTAINER ::= "RUNNING INSTALLED CONTAINER"
 // write the payload back over the serial connection. Used by tests that
 // exercise console UART input.
 UART-INPUT-REQUEST ::= "UART-INPUT-REQUEST: "
+// A test prints this marker followed by a baud rate to ask the tester to
+// acknowledge at the current rate and then switch the serial connection.
+UART-BAUD-RATE-REQUEST ::= "UART-BAUD-RATE-REQUEST: "
+UART-BAUD-RATE-ACK ::= "UART-BAUD-RATE-ACK"

--- a/tests/hw/esp-tester/shared.toit
+++ b/tests/hw/esp-tester/shared.toit
@@ -6,3 +6,7 @@ MINI-JAG-LISTENING ::= "MINI-JAG LISTENING"
 RUN-TEST ::= "RUN TEST"
 INSTALLED-CONTAINER ::= "INSTALLED CONTAINER"
 RUNNING-CONTAINER ::= "RUNNING INSTALLED CONTAINER"
+// A test prints this marker (followed by a payload) to ask the tester to
+// write the payload back over the serial connection. Used by tests that
+// exercise console UART input.
+UART-INPUT-REQUEST ::= "UART-INPUT-REQUEST: "

--- a/tests/hw/esp-tester/tester.toit
+++ b/tests/hw/esp-tester/tester.toit
@@ -199,6 +199,9 @@ class TestDevice:
   // Offset into $collected-output up to which UART input requests have
   // been answered.
   uart-input-handled_/int := 0
+  // Offset into $collected-output up to which UART baud-rate requests have
+  // been answered.
+  uart-baud-rate-handled_/int := 0
   ready-latch/monitor.Latch := monitor.Latch
   installed-container/monitor.Latch := monitor.Latch
   running-container/monitor.Latch := monitor.Latch
@@ -249,7 +252,24 @@ class TestDevice:
               request-end = collected-output.size
             payload := collected-output[payload-start..request-end].trim
             uart-input-handled_ = request-end
-            port.out.write "$payload\n"
+            port.out.write "$payload\n" --flush
+          // Acknowledge baud-rate requests at the current rate before both
+          // sides switch to the requested rate.
+          while true:
+            request-index := collected-output.index-of "\n$UART-BAUD-RATE-REQUEST" uart-baud-rate-handled_
+            if request-index < 0: break
+            rate-start := request-index + 1 + UART-BAUD-RATE-REQUEST.size
+            request-end := collected-output.index-of "\n" rate-start
+            if request-end < 0:
+              if not at-new-line: break  // Wait for the rest of the line.
+              request-end = collected-output.size
+            rate := int.parse collected-output[rate-start..request-end].trim
+            uart-baud-rate-handled_ = request-end
+            port.out.write "$UART-BAUD-RATE-ACK\n" --flush
+            // Some USB-UART adapters report an empty host queue before their
+            // hardware has emitted the final bytes at the old rate.
+            sleep --ms=100
+            port.baud-rate = rate
           if collected-output.contains JAG-DECODE:
             if file.is-file "$tmp-dir/$SNAPSHOT-NAME":
               // Otherwise it's probably an error during setup.
@@ -404,4 +424,3 @@ setup-tester invocation/cli.Invocation:
       "--config", wifi-config-path,
       "--port", port-path,
     ]
-

--- a/tests/hw/esp-tester/tester.toit
+++ b/tests/hw/esp-tester/tester.toit
@@ -196,6 +196,9 @@ class TestDevice:
   read-task/Task? := null
   is-active/bool := false
   collected-output/string := ""
+  // Offset into $collected-output up to which UART input requests have
+  // been answered.
+  uart-input-handled_/int := 0
   ready-latch/monitor.Latch := monitor.Latch
   installed-container/monitor.Latch := monitor.Latch
   running-container/monitor.Latch := monitor.Latch
@@ -231,6 +234,22 @@ class TestDevice:
           if collected-output.contains "\n$ALL-TESTS-DONE": set-latch_ all-tests-done
           if collected-output.contains "\n$INSTALLED-CONTAINER": set-latch_ installed-container
           if collected-output.contains "\n$RUNNING-CONTAINER": set-latch_ running-container
+          // Serve UART input requests: when the device prints a marker line,
+          // write the payload back to it over the serial connection.
+          while true:
+            request-index := collected-output.index-of "\n$UART-INPUT-REQUEST" uart-input-handled_
+            if request-index < 0: break
+            payload-start := request-index + 1 + UART-INPUT-REQUEST.size
+            request-end := collected-output.index-of "\n" payload-start
+            if request-end < 0:
+              // The trailing newline of a chunk is stripped and only added
+              // back with the next chunk, so a completed chunk means a
+              // completed line.
+              if not at-new-line: break  // Wait for the rest of the line.
+              request-end = collected-output.size
+            payload := collected-output[payload-start..request-end].trim
+            uart-input-handled_ = request-end
+            port.out.write "$payload\n"
           if collected-output.contains JAG-DECODE:
             if file.is-file "$tmp-dir/$SNAPSHOT-NAME":
               // Otherwise it's probably an error during setup.

--- a/tests/hw/esp32/fail.cmake
+++ b/tests/hw/esp32/fail.cmake
@@ -15,10 +15,6 @@
 
 
 set(TOIT_SKIP_TESTS
-  # On the test rig the S3's board1 is connected through the USB-Serial-JTAG
-  # console, so data written by the tester doesn't reach the UART0 RX pin.
-  uart-console-test.toit-esp32s3
-
   # The S3 doesn't have a DAC.
   dac-test.toit-esp32s3
   # We are missing a DHT11.

--- a/tests/hw/esp32/fail.cmake
+++ b/tests/hw/esp32/fail.cmake
@@ -15,6 +15,10 @@
 
 
 set(TOIT_SKIP_TESTS
+  # On the test rig the S3's board1 is connected through the USB-Serial-JTAG
+  # console, so data written by the tester doesn't reach the UART0 RX pin.
+  uart-console-test.toit-esp32s3
+
   # The S3 doesn't have a DAC.
   dac-test.toit-esp32s3
   # We are missing a DHT11.

--- a/tests/hw/esp32/uart-console-test.toit
+++ b/tests/hw/esp32/uart-console-test.toit
@@ -3,10 +3,10 @@
 // be found in the tests/LICENSE file.
 
 /**
-Tests reading input from the console UART.
+Tests reading, writing, and changing the baud rate of the console UART.
 
-The esp-tester watches the test's output for the $UART-INPUT-REQUEST marker
-  and writes the payload back over the same serial connection.
+The esp-tester watches the test's output for request markers and responds over
+  the same serial connection.
 
 No wiring is needed: the test uses the USB-serial connection that also
   carries the console output.
@@ -15,27 +15,58 @@ No wiring is needed: the test uses the USB-serial connection that also
 import expect show *
 import uart
 
-import ..esp-tester.shared show UART-INPUT-REQUEST
+import ..esp-tester.shared show UART-BAUD-RATE-ACK
+                                UART-BAUD-RATE-REQUEST
+                                UART-INPUT-REQUEST
 import .test
 
 MESSAGE ::= "hello-console"
+CONSOLE-BAUD-RATE ::= 115_200
+TEST-BAUD-RATE ::= 57_600
+BAUD-RATE-TOLERANCE ::= 20
+
+expect-baud expected/int actual/int:
+  // UART dividers are rounded slightly differently across chips.
+  expect (expected - BAUD-RATE-TOLERANCE) <= actual <= (expected + BAUD-RATE-TOLERANCE)
+
+expect-input port/uart.Port expected/string:
+  data := #[]
+  with-timeout --ms=30_000:
+    while data.size < expected.size:
+      data += port.in.read
+  expect-equals expected data.to-string
+
+request-input port/uart.Port payload/string:
+  port.out.write "$UART-INPUT-REQUEST$payload\n" --flush
+  expect-input port "$payload\n"
+
+change-baud-rate port/uart.Port rate/int:
+  port.out.write "$UART-BAUD-RATE-REQUEST$rate\n" --flush
+  // The tester sends this at the old rate and switches after it has drained.
+  expect-input port "$UART-BAUD-RATE-ACK\n"
+  port.baud-rate = rate
+  expect-baud rate port.baud-rate
+  // Give the tester time to update its host port before transmitting at the
+  // new rate.
+  sleep --ms=200
 
 main:
   run-test: test
 
 test:
   port := uart.Port.console
+  expect-baud CONSOLE-BAUD-RATE port.baud-rate
   // Opening the console port a second time must fail.
   expect-throw "ALREADY_IN_USE": uart.Port.console
-  print "$UART-INPUT-REQUEST$MESSAGE"
-  data := #[]
-  with-timeout --ms=30_000:
-    while data.size < MESSAGE.size + 1:
-      data += port.in.read
-  expect-equals "$MESSAGE\n" data.to-string
+  request-input port MESSAGE
   // Writing to the console port must work as well. The bytes simply show up
   // in the test output, interleaved with the system's own output.
-  port.out.write "console-write-works\n"
+  port.out.write "console-write-works\n" --flush
+
+  change-baud-rate port TEST-BAUD-RATE
+  request-input port MESSAGE
+  change-baud-rate port CONSOLE-BAUD-RATE
+
   port.close
   // After closing, the console port can be opened again.
   port2 := uart.Port.console

--- a/tests/hw/esp32/uart-console-test.toit
+++ b/tests/hw/esp32/uart-console-test.toit
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+/**
+Tests reading input from the console UART.
+
+The esp-tester watches the test's output for the $UART-INPUT-REQUEST marker
+  and writes the payload back over the same serial connection.
+
+No wiring is needed: the test uses the USB-serial connection that also
+  carries the console output.
+*/
+
+import expect show *
+import uart
+
+import ..esp-tester.shared show UART-INPUT-REQUEST
+import .test
+
+MESSAGE ::= "hello-console"
+
+main:
+  run-test: test
+
+test:
+  port := uart.Port.console
+  // Opening the console port a second time must fail.
+  expect-throw "ALREADY_IN_USE": uart.Port.console
+  print "$UART-INPUT-REQUEST$MESSAGE"
+  data := #[]
+  with-timeout --ms=30_000:
+    while data.size < MESSAGE.size + 1:
+      data += port.in.read
+  expect-equals "$MESSAGE\n" data.to-string
+  // Writing to the console port must work as well. The bytes simply show up
+  // in the test output, interleaved with the system's own output.
+  port.out.write "console-write-works\n"
+  port.close
+  // After closing, the console port can be opened again.
+  port2 := uart.Port.console
+  port2.close


### PR DESCRIPTION
The console UART (the one used for logging and `print`) can now be opened with `uart.Port.console`. It keeps the configuration it was given during boot; only the UART driver is installed, so RX becomes interrupt driven while system output continues through the polling VFS path (the same coexistence ESP-IDF's own console REPL uses). A dedicated one-slot pool guards single-open and returns the port on close, and in-flight TX is drained before the driver install since that resets the TX FIFO.

This is the base for driving hardware tests over the serial connection instead of WiFi (following the EC618 tester's serial mini-jag model): the esp-tester now answers `UART-INPUT-REQUEST: <payload>` marker lines by writing the payload back over the serial port, and the new `uart-console-test` exercises the full loop (open, double-open rejection, host echo received byte-exact, driver-side write, close/reopen).

Verified on the hardware rig: `uart-console-test.toit-esp32` passes, and the remaining 15 uart hardware tests pass on the new firmware (the teardown change touches every UART's close path). Skipped on esp32s3: that rig's board1 is connected through USB-Serial-JTAG, so host writes don't reach UART0 RX — S3 input needs a usb_serial_jtag equivalent as a follow-up.