### PR TITLE
Fix package directory permissions

### DIFF
--- a/tests/pkg/git-pkg2-gold-test.toit
+++ b/tests/pkg/git-pkg2-gold-test.toit
@@ -61,3 +61,13 @@ test tester/GoldTester:
   else:
     write-bits := 0b010_010_010
     expect-equals 0 (mode & write-bits)
+
+  [foo-path, fs.join foo-path "src"].do: | directory-path/string |
+    stat = file.stat directory-path
+    expect-not-null stat
+    mode = stat[file.ST-MODE]
+    if system.platform == system.PLATFORM-WINDOWS:
+      expect-equals 0 (mode & file.WINDOWS-FILE-ATTRIBUTE-READONLY)
+    else:
+      write-bits := 0b010_010_010
+      expect-equals write-bits (mode & write-bits)

--- a/tools/pkg/project/project.toit
+++ b/tools/pkg/project/project.toit
@@ -438,7 +438,7 @@ class Project:
           --hash=hash
           --fs-lock-token=fs-lock-token
       file.write-contents hash --path=repo-toit-git-path
-      make-read-only_ --recursive cached-repository-dir
+      make-files-read-only_ cached-repository-dir
     (cached-contents.get url --init=:{:})[version-string] = relative-dir
     write-cached-repository-contents_ cached-contents --fs-lock-token=fs-lock-token
     return cached-contents

--- a/tools/pkg/utils.toit
+++ b/tools/pkg/utils.toit
@@ -116,34 +116,40 @@ escape-path path/string -> string:
   return escaped-path
 
 /**
-Makes the given $path read-only.
-
-If $recursive is true and $path is a directory, makes all files and
-  directories within $path read-only as well.
+Makes files below the given $path read-only and directories writable.
 */
-make-read-only_ --recursive/bool path/string -> none:
-  if not recursive or file.is-file path:
+make-files-read-only_ path/string -> none:
+  if file.is-directory path:
+    stream := directory.DirectoryStream path
+    while child := stream.next:
+      make-files-read-only_ (fs.join path child)
+
     stat := file.stat path
-    if not stat:
-      return
+    if not stat: return
     mode := stat[file.ST-MODE]
     if system.platform == system.PLATFORM-WINDOWS:
       read-only-bit := file.WINDOWS-FILE-ATTRIBUTE-READONLY
-      if (mode & read-only-bit) != 0: return
-      file.chmod path (mode | read-only-bit)
+      if (mode & read-only-bit) == 0: return
+      file.chmod path (mode & ~read-only-bit)
       return
     write-bits := 0b010_010_010
-    if (mode & write-bits) == 0: return
-    file.chmod path (mode & ~write-bits)
+    if (mode & write-bits) == write-bits: return
+    file.chmod path (mode | write-bits)
     return
 
-  // If it's not a directory, just ignore it.
-  if not file.is-directory path: return
-
-  stream := directory.DirectoryStream path
-  while child := stream.next:
-    make-read-only_ --recursive (fs.join path child)
-  make-read-only_ --no-recursive path
+  // If it's not a file, just ignore it.
+  if not file.is-file path: return
+  stat := file.stat path
+  if not stat: return
+  mode := stat[file.ST-MODE]
+  if system.platform == system.PLATFORM-WINDOWS:
+    read-only-bit := file.WINDOWS-FILE-ATTRIBUTE-READONLY
+    if (mode & read-only-bit) != 0: return
+    file.chmod path (mode | read-only-bit)
+    return
+  write-bits := 0b010_010_010
+  if (mode & write-bits) == 0: return
+  file.chmod path (mode & ~write-bits)
 
 is-valid-toit-identifier str/string -> bool:
   last-was-dash := false
@@ -163,4 +169,3 @@ is-valid-toit-identifier str/string -> bool:
       continue
     return false
   return true
-


### PR DESCRIPTION
- keep cached package files read-only
- make cached package directories writable on Unix
- clear the read-only attribute from cached package directories on Windows
- cover root and nested package directory permissions
