### PR TITLE
pkg: use UI logger for package cache lock

### DIFF
--- a/tests/pkg/filelock-logger-test.toit
+++ b/tests/pkg/filelock-logger-test.toit
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import cli show Ui
+import cli.test show TestUi
+import expect show *
+import host.directory
+import system
+
+import ...tools.pkg.project
+import ...tools.pkg.semantic-version
+
+main:
+  tmp-dir := directory.mkdtemp "/tmp/filelock-logger-test-"
+  try:
+    ui := TestUi --level=Ui.DEBUG-LEVEL
+    config := ProjectConfiguration
+        --project-root=tmp-dir
+        --cwd=directory.cwd
+        --sdk-version=(SemanticVersion.parse system.vm-sdk-version)
+        --ui=ui
+    project := Project config --empty-lock-file --ui=ui
+    project.save
+
+    project.clean
+
+    expect (ui.stdout.contains "[filelock] : acquired lock")
+    expect (ui.stdout.contains "[filelock] : released lock")
+  finally:
+    directory.rmdir --force --recursive tmp-dir

--- a/tools/pkg/project/project.toit
+++ b/tools/pkg/project/project.toit
@@ -117,7 +117,7 @@ class Project:
   with-package-cache-lock_ [block]:
     assert: not owns-fs-lock_
     ensure-packages-cache-dir_
-    fs-lock.with-lock packages-fs-lock-path_:
+    fs-lock.with-lock packages-fs-lock-path_ --logger=ui_.logger:
       owns-fs-lock_ = true
       try:
         token := Object


### PR DESCRIPTION
Pass the project UI logger to the filesystem lock so lock messages respect the pkg command verbosity level. Adds a focused regression test for debug-level lock acquisition and release messages. Tested with Toit analysis, the focused regression test, and tests/pkg/package-test.toit.