### PR TITLE
Prepare source builds for Homebrew

### DIFF
--- a/.github/workflows/tar-ball.yml
+++ b/.github/workflows/tar-ball.yml
@@ -98,7 +98,7 @@ jobs:
           file: ${{ steps.create-tarball.outputs.archive_path }}
           asset_name: ${{ steps.create-tarball.outputs.archive_name }}
           tag: ${{ github.event.release.tag_name }}
-          overwrite: true
+          overwrite: false
 
     outputs:
       version: ${{ steps.create-tarball.outputs.version }}
@@ -226,7 +226,7 @@ jobs:
           file: "*.deb"
           file_glob: true
           tag: ${{ github.event.release.tag_name }}
-          overwrite: true
+          overwrite: false
 
   AUR:
     name: Update AUR package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ cmake_minimum_required(VERSION 3.20.0...4.0.1)
 
 project(toit)
 
+include(CTest)
 include(tools/toit.cmake)
 
 set(CMAKE_COLOR_DIAGNOSTICS ON)
@@ -197,8 +198,9 @@ if (NOT "${TOIT_SYSTEM_NAME}" MATCHES "esp32")
     FILES_MATCHING PATTERN "*"
   )
 
-  enable_testing()
-  add_subdirectory(tests)
+  if (BUILD_TESTING)
+    add_subdirectory(tests)
+  endif()
 
   add_subdirectory(examples)
   # External Toit packages and projects.

--- a/toolchains/host.cmake
+++ b/toolchains/host.cmake
@@ -22,5 +22,3 @@ set(CMAKE_CXX_FLAGS_DEBUG "-O1 -ggdb3 -fdiagnostics-color $ENV{LOCAL_CXXFLAGS}" 
 set(CMAKE_C_FLAGS_RELEASE "-Os $ENV{LOCAL_CFLAGS}" CACHE STRING "c Release flags")
 set(CMAKE_CXX_FLAGS_RELEASE "-Os $ENV{LOCAL_CXXFLAGS}" CACHE STRING "c++ Release flags")
 set(CMAKE_EXE_LINKER_FLAGS_RELEASE "$ENV{LOCAL_LDFLAGS}" CACHE STRING "Linker flags for release builds")
-
-enable_testing()

--- a/toolchains/host32.cmake
+++ b/toolchains/host32.cmake
@@ -33,5 +33,3 @@ set(CMAKE_SYSTEM_LIBRARY_PATH /lib32 /usr/lib32 CACHE PATH "The system library p
 set(FIND_LIBRARY_USE_LIB64_PATHS OFF CACHE BOOL "Use lib64 paths for finding libraries")
 
 set(GOARCH "386" CACHE STRING "The GOARCH for the toolchain")
-
-enable_testing()

--- a/toolchains/riscv64.cmake
+++ b/toolchains/riscv64.cmake
@@ -53,5 +53,3 @@ set(FIND_LIBRARY_USE_LIB64_PATHS OFF)
 
 set(GOOS "linux" CACHE STRING "The GOOS for the toolchain")
 set(GOARCH "riscv64" CACHE STRING "The GOARCH for the toolchain")
-
-enable_testing()


### PR DESCRIPTION
## Summary
- prevent release packaging jobs from overwriting existing tarball and Debian assets
- use the standard CMake BUILD_TESTING switch
- keep tests enabled by default, while allowing package managers to configure with -DBUILD_TESTING=OFF

## Verification
- configured, built, and installed the full SDK locally with BUILD_TESTING=OFF
- ran the installed toit binary and verified `toit info sdk` resolves the installed prefix

This supports the companion formula in toitlang/homebrew-toit#15.