### PR TITLE
Separate compile-time and runtime selector offsets

### DIFF
--- a/src/compiler/backend.cc
+++ b/src/compiler/backend.cc
@@ -163,7 +163,8 @@ static List<uint16> encode_typecheck_interface_list(const List<ir::Class*> inter
   return result;
 }
 
-Program* Backend::emit(ir::Program* ir_program) {
+Program* Backend::emit(ir::Program* ir_program,
+                       MethodSelectorOffsets* method_selector_offsets) {
   // Compile everything.
 
   auto classes = ir_program->classes();
@@ -178,7 +179,7 @@ Program* Backend::emit(ir::Program* ir_program) {
   });
 
   auto program = _new Program(null, 0);
-  ProgramBuilder program_builder(program);
+  ProgramBuilder program_builder(program, method_selector_offsets);
   program_builder.create_dispatch_table(dispatch_table.length());
 
   // Find the classes and interfaces for which we have a shortcut when doing as-checks.

--- a/src/compiler/backend.cc
+++ b/src/compiler/backend.cc
@@ -154,7 +154,7 @@ static List<uint16> encode_typecheck_interface_list(const List<ir::Class*> inter
     auto call_selector = interfaces[i]->typecheck_selector();
     ASSERT(call_selector.is_valid());
     Selector<PlainShape> selector(call_selector.name(), call_selector.shape().to_plain_shape());
-    int16 offset = dispatch_table.dispatch_offset_for(selector);
+    int offset = dispatch_table.dispatch_offset_for(selector);
     // We would have already replaced the interface call with a literal false if there
     //  wasn't any class implementing the interface.
     ASSERT(offset >= 0);

--- a/src/compiler/backend.h
+++ b/src/compiler/backend.h
@@ -17,6 +17,7 @@
 
 #include "byte_gen.h"
 #include "ir.h"
+#include "method_selector_offsets.h"
 #include "sources.h"
 
 namespace toit {
@@ -36,7 +37,7 @@ class Backend {
       , source_mapper_(source_mapper) {}
 
   // As a side-effect fills in the source-mapper.
-  Program* emit(ir::Program* program);
+  Program* emit(ir::Program* program, MethodSelectorOffsets* method_selector_offsets);
 
  private:
   SourceManager* source_manager_;

--- a/src/compiler/compiler.cc
+++ b/src/compiler/compiler.cc
@@ -1941,7 +1941,8 @@ toit::Program* construct_program(ir::Program* ir_program,
                                  SourceMapper* source_mapper,
                                  TypeOracle* oracle,
                                  TypeDatabase* propagated_types,
-                                 bool run_optimizations) {
+                                 bool run_optimizations,
+                                 MethodSelectorOffsets* method_selector_offsets) {
   source_mapper->register_selectors(ir_program->classes());
 
   drop_abstract_methods(ir_program);
@@ -1976,7 +1977,7 @@ toit::Program* construct_program(ir::Program* ir_program,
   assign_global_ids(ir_program->globals());
 
   Backend backend(source_mapper->manager(), source_mapper);
-  auto program = backend.emit(ir_program);
+  auto program = backend.emit(ir_program, method_selector_offsets);
   return program;
 }
 
@@ -2176,7 +2177,13 @@ Pipeline::Result Pipeline::run(List<const char*> source_paths, bool propagate) {
   SourceMapper unoptimized_source_mapper(source_manager());
   auto source_mapper = &unoptimized_source_mapper;
   TypeOracle oracle(source_mapper);
-  auto program = construct_program(ir_program, source_mapper, &oracle, null, run_optimizations);
+  MethodSelectorOffsets method_selector_offsets;
+  auto program = construct_program(ir_program,
+                                   source_mapper,
+                                   &oracle,
+                                   null,
+                                   run_optimizations,
+                                   &method_selector_offsets);
 
   SourceMapper optimized_source_mapper(source_manager());
   if (run_optimizations && configuration_.optimization_level >= 2) {
@@ -2191,14 +2198,20 @@ Pipeline::Result Pipeline::run(List<const char*> source_paths, bool propagate) {
     // to behave the same way for the output to be correct.
     check_types_and_deprecations(ir_program, quiet);
     ASSERT(!diagnostics()->encountered_error());
-    TypeDatabase* types = TypeDatabase::compute(program);
+    TypeDatabase* types = TypeDatabase::compute(program, &method_selector_offsets);
     source_mapper = &optimized_source_mapper;
-    program = construct_program(ir_program, source_mapper, &oracle, types, true);
+    method_selector_offsets.clear();
+    program = construct_program(ir_program,
+                                source_mapper,
+                                &oracle,
+                                types,
+                                true,
+                                &method_selector_offsets);
     delete types;
   }
 
   if (propagate) {
-    TypeDatabase* types = TypeDatabase::compute(program);
+    TypeDatabase* types = TypeDatabase::compute(program, &method_selector_offsets);
     auto json = types->as_json();
     printf("%s", json.c_str());
     delete types;

--- a/src/compiler/method_selector_offsets.h
+++ b/src/compiler/method_selector_offsets.h
@@ -1,0 +1,30 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#pragma once
+
+#include "../top.h"
+
+#include <unordered_map>
+
+namespace toit {
+namespace compiler {
+
+// Maps runtime method IDs to the full selector offsets used during compilation.
+// Negative offsets encode class-check indexes and are not needed at runtime.
+using MethodSelectorOffsets = std::unordered_map<int, int32>;
+
+} // namespace toit::compiler
+} // namespace toit

--- a/src/compiler/method_selector_offsets.h
+++ b/src/compiler/method_selector_offsets.h
@@ -24,7 +24,7 @@ namespace compiler {
 
 // Maps runtime method IDs to the full selector offsets used during compilation.
 // Negative offsets encode class-check indexes and are not needed at runtime.
-using MethodSelectorOffsets = std::unordered_map<int, int32>;
+using MethodSelectorOffsets = std::unordered_map<int, word>;
 
 } // namespace toit::compiler
 } // namespace toit

--- a/src/compiler/program_builder.cc
+++ b/src/compiler/program_builder.cc
@@ -26,9 +26,12 @@
 namespace toit {
 namespace compiler {
 
-ProgramBuilder::ProgramBuilder(Program* program)
+ProgramBuilder::ProgramBuilder(
+    Program* program,
+    MethodSelectorOffsets* method_selector_offsets)
     : program_heap_(program)
-    , program_(program) {}
+    , program_(program)
+    , method_selector_offsets_(method_selector_offsets) {}
 
 void ProgramBuilder::dup() {
   push(top());
@@ -135,7 +138,7 @@ void ProgramBuilder::push_lazy_initializer_id(int id) {
   push(lazy_initializer);
 }
 
-int ProgramBuilder::create_method(word selector_offset,
+int ProgramBuilder::create_method(int32 selector_offset,
                                   bool is_field_accessor,
                                   int arity,
                                   List<uint8> bytecodes,
@@ -143,6 +146,7 @@ int ProgramBuilder::create_method(word selector_offset,
   int method_id;
   auto method = Method::invalid();
   allocate_method(bytecodes.length(), max_height, &method_id, &method);
+  (*method_selector_offsets_)[method_id] = selector_offset;
   method._initialize_method(selector_offset, is_field_accessor, arity, bytecodes, max_height);
   global_max_stack_height_ = Utils::max(global_max_stack_height_, max_height);
   return method_id;

--- a/src/compiler/program_builder.cc
+++ b/src/compiler/program_builder.cc
@@ -138,7 +138,7 @@ void ProgramBuilder::push_lazy_initializer_id(int id) {
   push(lazy_initializer);
 }
 
-int ProgramBuilder::create_method(int32 selector_offset,
+int ProgramBuilder::create_method(word selector_offset,
                                   bool is_field_accessor,
                                   int arity,
                                   List<uint8> bytecodes,

--- a/src/compiler/program_builder.h
+++ b/src/compiler/program_builder.h
@@ -24,6 +24,7 @@
 
 #include "list.h"
 #include "map.h"
+#include "method_selector_offsets.h"
 #include "symbol.h"
 #include "util.h"
 
@@ -34,7 +35,7 @@ namespace compiler {
 // A simple stack avoids the need for handles to survive garbage collection.
 class ProgramBuilder {
  public:
-  explicit ProgramBuilder(Program* program);
+  ProgramBuilder(Program* program, MethodSelectorOffsets* method_selector_offsets);
 
   Program* program() const { return program_; }
   int size() const { return stack_.size(); }
@@ -64,7 +65,7 @@ class ProgramBuilder {
 
   // Removes the top 'len' elements and replaces them with an array containing those elements.
   void create_class(int id, const char* name, int instance_size, bool is_runtime);
-  int create_method(word selector_offset, bool is_field_stub, int arity, List<uint8> codes, int max_height);
+  int create_method(int32 selector_offset, bool is_field_stub, int arity, List<uint8> codes, int max_height);
   int create_lambda(int captured_count, int arity, List<uint8> codes, int max_height);
   int create_block(int arity, List<uint8> codes, int max_height);
   int absolute_bci_for(int method_id);
@@ -119,6 +120,7 @@ class ProgramBuilder {
 
   ProgramHeap program_heap_;
   Program* program_;
+  MethodSelectorOffsets* method_selector_offsets_;
 
   UnorderedMap<std::string, String*> symbols_;
   std::vector<Object*> stack_;

--- a/src/compiler/program_builder.h
+++ b/src/compiler/program_builder.h
@@ -65,7 +65,7 @@ class ProgramBuilder {
 
   // Removes the top 'len' elements and replaces them with an array containing those elements.
   void create_class(int id, const char* name, int instance_size, bool is_runtime);
-  int create_method(int32 selector_offset, bool is_field_stub, int arity, List<uint8> codes, int max_height);
+  int create_method(word selector_offset, bool is_field_stub, int arity, List<uint8> codes, int max_height);
   int create_lambda(int captured_count, int arity, List<uint8> codes, int max_height);
   int create_block(int arity, List<uint8> codes, int max_height);
   int absolute_bci_for(int method_id);

--- a/src/compiler/propagation/type_database.cc
+++ b/src/compiler/propagation/type_database.cc
@@ -120,13 +120,15 @@ void TypeDatabase::check_method_entry(Method method, Object** sp) const {
   }
 }
 
-TypeDatabase* TypeDatabase::compute(Program* program) {
+TypeDatabase* TypeDatabase::compute(
+    Program* program,
+    const MethodSelectorOffsets* method_selector_offsets) {
   auto probe = cache_.find(program);
   if (probe != cache_.end()) return probe->second;
 
   AllowThrowingNew allow;
   uint64 start = OS::get_monotonic_time();
-  TypePropagator propagator(program);
+  TypePropagator propagator(program, method_selector_offsets);
   TypeDatabase* types = new TypeDatabase(program, propagator.words_per_type());
   propagator.propagate(types);
   uint64 elapsed = OS::get_monotonic_time() - start;

--- a/src/compiler/propagation/type_database.h
+++ b/src/compiler/propagation/type_database.h
@@ -18,6 +18,7 @@
 #include "type_set.h"
 
 #include "../ir.h"
+#include "../method_selector_offsets.h"
 #include "../../objects.h"
 
 #include <unordered_map>
@@ -35,7 +36,9 @@ class SourceMapper;
 
 class TypeDatabase {
  public:
-  static TypeDatabase* compute(Program* program);
+  static TypeDatabase* compute(
+      Program* program,
+      const MethodSelectorOffsets* method_selector_offsets = null);
   ~TypeDatabase();
 
   const std::vector<Method> methods() const;

--- a/src/compiler/propagation/type_propagator.cc
+++ b/src/compiler/propagation/type_propagator.cc
@@ -67,10 +67,21 @@ namespace compiler {
 
 static const int INITIALIZER_ID_INDEX = 0;
 
-TypePropagator::TypePropagator(Program* program)
+TypePropagator::TypePropagator(
+    Program* program,
+    const MethodSelectorOffsets* method_selector_offsets)
     : program_(program)
+    , method_selector_offsets_(method_selector_offsets)
     , words_per_type_(TypeSet::words_per_type(program)) {
   TypePrimitive::set_up();
+}
+
+int TypePropagator::selector_offset(Method method) const {
+  if (method_selector_offsets_ == null) return method.selector_offset();
+  int method_id = program_->absolute_bci_from_bcp(method.header_bcp());
+  auto probe = method_selector_offsets_->find(method_id);
+  ASSERT(probe != method_selector_offsets_->end());
+  return probe->second;
 }
 
 void TypePropagator::ensure_entry_main() {
@@ -473,7 +484,7 @@ void TypePropagator::call_static(MethodTemplate* caller,
   std::vector<ConcreteType> arguments;
   stack->push_empty();
 
-  word offset = target.selector_offset();
+  word offset = selector_offset(target);
   bool handle_as_static = (offset == -1);
   if (offset >= 0) {
     ASSERT(arity > 0);
@@ -559,7 +570,7 @@ void TypePropagator::call_virtual(MethodTemplate* caller,
     Method target = (entry_id >= 0)
         ? Method(program->bytecodes, entry_id)
         : Method::invalid();
-    if (!target.is_valid() || target.selector_offset() != offset) {
+    if (!target.is_valid() || selector_offset(target) != offset) {
       // There is a chance we'll get a lookup error thrown here.
       ensure_lookup_failure();
       scope->throw_maybe();
@@ -1588,7 +1599,8 @@ void MethodTemplate::propagate() {
   // concrete receiver type; not any.
   bool is_normal = method_.is_normal_method() ||
       method_.is_field_accessor();
-  bool is_virtual = is_normal && method_.selector_offset() >= 0;
+  int selector_offset = propagator_->selector_offset(method_);
+  bool is_virtual = is_normal && selector_offset >= 0;
   if (is_virtual) {
     ASSERT(arguments_.size() >= 1);
     ConcreteType receiver = argument(0);
@@ -1600,7 +1612,7 @@ void MethodTemplate::propagate() {
   // does a manual null check on both arguments, which means that null never
   // flows into the method body. We have to simulate that.
   Program* program = propagator_->program();
-  if (method_.selector_offset() == program->invoke_bytecode_offset(INVOKE_EQ)) {
+  if (selector_offset == program->invoke_bytecode_offset(INVOKE_EQ)) {
     ConcreteType null_type = ConcreteType(Smi::value(program->null_class_id()));
     ASSERT(!argument(0).is_any());  // Receiver is always a single type.
     bool receiver_is_null = argument(0).matches(null_type);

--- a/src/compiler/propagation/type_propagator.cc
+++ b/src/compiler/propagation/type_propagator.cc
@@ -76,7 +76,7 @@ TypePropagator::TypePropagator(
   TypePrimitive::set_up();
 }
 
-int TypePropagator::selector_offset(Method method) const {
+word TypePropagator::selector_offset(Method method) const {
   if (method_selector_offsets_ == null ||
       (!method.is_normal_method() && !method.is_field_accessor())) {
     return method.selector_offset();
@@ -1602,7 +1602,7 @@ void MethodTemplate::propagate() {
   // concrete receiver type; not any.
   bool is_normal = method_.is_normal_method() ||
       method_.is_field_accessor();
-  int selector_offset = propagator_->selector_offset(method_);
+  word selector_offset = propagator_->selector_offset(method_);
   bool is_virtual = is_normal && selector_offset >= 0;
   if (is_virtual) {
     ASSERT(arguments_.size() >= 1);

--- a/src/compiler/propagation/type_propagator.cc
+++ b/src/compiler/propagation/type_propagator.cc
@@ -77,7 +77,10 @@ TypePropagator::TypePropagator(
 }
 
 int TypePropagator::selector_offset(Method method) const {
-  if (method_selector_offsets_ == null) return method.selector_offset();
+  if (method_selector_offsets_ == null ||
+      (!method.is_normal_method() && !method.is_field_accessor())) {
+    return method.selector_offset();
+  }
   int method_id = program_->absolute_bci_from_bcp(method.header_bcp());
   auto probe = method_selector_offsets_->find(method_id);
   ASSERT(probe != method_selector_offsets_->end());

--- a/src/compiler/propagation/type_propagator.h
+++ b/src/compiler/propagation/type_propagator.h
@@ -23,6 +23,7 @@
 #include "worklist.h"
 
 #include "../map.h"
+#include "../method_selector_offsets.h"
 #include "../set.h"
 
 #include "../../top.h"
@@ -44,10 +45,13 @@ class TypeDatabase;
 
 class TypePropagator {
  public:
-  explicit TypePropagator(Program* program);
+  TypePropagator(
+      Program* program,
+      const MethodSelectorOffsets* method_selector_offsets = null);
 
   Program* program() const { return program_; }
   int words_per_type() const { return words_per_type_; }
+  int selector_offset(Method method) const;
 
   void propagate(TypeDatabase* types);
 
@@ -80,6 +84,7 @@ class TypePropagator {
 
  private:
   Program* const program_;
+  const MethodSelectorOffsets* method_selector_offsets_;
   int words_per_type_;
 
 #define HAS_ENTRY_POINT(name, symbol, arity) \

--- a/src/compiler/propagation/type_propagator.h
+++ b/src/compiler/propagation/type_propagator.h
@@ -51,7 +51,7 @@ class TypePropagator {
 
   Program* program() const { return program_; }
   int words_per_type() const { return words_per_type_; }
-  int selector_offset(Method method) const;
+  word selector_offset(Method method) const;
 
   void propagate(TypeDatabase* types);
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -833,6 +833,9 @@ class Method {
   }
 
   void _initialize_method(int selector_offset, bool is_field_accessor, int arity, List<uint8> bytecodes, int max_height) {
+    // The runtime only needs to distinguish non-virtual methods. The compiler
+    // keeps the exact negative selector offset in separate metadata.
+    if (selector_offset < 0) selector_offset = -1;
     Kind kind = is_field_accessor ? FIELD_ACCESSOR : METHOD;
     _initialize(kind, selector_offset, arity, bytecodes, max_height);
     ASSERT(this->arity() == arity);
@@ -875,13 +878,46 @@ class Method {
     return result;
   }
 
+  uint16 _uint16_at(word offset) const {
+    uint16 result;
+    memcpy(&result, &bytes_[offset], 2);
+    return result;
+  }
+
   void _set_int16_at(word offset, int value) {
     int16 source = value;
     memcpy(&bytes_[offset], &source, 2);
   }
 
-  int value_() const { return _int16_at(VALUE_OFFSET); }
-  void _set_value(int value) { _set_int16_at(VALUE_OFFSET, value); }
+  void _set_uint16_at(word offset, int value) {
+    uint16 source = value;
+    memcpy(&bytes_[offset], &source, 2);
+  }
+
+  int value_() const {
+#ifndef TOIT_FREERTOS
+    if (is_normal_method() || is_field_accessor()) {
+      uint16 value = _uint16_at(VALUE_OFFSET);
+      return value == UINT16_MAX ? -1 : value;
+    }
+#endif
+    return _int16_at(VALUE_OFFSET);
+  }
+
+  void _set_value(int value) {
+    bool is_method = is_normal_method() || is_field_accessor();
+#ifndef TOIT_FREERTOS
+    if (is_method) {
+      if (value >= UINT16_MAX) FATAL("Selector offset too big: %d", value);
+      _set_uint16_at(VALUE_OFFSET, value < 0 ? UINT16_MAX : value);
+      return;
+    }
+#endif
+    if (value < INT16_MIN || value > INT16_MAX) {
+      FATAL("Method value out of range: %d", value);
+    }
+    _set_int16_at(VALUE_OFFSET, value);
+  }
 
   void _set_arity(int arity) {
     ASSERT(arity <= 0xFF);

--- a/src/objects.h
+++ b/src/objects.h
@@ -808,7 +808,10 @@ class Method {
 
   int arity() const { return bytes_[ARITY_OFFSET]; }
   int captured_count() const { return value_(); }
-  int selector_offset() const { return value_(); }
+  int selector_offset() const {
+    int value = value_();
+    return value == UINT16_MAX ? -1 : value;
+  }
   uint8* entry() const { return &bytes_[ENTRY_OFFSET]; }
   int max_height() const { return (bytes_[KIND_HEIGHT_OFFSET] >> KIND_BITS) * 4; }
 
@@ -832,14 +835,16 @@ class Method {
     ASSERT(this->captured_count() == captured_count);
   }
 
-  void _initialize_method(int selector_offset, bool is_field_accessor, int arity, List<uint8> bytecodes, int max_height) {
-    // The runtime only needs to distinguish non-virtual methods. The compiler
-    // keeps the exact negative selector offset in separate metadata.
-    if (selector_offset < 0) selector_offset = -1;
+  void _initialize_method(word selector_offset, bool is_field_accessor, int arity, List<uint8> bytecodes, int max_height) {
+    // The runtime uses UINT16_MAX to identify non-virtual methods. The compiler
+    // keeps their exact negative selector offsets in separate metadata.
+    if (selector_offset >= UINT16_MAX) {
+      FATAL("Selector offset too big: %" PRIdPTR, selector_offset);
+    }
+    if (selector_offset < 0) selector_offset = UINT16_MAX;
     Kind kind = is_field_accessor ? FIELD_ACCESSOR : METHOD;
     _initialize(kind, selector_offset, arity, bytecodes, max_height);
     ASSERT(this->arity() == arity);
-    ASSERT(this->selector_offset() == selector_offset);
   }
 
   friend class compiler::ProgramBuilder;
@@ -883,16 +888,13 @@ class Method {
     memcpy(&bytes_[offset], &source, 2);
   }
 
-  int value_() const {
-    uint16 value = _uint16_at(VALUE_OFFSET);
-    return value == UINT16_MAX ? -1 : value;
-  }
+  int value_() const { return _uint16_at(VALUE_OFFSET); }
 
   void _set_value(int value) {
-    if (value < -1 || value >= UINT16_MAX) {
+    if (value < 0 || value > UINT16_MAX) {
       FATAL("Method value out of range: %d", value);
     }
-    _set_uint16_at(VALUE_OFFSET, value < 0 ? UINT16_MAX : value);
+    _set_uint16_at(VALUE_OFFSET, value);
   }
 
   void _set_arity(int arity) {
@@ -911,8 +913,6 @@ class Method {
     int encoded_height = scaled_height << KIND_BITS;
     bytes_[KIND_HEIGHT_OFFSET] = kind | encoded_height;
   }
-  void _set_captured_count(int value) { _set_value(value); }
-  void _set_selector_offset(int value) { _set_value(value); }
   void _set_bytecodes(List<uint8> bytecodes) {
     if (bytecodes.length() > 0) {
       memcpy(&bytes_[ENTRY_OFFSET], bytecodes.data(), bytecodes.length());

--- a/src/objects.h
+++ b/src/objects.h
@@ -872,21 +872,10 @@ class Method {
     ASSERT(this->value_() == value);
   }
 
-  int _int16_at(word offset) const {
-    int16 result;
-    memcpy(&result, &bytes_[offset], 2);
-    return result;
-  }
-
   uint16 _uint16_at(word offset) const {
     uint16 result;
     memcpy(&result, &bytes_[offset], 2);
     return result;
-  }
-
-  void _set_int16_at(word offset, int value) {
-    int16 source = value;
-    memcpy(&bytes_[offset], &source, 2);
   }
 
   void _set_uint16_at(word offset, int value) {
@@ -895,28 +884,15 @@ class Method {
   }
 
   int value_() const {
-#ifndef TOIT_FREERTOS
-    if (is_normal_method() || is_field_accessor()) {
-      uint16 value = _uint16_at(VALUE_OFFSET);
-      return value == UINT16_MAX ? -1 : value;
-    }
-#endif
-    return _int16_at(VALUE_OFFSET);
+    uint16 value = _uint16_at(VALUE_OFFSET);
+    return value == UINT16_MAX ? -1 : value;
   }
 
   void _set_value(int value) {
-    bool is_method = is_normal_method() || is_field_accessor();
-#ifndef TOIT_FREERTOS
-    if (is_method) {
-      if (value >= UINT16_MAX) FATAL("Selector offset too big: %d", value);
-      _set_uint16_at(VALUE_OFFSET, value < 0 ? UINT16_MAX : value);
-      return;
-    }
-#endif
-    if (value < INT16_MIN || value > INT16_MAX) {
+    if (value < -1 || value >= UINT16_MAX) {
       FATAL("Method value out of range: %d", value);
     }
-    _set_int16_at(VALUE_OFFSET, value);
+    _set_uint16_at(VALUE_OFFSET, value < 0 ? UINT16_MAX : value);
   }
 
   void _set_arity(int arity) {

--- a/tools/image.toit
+++ b/tools/image.toit
@@ -1177,6 +1177,11 @@ build-image snapshot/snapshot.Program word-size/int -> Image
     --system-uuid/Uuid
     --snapshot-uuid/Uuid
     --id/Uuid:
+  if word-size == 4:
+    snapshot.methods.do: | method |
+      if (method.is-normal-method or method.is-field-accessor) and
+          method.selector-offset > 0x7fff:
+        throw "Selector offset $(method.selector-offset) does not fit in a 32-bit image"
   ToitProgram.init-constants snapshot
   image := Image snapshot word-size --id=id
   program := ToitProgram snapshot

--- a/tools/image.toit
+++ b/tools/image.toit
@@ -1177,11 +1177,6 @@ build-image snapshot/snapshot.Program word-size/int -> Image
     --system-uuid/Uuid
     --snapshot-uuid/Uuid
     --id/Uuid:
-  if word-size == 4:
-    snapshot.methods.do: | method |
-      if (method.is-normal-method or method.is-field-accessor) and
-          method.selector-offset > 0x7fff:
-        throw "Selector offset $(method.selector-offset) does not fit in a 32-bit image"
   ToitProgram.init-constants snapshot
   image := Image snapshot word-size --id=id
   program := ToitProgram snapshot

--- a/tools/snapshot.toit
+++ b/tools/snapshot.toit
@@ -512,6 +512,9 @@ class ToitMethod:
     kind       = kind-height & 0x3
     max-height = (kind-height >> 2) * 4
     value = LITTLE-ENDIAN.int16 all-bytecodes at
+    if kind == METHOD or kind == FIELD-ACCESSOR:
+      encoded-value := LITTLE-ENDIAN.uint16 all-bytecodes at
+      value = encoded-value == 0xffff ? -1 : encoded-value
     at += 2
     assert: at - id == HEADER-SIZE
     bytecodes = all-bytecodes.copy at (at + bytecode-size)

--- a/tools/snapshot.toit
+++ b/tools/snapshot.toit
@@ -511,10 +511,8 @@ class ToitMethod:
     kind-height := all-bytecodes[at++]
     kind       = kind-height & 0x3
     max-height = (kind-height >> 2) * 4
-    value = LITTLE-ENDIAN.int16 all-bytecodes at
-    if kind == METHOD or kind == FIELD-ACCESSOR:
-      encoded-value := LITTLE-ENDIAN.uint16 all-bytecodes at
-      value = encoded-value == 0xffff ? -1 : encoded-value
+    encoded-value := LITTLE-ENDIAN.uint16 all-bytecodes at
+    value = encoded-value == 0xffff ? -1 : encoded-value
     at += 2
     assert: at - id == HEADER-SIZE
     bytecodes = all-bytecodes.copy at (at + bytecode-size)

--- a/tools/snapshot.toit
+++ b/tools/snapshot.toit
@@ -511,8 +511,7 @@ class ToitMethod:
     kind-height := all-bytecodes[at++]
     kind       = kind-height & 0x3
     max-height = (kind-height >> 2) * 4
-    encoded-value := LITTLE-ENDIAN.uint16 all-bytecodes at
-    value = encoded-value == 0xffff ? -1 : encoded-value
+    value = LITTLE-ENDIAN.uint16 all-bytecodes at
     at += 2
     assert: at - id == HEADER-SIZE
     bytecodes = all-bytecodes.copy at (at + bytecode-size)
@@ -526,7 +525,7 @@ class ToitMethod:
     return HEADER-SIZE + bytecodes.size
 
   selector-offset:
-    return value
+    return value == 0xffff ? -1 : value
 
   absolute-entry-bci -> int:
     return id + HEADER-SIZE


### PR DESCRIPTION
## Summary

- retain full signed 32-bit selector offsets in compiler-only metadata
- encode runtime method selectors as uint16 values, with 0xffff as the non-virtual sentinel
- preserve the exact negative class-check indexes used by type propagation without emitting them
- reject selector offsets above the signed 16-bit limit when creating a 32-bit image
- keep embedded method headers at four bytes

This fixes the nightly O0 SDK build failure where selector offset 33109 was decoded as a negative value and caused LOOKUP_FAILED.

## Testing

- TOIT_OPTIMIZATION_OVERRIDE=0 TOIT_ASSERT_OVERRIDE=0 make HOST=host-O0 TOOLCHAIN=host sdk
- ctest --test-dir build/host-O0 --output-on-failure -R ^tests/toit/snapshot-to-image-test.toit|tests/types-test.toit|tests/types2-test.toit|tests/types3-test.toit$
- verified snapshot-to-image -m64 accepts selector 33109
- verified snapshot-to-image -m32 rejects selector 33109 and accepts a normal embedded-sized snapshot