### PR TITLE
uart: keep filling after partial writes

### DIFF
--- a/lib/uart.toit
+++ b/lib/uart.toit
@@ -392,11 +392,14 @@ class UartWriter extends io.Writer:
   write data/io.Data from/int=0 to/int=data.byte-size --break-length/int=0 --flush/bool=false -> int:
     data-size := to - from
     while not is-closed_:
-      from += try-write data from to --break-length=break-length
+      written := try-write data from to --break-length=break-length
+      from += written
       if from >= to:
         if flush: this.flush
         return data-size
-      wait-for-more-room_
+      // Retry immediately while the port accepts bytes. It may have another
+      // staging buffer available even though the first write was partial.
+      if written == 0: wait-for-more-room_
     assert: is-closed_
     throw "WRITER_CLOSED"
 


### PR DESCRIPTION
PR #3060 fixed write --flush so it flushes once after the complete write instead of flushing each partial chunk. One part of the EC618 gap-free UART fix was still missing: UartWriter.write slept after every partial write, preventing drivers with a second TX staging buffer from receiving the next chunk before the current chunk completed.

Retry immediately while try-write makes progress, and wait for the TX event only after a zero-progress write.

Validation:
- SDK build passed.
- tests/uart-test.toit compiles successfully.
- The runtime PTY test hits its existing 40-second timeout both with this change and on unmodified master in this environment.
- The originating EC618 gap-free TX hardware test passes through 921600 baud.