### PR TITLE
Cache the parsed registry descriptions.

### DIFF
--- a/tests/pkg/assets/completion/gold/25-corrupt-descriptions.gold
+++ b/tests/pkg/assets/completion/gold/25-corrupt-descriptions.gold
@@ -1,0 +1,13 @@
+// A corrupt parsed-descriptions cache falls back to parsing the registry content.
+==================
+[complete, install, ]
+localhost:<[*PORT*]>/pkg/pkg1	git-package 1
+localhost:<[*PORT*]>/pkg/pkg2	git-package 2
+localhost:<[*PORT*]>/pkg/pkg3	git-package 3
+localhost:<[*PORT*]>/pkg/pkg4	git-package 4
+pkg1	git-package 1
+pkg2	git-package 2
+pkg3	git-package 3
+pkg4	git-package 4
+:4
+Exit Code: 0

--- a/tests/pkg/completion-gold-test.toit
+++ b/tests/pkg/completion-gold-test.toit
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the tests/LICENSE file.
 
+import expect show *
+
 import .gold-tester
 
 main args:
@@ -27,6 +29,17 @@ test tester/GoldTester:
     ["// Option names are completed as well."],
     ["complete", "install", "--"],
   ]
+
+  // The sync eagerly cached the parsed descriptions.
+  expect (tester.has-descriptions-cache "git-pkgs")
+
+  tester.corrupt-descriptions-cache "git-pkgs"
+  tester.gold "25-corrupt-descriptions" [
+    ["// A corrupt parsed-descriptions cache falls back to parsing the registry content."],
+    ["complete", "install", ""],
+  ]
+  // The fallback repaired the cached parsed descriptions.
+  expect (tester.has-descriptions-cache "git-pkgs")
 
   tester.gold "30-describe" [
     ["complete", "describe", ""],

--- a/tests/pkg/gold-tester.toit
+++ b/tests/pkg/gold-tester.toit
@@ -118,6 +118,20 @@ class GoldTester:
       return cache.get-file-path key: unreachable
     unreachable
 
+  has-descriptions-cache name/string -> bool:
+    with-registry-cache_ name: | cache/Cache key/string |
+      return cache.contains (descriptions-key_ key)
+    unreachable
+
+  corrupt-descriptions-cache name/string -> none:
+    with-registry-cache_ name: | cache/Cache key/string |
+      path := cache.get-file-path (descriptions-key_ key): unreachable
+      file.write-contents --path=path "garbage"
+
+  // Mirrors the key computation of GitRegistry.
+  static descriptions-key_ ar-key/string -> string:
+    return (ar-key.trim --right ".ar") + ".descriptions"
+
   with-registry-cache_ name/string [block]:
     cache := Cache --app-name="toit_pkg" --path=registry-cache-dir_
     registry-data := cache.get "registries.yaml": unreachable

--- a/tools/pkg/commands/completions_.toit
+++ b/tools/pkg/commands/completions_.toit
@@ -17,6 +17,7 @@ import cli
 import encoding.yaml
 import fs
 import host.file
+import log
 
 import ..project.specification
 import ..registry
@@ -56,8 +57,13 @@ Runs the $block and returns its result.
 
 Returns an empty list if the block throws or takes longer than
   $COMPLETION-TIMEOUT-MS_.
+
+Silences the default logger: the completion candidates are printed to
+  stdout, so any library logging (like the file-lock logging of the
+  cache) would corrupt the completion output.
 */
 guarded_ [block] -> List:
+  log.set-default (log.default.with-level log.FATAL-LEVEL)
   result := []
   catch:
     with-timeout --ms=COMPLETION-TIMEOUT-MS_:

--- a/tools/pkg/registry/git.toit
+++ b/tools/pkg/registry/git.toit
@@ -94,27 +94,36 @@ class GitRegistry extends Registry:
     registry-content := content  // Also sets $loaded-hash_.
     key := descriptions-cache-key_
     hash := loaded-hash_
-    if cache.contains key:
-      catch:  // On any error fall back to parsing the description files.
-        encoded := cache.get key: unreachable
-        decoded := ubjson.decode encoded
-        if decoded[DESCRIPTIONS-VERSION-KEY_] == DESCRIPTIONS-FORMAT-VERSION_ and
-            decoded[DESCRIPTIONS-HASH-KEY_] == hash:
-          descriptions := decoded[DESCRIPTIONS-KEY_].map: | description-content/Map |
-            Description description-content --path="<cached>" --ui=ui_
-          return DescriptionUrlCache.filled descriptions
+    cached/DescriptionUrlCache? := null
+    cache-error := catch:
+      encoded := cache.get key: | store/FileStore |
+        descriptions := DescriptionUrlCache registry-content --ui=ui_
+        store.save (encode-description-cache_ descriptions hash)
+      decoded := ubjson.decode encoded
+      if decoded[DESCRIPTIONS-VERSION-KEY_] == DESCRIPTIONS-FORMAT-VERSION_ and
+          decoded[DESCRIPTIONS-HASH-KEY_] == hash:
+        descriptions := decoded[DESCRIPTIONS-KEY_].map: | description-content/Map |
+          Description description-content --path="<cached>" --ui=ui_
+        cached = DescriptionUrlCache.filled descriptions
+    if cache-error:
+      ui_.emit --verbose "Unable to read parsed descriptions cache for registry $name: $cache-error"
+    if cached: return cached
 
     result := DescriptionUrlCache registry-content --ui=ui_
-    encoded := ubjson.encode {
+    cache-error = catch:
+      cache.update key: | old-path/string store/FileStore |
+        store.save (encode-description-cache_ result hash)
+    if cache-error:
+      ui_.emit --verbose "Unable to update parsed descriptions cache for registry $name: $cache-error"
+    return result
+
+  encode-description-cache_ descriptions/DescriptionUrlCache hash/string -> ByteArray:
+    return ubjson.encode {
       DESCRIPTIONS-VERSION-KEY_: DESCRIPTIONS-FORMAT-VERSION_,
       DESCRIPTIONS-HASH-KEY_: hash,
-      DESCRIPTIONS-KEY_: result.all-descriptions.map: | description/Description |
+      DESCRIPTIONS-KEY_: descriptions.all-descriptions.map: | description/Description |
           description.to-json,
     }
-    catch:  // Not being able to write the cache is not fatal.
-      cache.update key: | old-path/string store/FileStore |
-        store.save encoded
-    return result
 
   update-cache_ -> none
       --clear-cache/bool

--- a/tools/pkg/registry/git.toit
+++ b/tools/pkg/registry/git.toit
@@ -14,6 +14,7 @@
 // directory of this repository.
 
 import ar show ArReader ArWriter ArFile
+import encoding.ubjson
 import encoding.yaml
 import fs
 import host.file
@@ -26,6 +27,8 @@ import ..git
 import ..file-system-view
 import ..utils
 import ..semantic-version
+import .cache
+import .description
 import .registry
 
 class GitRegistry extends Registry:
@@ -34,9 +37,16 @@ class GitRegistry extends Registry:
   static PACK-FILE_ ::= "pack"
   static HASH-FILE_ ::= "hash"
 
+  static DESCRIPTIONS-FORMAT-VERSION_ ::= 1
+  static DESCRIPTIONS-VERSION-KEY_ ::= "version"
+  static DESCRIPTIONS-HASH-KEY_ ::= "hash"
+  static DESCRIPTIONS-KEY_ ::= "descriptions"
+
   url/string
   ref-hash/string
   content_/FileSystemView? := null
+  // The hash of the pack that $content_ was loaded from.
+  loaded-hash_/string? := null
 
   // The ref-hash is currently only used for testing.
   constructor name .url .ref-hash=HEAD-INDICATOR_ --ui/cli.Ui:
@@ -57,9 +67,54 @@ class GitRegistry extends Registry:
   cache-key_ -> string:
     return "registry/git/$(url).ar"
 
+  // The cache entry with the parsed descriptions of the pack at $cache-key_.
+  // Kept as a separate entry (instead of inside the AR file), so that older
+  // versions of the pkg tool are not affected by it.
+  descriptions-cache-key_ -> string:
+    return "registry/git/$(url).descriptions"
+
   content -> FileSystemView:
     if not content_: content_ = load_
     return content_
+
+  description-cache -> DescriptionUrlCache:
+    if not description-cache_:
+      description-cache_ = load-description-cache_
+    return description-cache_
+
+  /**
+  Loads the parsed descriptions of this registry.
+
+  Uses the cached parsed form if it matches the current registry
+    content. Otherwise parses all description files from the $content
+    and updates the cached parsed form, so that later invocations (in
+    particular shell completions) don't need to parse them again.
+  */
+  load-description-cache_ -> DescriptionUrlCache:
+    registry-content := content  // Also sets $loaded-hash_.
+    key := descriptions-cache-key_
+    hash := loaded-hash_
+    if cache.contains key:
+      catch:  // On any error fall back to parsing the description files.
+        encoded := cache.get key: unreachable
+        decoded := ubjson.decode encoded
+        if decoded[DESCRIPTIONS-VERSION-KEY_] == DESCRIPTIONS-FORMAT-VERSION_ and
+            decoded[DESCRIPTIONS-HASH-KEY_] == hash:
+          descriptions := decoded[DESCRIPTIONS-KEY_].map: | description-content/Map |
+            Description description-content --path="<cached>" --ui=ui_
+          return DescriptionUrlCache.filled descriptions
+
+    result := DescriptionUrlCache registry-content --ui=ui_
+    encoded := ubjson.encode {
+      DESCRIPTIONS-VERSION-KEY_: DESCRIPTIONS-FORMAT-VERSION_,
+      DESCRIPTIONS-HASH-KEY_: hash,
+      DESCRIPTIONS-KEY_: result.all-descriptions.map: | description/Description |
+          description.to-json,
+    }
+    catch:  // Not being able to write the cache is not fatal.
+      cache.update key: | old-path/string store/FileStore |
+        store.save encoded
+    return result
 
   update-cache_ -> none
       --clear-cache/bool
@@ -149,12 +204,17 @@ class GitRegistry extends Registry:
 
       if entry.name == PACK-FILE_:
         pack := Pack entry.contents hash
+        loaded-hash_ = hash
         return pack.content
 
       ui_.emit --warning "Ignoring unknown cache entry for registry $name at $key: $entry.name"
 
   sync --clear-cache/bool -> FileSystemView:
     content_ = load_ --sync --clear-cache=clear-cache
+    // Parse the descriptions eagerly: this updates the cached parsed form if
+    // necessary, so that later invocations don't need to parse all
+    // description files again.
+    description-cache_ = load-description-cache_
     return content_
 
   to-map -> Map:


### PR DESCRIPTION
Loading a git registry parsed every description file out of the git pack on every invocation (roughly 1.3 seconds for the toit registry). This parses them when the registry is synced instead, and stores the parsed form in a separate cache entry (ubjson, keyed by the pack hash).

Loads fall back to parsing the pack when the entry is missing, stale or corrupt, and repair the entry in passing, so caches written by older versions keep working and get upgraded on first use. Older versions of the pkg tool ignore the new entry entirely.

With this, `pkg install <tab>` on the real registry goes from ~1.3s to ~0.2s.

Also silences the default logger during completions: the cache's file-lock logging would otherwise end up in the completion candidates.

Builds on the shell-completion work from #3090.
