### PR TITLE
Speed up mini-jag serial control

### DIFF
--- a/tests/hw/esp-tester/mini-jag.toit
+++ b/tests/hw/esp-tester/mini-jag.toit
@@ -40,16 +40,30 @@ with-control-channel [block]:
   if control == "serial":
     port := uart.Port.console --large-buffers
     try:
+      switch-console-baud-rate port
       print MINI-JAG-LISTENING
       block.call port.in
     finally:
       port.close
   else if control == "network":
-    with-client: | socket/tcp.Socket |
-      block.call socket.in
+    port := uart.Port.console --large-buffers
+    try:
+      switch-console-baud-rate port
+      with-client: | socket/tcp.Socket |
+        block.call socket.in
+    finally:
+      port.close
   else:
     throw "Unknown control channel: $control"
 
+switch-console-baud-rate port/uart.Port:
+  // The host switches after flushing its acknowledgement. Give it a short
+  // scheduling margin before transmitting at the new rate.
+  print "$UART-BAUD-RATE-REQUEST$CONTROL-BAUD-RATE"
+  ack := port.in.read-string UART-BAUD-RATE-ACK.size + 1
+  if ack != "$UART-BAUD-RATE-ACK\n": throw "BAUD-RATE-ACK MISMATCH"
+  sleep --ms=UART-BAUD-RATE-SWITCH-DELAY-MS
+  port.baud-rate = CONTROL-BAUD-RATE
 with-client [block]:
   network/net.Client? := null
   for i := 0; i < NETWORK-RETRIES; i++:

--- a/tests/hw/esp-tester/shared.toit
+++ b/tests/hw/esp-tester/shared.toit
@@ -14,9 +14,17 @@ UART-INPUT-REQUEST ::= "UART-INPUT-REQUEST: "
 // acknowledge at the current rate and then switch the serial connection.
 UART-BAUD-RATE-REQUEST ::= "UART-BAUD-RATE-REQUEST: "
 UART-BAUD-RATE-ACK ::= "UART-BAUD-RATE-ACK"
+// Gives the host time to apply the requested rate before the device transmits
+// at that rate.
+UART-BAUD-RATE-SWITCH-DELAY-MS ::= 10
 
 // The asset that selects mini-jag's control transport.
 CONTROL-ASSET ::= "control"
+
+// mini-jag starts at the default console rate, synchronizes with the host,
+// then switches to this rate while receiving a test container.
+CONSOLE-BAUD-RATE ::= 115_200
+CONTROL-BAUD-RATE ::= 921_600
 
 // The device pulls the container image in chunks of this size, requesting
 // each one with $CHUNK-REQUEST. The serial transport has no flow control,

--- a/tests/hw/esp-tester/tester.toit
+++ b/tests/hw/esp-tester/tester.toit
@@ -234,7 +234,7 @@ class TestDevice:
   socket_/tcp.Socket? := null
 
   constructor --.name --.toit-exe --port-path/string --.ui --.already-installed --.use-network:
-    port = uart.HostPort port-path --baud-rate=115200
+    port = uart.HostPort port-path --baud-rate=CONSOLE-BAUD-RATE
     tmp-dir = directory.mkdtemp "/tmp/esp-tester"
     read-task = task --background::
       try:
@@ -287,9 +287,6 @@ class TestDevice:
             rate := int.parse collected-output[rate-start..request-end].trim
             uart-baud-rate-handled_ = request-end
             port.out.write "$UART-BAUD-RATE-ACK\n" --flush
-            // Some USB-UART adapters report an empty host queue before their
-            // hardware has emitted the final bytes at the old rate.
-            sleep --ms=100
             port.baud-rate = rate
           // Grant one send permit per chunk request.
           while true:
@@ -410,6 +407,10 @@ class TestDevice:
     summer := crc.Crc32
     summer.add image
     out.write summer.get
+    // Send the header before waiting for the device to request image data.
+    // This is necessary for the serial transport, whose writer may buffer the
+    // small header at high baud rates.
+    out.flush
     // The device pulls the image chunk by chunk: it prints a request
     // whenever it is ready for more. Never send more than requested, since
     // the serial transport has no flow control.
@@ -425,7 +426,15 @@ class TestDevice:
 
   run-test -> none:
     log "Running test on device $name"
-    control-out.write RUN-TEST
+    if use-network:
+      socket_.out.write RUN-TEST
+    else:
+      port.out.write RUN-TEST --flush
+    // mini-jag receives the run signal at $CONTROL-BAUD-RATE, then resets
+    // before starting the test. The next container starts its console at the
+    // default rate, which lets console tests negotiate their own rate.
+    sleep --ms=100
+    port.baud-rate = CONSOLE-BAUD-RATE
 
 setup-tester invocation/cli.Invocation:
   if os.env.get "TOIT_SKIP_SETUP": return

--- a/tests/hw/esp32/uart-console-test.toit
+++ b/tests/hw/esp32/uart-console-test.toit
@@ -17,6 +17,7 @@ import uart
 
 import ..esp-tester.shared show UART-BAUD-RATE-ACK
                                 UART-BAUD-RATE-REQUEST
+                                UART-BAUD-RATE-SWITCH-DELAY-MS
                                 UART-INPUT-REQUEST
 import .test
 
@@ -46,9 +47,8 @@ change-baud-rate port/uart.Port rate/int:
   expect-input port "$UART-BAUD-RATE-ACK\n"
   port.baud-rate = rate
   expect-baud rate port.baud-rate
-  // Give the tester time to update its host port before transmitting at the
-  // new rate.
-  sleep --ms=200
+  // Give the tester a short scheduling margin to apply the new rate.
+  sleep --ms=UART-BAUD-RATE-SWITCH-DELAY-MS
 
 main:
   run-test: test


### PR DESCRIPTION
Mini-jag negotiates 921600 baud with the host before receiving a test container, then the host returns to the default console baud before the test starts. This keeps console tests free to change their own rate.

Tested: `ctest --verbose --test-dir build/hw -C esp32 -R "uart-console-test\\.toit-esp32$"`.