### PR TITLE
Recover from ESP tester UART data loss

### DIFF
--- a/src/resources/uart_esp32.cc
+++ b/src/resources/uart_esp32.cc
@@ -649,7 +649,7 @@ PRIMITIVE(read) {
   ARGS(UartResource, uart)
 
 #ifdef CONFIG_TOIT_REPORT_UART_DATA_LOSS
-  if (uart->has_dropped_data() && uart->has_reported_dropped_data()) {
+  if (uart->has_dropped_data() && !uart->has_reported_dropped_data()) {
     uart->set_has_reported_dropped_data();
     ESP_LOGE("uart", "dropped data; no further warnings will be issued");
   }

--- a/src/resources/uart_esp32.cc
+++ b/src/resources/uart_esp32.cc
@@ -68,6 +68,10 @@ const int kErrorState = 1 << 1;
 const int kWriteState = 1 << 2;
 const int kBreakState = 1 << 3;
 
+const int kHighSpeedBaudRate = 460800;
+const uint8 kHighSpeedRxFullThreshold = 35;
+const uint8 kLowSpeedRxFullThreshold = 105;
+
 static ResourcePool<uart_port_t, kInvalidUartPort> uart_ports(
 #ifndef CONFIG_ESP_CONSOLE_UART
     UART_NUM_0,
@@ -373,7 +377,7 @@ PRIMITIVE(create) {
   if ((options & 8) != 0) {
     // High speed setting.
     interrupt_flags |= HI;
-    full_interrupt_threshold = 35;
+    full_interrupt_threshold = kHighSpeedRxFullThreshold;
     tx_buffer_size = 2048;
     rx_buffer_size = 2048;
   } else if ((options & 4) != 0) {
@@ -385,7 +389,7 @@ PRIMITIVE(create) {
   } else {
     // Low speed setting.
     interrupt_flags |= LO;
-    full_interrupt_threshold = 105;
+    full_interrupt_threshold = kLowSpeedRxFullThreshold;
     tx_buffer_size = 256;
     rx_buffer_size = 768;
   }
@@ -594,6 +598,17 @@ PRIMITIVE(get_baud_rate) {
 
 PRIMITIVE(set_baud_rate) {
   ARGS(UartResource, uart, uint32, baud_rate)
+#ifdef CONFIG_ESP_CONSOLE_UART
+  if (uart->port() == CONFIG_ESP_CONSOLE_UART_NUM) {
+    // The console has no speed option. Leave enough room in the hardware FIFO
+    // for interrupt latency when flash operations temporarily stall the CPU.
+    uint8 threshold = baud_rate >= kHighSpeedBaudRate
+        ? kHighSpeedRxFullThreshold
+        : kLowSpeedRxFullThreshold;
+    esp_err_t err = uart_set_rx_full_threshold(uart->port(), threshold);
+    if (err != ESP_OK) return Primitive::os_error(err, process);
+  }
+#endif
   esp_err_t err = uart_set_baudrate(uart->port(), baud_rate);
   if (err != ESP_OK) return Primitive::os_error(err, process);
   return process->null_object();

--- a/tests/hw/esp-tester/mini-jag.toit
+++ b/tests/hw/esp-tester/mini-jag.toit
@@ -42,7 +42,15 @@ with-control-channel [block]:
     try:
       switch-console-baud-rate port
       print MINI-JAG-LISTENING
-      block.call port.in
+      error-monitor := task --background::
+        previous-errors := port.errors
+        while port.errors == previous-errors:
+          sleep --ms=1
+        print "$UART-TRANSFER-ERROR: $(port.errors)"
+      try:
+        block.call port.in
+      finally:
+        error-monitor.cancel
     finally:
       port.close
   else if control == "network":
@@ -114,9 +122,8 @@ install-new-test reader/io.Reader:
   written-size := 0
   requested := 0
   while written-size < size:
-    // Keep up to two chunks in flight: the next one streams in while the
-    // current one is written to flash.
-    while requested < size and requested - written-size < 2 * CHUNK-SIZE:
+    // Keep only one requested chunk outstanding while writing to flash.
+    while requested < size and requested - written-size < CHUNK-SIZE:
       print CHUNK-REQUEST
       requested += min CHUNK-SIZE (size - requested)
     chunk-size := min CHUNK-SIZE (size - written-size)

--- a/tests/hw/esp-tester/mini-jag.toit
+++ b/tests/hw/esp-tester/mini-jag.toit
@@ -122,8 +122,8 @@ install-new-test reader/io.Reader:
   written-size := 0
   requested := 0
   while written-size < size:
-    // Keep only one requested chunk outstanding while writing to flash.
-    while requested < size and requested - written-size < CHUNK-SIZE:
+    // Keep two requested chunks outstanding while writing to flash.
+    while requested < size and requested - written-size < 2 * CHUNK-SIZE:
       print CHUNK-REQUEST
       requested += min CHUNK-SIZE (size - requested)
     chunk-size := min CHUNK-SIZE (size - written-size)

--- a/tests/hw/esp-tester/shared.toit
+++ b/tests/hw/esp-tester/shared.toit
@@ -33,7 +33,8 @@ CONTROL-BAUD-RATE ::= 921_600
 // The device pulls the container image in chunks of this size, requesting
 // each one with $CHUNK-REQUEST. The serial transport has no flow control,
 // so the device must never have more data in flight than it asked for. It
-// keeps only one requested chunk outstanding so flash writes can't cause the
-// receive buffer to overflow.
-CHUNK-SIZE ::= 1920
+// keeps two requested chunks outstanding so the wire stays busy while a chunk
+// is written to flash. Together they use half of the 4096-byte receive buffer,
+// leaving the other half as headroom.
+CHUNK-SIZE ::= 1024
 CHUNK-REQUEST ::= "READY FOR CHUNK"

--- a/tests/hw/esp-tester/shared.toit
+++ b/tests/hw/esp-tester/shared.toit
@@ -14,9 +14,13 @@ UART-INPUT-REQUEST ::= "UART-INPUT-REQUEST: "
 // acknowledge at the current rate and then switch the serial connection.
 UART-BAUD-RATE-REQUEST ::= "UART-BAUD-RATE-REQUEST: "
 UART-BAUD-RATE-ACK ::= "UART-BAUD-RATE-ACK"
+UART-TRANSFER-ERROR ::= "UART TRANSFER ERROR"
 // Gives the host time to apply the requested rate before the device transmits
 // at that rate.
 UART-BAUD-RATE-SWITCH-DELAY-MS ::= 10
+// Gives USB-UART adapters time to transmit at the old rate before the host
+// changes rate. This must be shorter than $UART-BAUD-RATE-SWITCH-DELAY-MS.
+UART-HOST-BAUD-RATE-SWITCH-DELAY-MS ::= 5
 
 // The asset that selects mini-jag's control transport.
 CONTROL-ASSET ::= "control"
@@ -29,8 +33,7 @@ CONTROL-BAUD-RATE ::= 921_600
 // The device pulls the container image in chunks of this size, requesting
 // each one with $CHUNK-REQUEST. The serial transport has no flow control,
 // so the device must never have more data in flight than it asked for. It
-// keeps up to two chunks in flight (so the wire stays busy while a chunk
-// is written to flash), which means both must fit in the console UART's
-// 4096-byte receive buffer.
+// keeps only one requested chunk outstanding so flash writes can't cause the
+// receive buffer to overflow.
 CHUNK-SIZE ::= 1920
 CHUNK-REQUEST ::= "READY FOR CHUNK"

--- a/tests/hw/esp-tester/tester.toit
+++ b/tests/hw/esp-tester/tester.toit
@@ -133,68 +133,79 @@ run-test invocation/cli.Invocation:
   already-installed := false
   attempts := flaky ? 3 : 1
   attempts.repeat: | attempt/int |
-    print "\n"
-    log "Attempt $(attempt + 1) of $attempts"
-    // If we didn't manage to install the test something went wrong.
-    catch --unwind=(: not already-installed or attempt == attempts - 1):
-      board1 := TestDevice
-          --name="board1"
-          --port-path=port-board1
-          --ui=ui
-          --toit-exe=toit-exe
-          --already-installed=already-installed
-          --use-network=use-network
-      board2/TestDevice? := null
+    transfer-attempt := 0
+    while true:
+      print "\n"
+      log "Attempt $(attempt + 1) of $attempts"
+      error := catch:
+        board1 := TestDevice
+            --name="board1"
+            --port-path=port-board1
+            --ui=ui
+            --toit-exe=toit-exe
+            --already-installed=already-installed
+            --use-network=use-network
+        board2/TestDevice? := null
 
-      try:
-        board1-ready := monitor.Latch
+        try:
+          board1-ready := monitor.Latch
 
-        task::
-          image/ByteArray? := null
-          Task.group [
-            :: board1.connect,
-            :: image = board1.compile-test test-path,
-          ]
-          board1.install-test image arg
-          log "Board1 ready"
-          board1-ready.set true
+          task::
+            error := catch:
+              image/ByteArray? := null
+              Task.group [
+                :: board1.connect,
+                :: image = board1.compile-test test-path,
+              ]
+              board1.install-test image arg
+              log "Board1 ready"
+              board1-ready.set true
+            if error: board1-ready.set --exception error
 
-        if port-board2:
-          board2 = TestDevice
-              --name="board2"
-              --port-path=port-board2
-              --ui=ui
-              --toit-exe=toit-exe
-              --already-installed=already-installed
-              --use-network=use-network
-          image2/ByteArray? := null
-          Task.group [
-            :: board2.connect,
-            :: image2 = board2.compile-test test2-path,
-          ]
-          board2.install-test image2 arg
-          log "Board2 ready"
+          if port-board2:
+            board2 = TestDevice
+                --name="board2"
+                --port-path=port-board2
+                --ui=ui
+                --toit-exe=toit-exe
+                --already-installed=already-installed
+                --use-network=use-network
+            image2/ByteArray? := null
+            Task.group [
+              :: board2.connect,
+              :: image2 = board2.compile-test test2-path,
+            ]
+            board2.install-test image2 arg
+            log "Board2 ready"
 
-        board1-ready.get
-        already-installed = true
+          board1-ready.get
+          already-installed = true
 
-        board1.run-test
-        if port-board2:
-          board1.running-container.get
-          board2.run-test
+          board1.run-test
+          if port-board2:
+            board1.running-container.get
+            board2.run-test
 
-        ui.emit --verbose "Waiting for all tests to be done."
-        board1.all-tests-done.get
-        log "Board1 done"
-        if board2:
-          board2.all-tests-done.get
-          log "Board2 done"
+          ui.emit --verbose "Waiting for all tests to be done."
+          board1.all-tests-done.get
+          log "Board1 done"
+          if board2:
+            board2.all-tests-done.get
+            log "Board2 done"
 
-        // Success. No need to run another attempt.
-        return
-      finally:
-        board1.close
-        if board2: board2.close
+          // Success. No need to run another attempt.
+          return
+        finally:
+          board1.close
+          if board2: board2.close
+
+      if error == UART-TRANSFER-ERROR and transfer-attempt == 0:
+        transfer-attempt++
+        log "Retrying after a UART transfer error"
+        continue
+      // If we didn't manage to install the test something went wrong.
+      if not already-installed or attempt == attempts - 1: throw error
+      break
 
 class TestDevice:
   static SNAPSHOT-NAME ::= "test.snap"
@@ -256,6 +267,9 @@ class TestDevice:
           collected-output += data-str
           if collected-output.contains "\n$MINI-JAG-LISTENING": set-latch_ ready-latch
           if collected-output.contains "\n$ALL-TESTS-DONE": set-latch_ all-tests-done
+          if collected-output.contains "\n$UART-TRANSFER-ERROR":
+            if not installed-container.has-value:
+              installed-container.set --exception UART-TRANSFER-ERROR
           if collected-output.contains "\n$INSTALLED-CONTAINER": set-latch_ installed-container
           if collected-output.contains "\n$RUNNING-CONTAINER": set-latch_ running-container
           // Serve UART input requests: when the device prints a marker line,
@@ -287,6 +301,9 @@ class TestDevice:
             rate := int.parse collected-output[rate-start..request-end].trim
             uart-baud-rate-handled_ = request-end
             port.out.write "$UART-BAUD-RATE-ACK\n" --flush
+            // Some USB-UART adapters report an empty host queue before their
+            // hardware has emitted the final bytes at the old rate.
+            sleep --ms=UART-HOST-BAUD-RATE-SWITCH-DELAY-MS
             port.baud-rate = rate
           // Grant one send permit per chunk request.
           while true:
@@ -308,10 +325,13 @@ class TestDevice:
             all-tests-done.set --exception "Error detected"
 
       finally:
-        read-task = null
         if port:
           port.close
           port = null
+        // Publish termination only after the port has been released.  A UART
+        // transfer retry may otherwise race with this cleanup when reopening
+        // the same host serial device.
+        read-task = null
 
   set-latch_ latch/monitor.Latch:
     if latch.has-value: return
@@ -320,6 +340,11 @@ class TestDevice:
   close:
     if read-task:
       read-task.cancel
+      // Task.cancel is asynchronous.  Wait for the reader's finally block to
+      // close the serial device before a retry constructs another TestDevice.
+      critical-do --no-respect-deadline:
+        with-timeout --ms=1_000:
+          while read-task: sleep --ms=1
     if file.is-directory tmp-dir:
       directory.rmdir --recursive tmp-dir
     disconnect-network
@@ -433,7 +458,7 @@ class TestDevice:
     // mini-jag receives the run signal at $CONTROL-BAUD-RATE, then resets
     // before starting the test. The next container starts its console at the
     // default rate, which lets console tests negotiate their own rate.
-    sleep --ms=100
+    sleep --ms=UART-HOST-BAUD-RATE-SWITCH-DELAY-MS
     port.baud-rate = CONSOLE-BAUD-RATE
 
 setup-tester invocation/cli.Invocation:


### PR DESCRIPTION
## Summary

- detect ESP32 console UART receive errors during mini-jag container transfers
- abort and retry a failed transfer once after fully releasing the host serial ports
- keep two 1024-byte chunks in flight at 921600 baud so flash writes do not leave gaps
- lower the high-speed console UART RX-full threshold from the ESP-IDF default of 120 bytes to 35 bytes, matching regular high-speed Toit UARTs
- fix the inverted ESP32 one-time dropped-data warning condition

## Root cause

The failing transfers produce `UART_FIFO_OVF`, not `UART_BUFFER_FULL`. The ESP32 UART FIFO holds 128 bytes, while the console kept ESP-IDF's default 120-byte RX-full interrupt threshold. At 921600 baud that leaves only about 87 microseconds for the ISR to run. Flash activity can exceed that latency, even though the UART ISR and its direct receive path are in IRAM. A 35-byte threshold leaves about 1 millisecond of FIFO headroom.

## Testing

- reproduced `UART_FIFO_OVF` with two 1024-byte chunks and the default threshold
- verified that moving from a shared to a dedicated interrupt did not reliably fix it
- `uart-console-test.toit-esp32s3` repeated 10 times: passed
- `spi-board1.toit-esp32s3` with setup and both boards reflashed: passed
- `spi-board1.toit-esp32s3` repeated 10 times without reflashing: passed
- `uart-error-test.toit-esp32s3`: passed, including dropped-data warning
- ESP32-S3 firmware build: passed
- Toit analyze with warnings as errors: passed
- `git diff --check`: passed
