### PR TITLE
pkg: add licenses command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,19 @@ if (NOT "${TOIT_SYSTEM_NAME}" MATCHES "esp32")
   add_subdirectory(tools)
   add_subdirectory(system/extensions/host)
 
+  # Keep the license information shipped with the SDK identical to the
+  # information used by the Debian package.
+  configure_file(
+    "${CMAKE_SOURCE_DIR}/debian/copyright"
+    "${CMAKE_BINARY_DIR}/sdk/lib/toit/SDK-LICENSES"
+    COPYONLY
+  )
+  install(
+    FILES "${CMAKE_SOURCE_DIR}/debian/copyright"
+    DESTINATION lib/toit
+    RENAME SDK-LICENSES
+  )
+
   # Copy the lib folder to /usr/lib/toit/lib (recursively).
   install(DIRECTORY ${CMAKE_SOURCE_DIR}/lib/
     DESTINATION lib/toit/lib

--- a/debian/install
+++ b/debian/install
@@ -1,4 +1,5 @@
 usr/bin/toit usr/bin
 usr/lib/toit/bin usr/lib/toit
+usr/lib/toit/SDK-LICENSES usr/lib/toit
 usr/lib/toit/lib usr/lib/toit
 usr/lib/toit/vessels usr/lib/toit

--- a/tests/pkg/assets/completion/gold/50-misc.gold
+++ b/tests/pkg/assets/completion/gold/50-misc.gold
@@ -5,6 +5,7 @@ clean	Removes unnecessary packages.
 describe	Generates a description of the given package.
 init	Initializes the current directory as the root of the project.
 install	Installs a package in the current project, or downloads all dependencies.
+licenses	Collects the top-level LICENSE files of a project and its dependencies.
 list	Lists all packages.
 registry	Manages registries.
 search	Searches for the given name in all packages.

--- a/tests/pkg/assets/licenses/GIT-SERVE-PKGS/missing/v1.0.0/package.yaml
+++ b/tests/pkg/assets/licenses/GIT-SERVE-PKGS/missing/v1.0.0/package.yaml
@@ -1,0 +1,2 @@
+name: missing
+description: Package without a license file.

--- a/tests/pkg/assets/licenses/GIT-SERVE-PKGS/nested/v1.0.0/LICENSE
+++ b/tests/pkg/assets/licenses/GIT-SERVE-PKGS/nested/v1.0.0/LICENSE
@@ -1,0 +1,1 @@
+Nested remote package license.

--- a/tests/pkg/assets/licenses/GIT-SERVE-PKGS/nested/v1.0.0/package.yaml
+++ b/tests/pkg/assets/licenses/GIT-SERVE-PKGS/nested/v1.0.0/package.yaml
@@ -1,0 +1,2 @@
+name: nested
+description: Nested remote package.

--- a/tests/pkg/assets/licenses/GIT-SERVE-PKGS/remote/v1.0.0/LICENSE
+++ b/tests/pkg/assets/licenses/GIT-SERVE-PKGS/remote/v1.0.0/LICENSE
@@ -1,0 +1,1 @@
+Remote package license.

--- a/tests/pkg/assets/licenses/GIT-SERVE-PKGS/remote/v1.0.0/package.yaml
+++ b/tests/pkg/assets/licenses/GIT-SERVE-PKGS/remote/v1.0.0/package.yaml
@@ -1,0 +1,6 @@
+name: remote
+description: Remote package.
+dependencies:
+  nested:
+    url: localhost:<[*PORT*]>/pkg/nested
+    version: ^1.0.0

--- a/tests/pkg/assets/licenses/LICENSE
+++ b/tests/pkg/assets/licenses/LICENSE
@@ -1,0 +1,1 @@
+Root application license.

--- a/tests/pkg/assets/licenses/gold/10-licenses.gold
+++ b/tests/pkg/assets/licenses/gold/10-licenses.gold
@@ -1,0 +1,44 @@
+OK
+[pkg, registry, add, test-registry, --local, registry]
+==================
+OK
+[pkg, install, remote]
+Package 'localhost:<[*PORT*]>/pkg/remote@1.0.0' installed with prefix 'remote'.
+==================
+OK
+[pkg, licenses, --no-include-sdk, --output=THIRD_PARTY_LICENSES]
+Wrote licenses for 4 packages to 'THIRD_PARTY_LICENSES'.
+==================
+== cat THIRD_PARTY_LICENSES
+================================================================================
+Package: license-app
+Source: .
+License file: LICENSE
+================================================================================
+Root application license.
+
+================================================================================
+Package: local
+Source: local
+License file: LICENSE
+================================================================================
+Local package license.
+
+================================================================================
+Package: nested
+Source: localhost:<[*PORT*]>/pkg/nested
+Version: 1.0.0
+Revision: deadbeef1234567890abcdef1234567890abcdef
+License file: LICENSE
+================================================================================
+Nested remote package license.
+
+================================================================================
+Package: remote
+Source: localhost:<[*PORT*]>/pkg/remote
+Version: 1.0.0
+Revision: deadbeef1234567890abcdef1234567890abcdef
+License file: LICENSE
+================================================================================
+Remote package license.
+

--- a/tests/pkg/assets/licenses/gold/15-sdk-licenses.gold
+++ b/tests/pkg/assets/licenses/gold/15-sdk-licenses.gold
@@ -1,0 +1,3 @@
+OK
+[pkg, licenses, --output=LICENSES_WITH_SDK]
+Wrote licenses for 5 packages to 'LICENSES_WITH_SDK'.

--- a/tests/pkg/assets/licenses/gold/20-missing-license.gold
+++ b/tests/pkg/assets/licenses/gold/20-missing-license.gold
@@ -1,0 +1,7 @@
+OK
+[pkg, install, missing]
+Package 'localhost:<[*PORT*]>/pkg/missing@1.0.0' installed with prefix 'missing'.
+==================
+Aborted
+[pkg, licenses, --output=THIRD_PARTY_LICENSES]
+Error: Package 'missing' has no top-level LICENSE file at '<[*WORKING-DIR*]>/.packages/localhost:<[*PORT*]>/pkg/missing/1.0.0/LICENSE'.

--- a/tests/pkg/assets/licenses/local/LICENSE
+++ b/tests/pkg/assets/licenses/local/LICENSE
@@ -1,0 +1,1 @@
+Local package license.

--- a/tests/pkg/assets/licenses/package.yaml
+++ b/tests/pkg/assets/licenses/package.yaml
@@ -1,0 +1,4 @@
+name: license-app
+dependencies:
+  local:
+    path: local

--- a/tests/pkg/assets/licenses/registry/missing/1.0.0/desc.yaml
+++ b/tests/pkg/assets/licenses/registry/missing/1.0.0/desc.yaml
@@ -1,0 +1,6 @@
+name: missing
+description: Package without a license file.
+url: localhost:<[*PORT*]>/pkg/missing
+version: 1.0.0
+hash: deadbeef1234567890abcdef1234567890abcdef
+license: MIT

--- a/tests/pkg/assets/licenses/registry/nested/1.0.0/desc.yaml
+++ b/tests/pkg/assets/licenses/registry/nested/1.0.0/desc.yaml
@@ -1,0 +1,6 @@
+name: nested
+description: Nested remote package.
+url: localhost:<[*PORT*]>/pkg/nested
+version: 1.0.0
+hash: deadbeef1234567890abcdef1234567890abcdef
+license: MIT

--- a/tests/pkg/assets/licenses/registry/remote/1.0.0/desc.yaml
+++ b/tests/pkg/assets/licenses/registry/remote/1.0.0/desc.yaml
@@ -1,0 +1,9 @@
+name: remote
+description: Remote package.
+url: localhost:<[*PORT*]>/pkg/remote
+version: 1.0.0
+hash: deadbeef1234567890abcdef1234567890abcdef
+license: MIT
+dependencies:
+  - url: localhost:<[*PORT*]>/pkg/nested
+    version: ^1.0.0

--- a/tests/pkg/licenses-gold-test.toit
+++ b/tests/pkg/licenses-gold-test.toit
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import .gold-tester
+
+import expect show *
+import host.file
+
+main args:
+  with-gold-tester args: test it
+
+test tester/GoldTester:
+  tester.gold "10-licenses" [
+    ["pkg", "registry", "add", "test-registry", "--local", "registry"],
+    ["pkg", "install", "remote"],
+    ["pkg", "licenses", "--no-include-sdk", "--output=THIRD_PARTY_LICENSES"],
+    ["cat", "THIRD_PARTY_LICENSES"],
+  ]
+
+  tester.gold "15-sdk-licenses" [
+    ["pkg", "licenses", "--output=LICENSES_WITH_SDK"],
+  ]
+  with-sdk := (file.read-contents "$tester.working-dir/LICENSES_WITH_SDK").to-string
+  expect (with-sdk.contains "Package: Toit SDK")
+  expect (with-sdk.contains "Upstream-Name: Toit SDK")
+  expect (with-sdk.contains "Files: third_party/dragonbox/*")
+
+  tester.gold "20-missing-license" [
+    ["pkg", "install", "missing"],
+    ["pkg", "licenses", "--output=THIRD_PARTY_LICENSES"],
+  ]

--- a/tools/pkg/commands/licenses.toit
+++ b/tools/pkg/commands/licenses.toit
@@ -131,6 +131,8 @@ class LicensesCommand extends PkgProjectCommand:
             "toit",
             "SDK-LICENSES",
           ],
+      // This fallback is only for development when running
+      // `toit tools/toit.toit`.
       fs.to-absolute
           fs.join [program-dir, "..", "..", "debian", "copyright"],
     ]
@@ -150,7 +152,7 @@ class LicensesCommand extends PkgProjectCommand:
         --version=system.vm-sdk-version
         --revision=null
 
-  write-entry_ output/io.Buffer entry/LicenseEntry_:
+  write-entry_ output/io.Writer entry/LicenseEntry_:
     if not file.is-file entry.license-path:
       error "Package '$entry.name' has no top-level LICENSE file at '$entry.license-path'."
 

--- a/tools/pkg/commands/licenses.toit
+++ b/tools/pkg/commands/licenses.toit
@@ -1,0 +1,192 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+import cli
+import fs
+import host.file
+import io
+import system
+
+import ..pkg
+import ..project
+import ..project.lock
+import ..project.specification
+
+import .base_
+
+class LicenseEntry_:
+  name/string
+  source/string
+  license-path/string
+  license-name/string
+  version/string?
+  revision/string?
+
+  constructor
+      --.name
+      --.source
+      --.license-path
+      --.license-name
+      --.version
+      --.revision:
+
+  compare-to other/LicenseEntry_ -> int:
+    return source.compare-to other.source --if-equal=:
+      name.compare-to other.name --if-equal=:
+        (version or "").compare-to (other.version or "")
+
+class LicensesCommand extends PkgProjectCommand:
+  output-path/string
+  include-sdk/bool
+
+  constructor invocation/cli.Invocation:
+    output-path = invocation[OUTPUT-OPTION]
+    include-sdk = invocation[INCLUDE-SDK-OPTION]
+    super invocation
+
+  execute:
+    project.install --no-recompute --registries=registries
+
+    entries := collect-entries_
+    output := io.Buffer
+    entries.do: write-entry_ output it
+    file.write-contents output.bytes --path=output-path
+    ui.emit --info "Wrote licenses for $entries.size packages to '$output-path'."
+
+  collect-entries_ -> List:
+    root-specification := project.specification
+    root-name := root-specification.has-name
+        ? root-specification.name
+        : fs.basename project.root
+    entries := [
+      LicenseEntry_
+          --name=root-name
+          --source="."
+          --license-path=(fs.join project.root "LICENSE")
+          --license-name="LICENSE"
+          --version=null
+          --revision=null,
+    ]
+
+    lock-file := project.lock-file
+    if not lock-file: return entries
+
+    dependency-entries := lock-file.packages.map: | package/Package |
+      if package is RepositoryPackage:
+        repository-package := package as RepositoryPackage
+        specification := project.load-package-specification
+            repository-package.url
+            repository-package.version
+        continue.map LicenseEntry_
+            --name=specification.name
+            --source=repository-package.url
+            --license-path=(fs.join specification.root-dir "LICENSE")
+            --license-name="LICENSE"
+            --version=repository-package.version.to-string
+            --revision=repository-package.ref-hash
+
+      local-package := package as LocalPackage
+      root := root-specification.absolute-path-for-dependency local-package.path
+      name := local-package.name or fs.basename root
+      specification-path := fs.join root Specification.FILE-NAME
+      if file.is-file specification-path:
+        specification := project.load-local-specification local-package.path
+        if specification.has-name: name = specification.name
+      continue.map LicenseEntry_
+          --name=name
+          --source=local-package.path
+          --license-path=(fs.join root "LICENSE")
+          --license-name="LICENSE"
+          --version=null
+          --revision=null
+
+    dependency-entries.sort --in-place: | a/LicenseEntry_ b/LicenseEntry_ |
+      a.compare-to b
+    entries.add-all dependency-entries
+    if include-sdk: entries.add sdk-license-entry_
+    return entries
+
+  sdk-license-entry_ -> LicenseEntry_:
+    program-dir := fs.dirname system.program-path
+    candidates := [
+      fs.to-absolute
+          fs.join [
+            program-dir,
+            "..",
+            "..",
+            "..",
+            "lib",
+            "toit",
+            "SDK-LICENSES",
+          ],
+      fs.to-absolute
+          fs.join [program-dir, "..", "..", "debian", "copyright"],
+    ]
+    license-path/string? := null
+    candidates.do: | candidate/string |
+      if not license-path and file.is-file candidate: license-path = candidate
+    if not license-path:
+      error """
+          Unable to find the Toit SDK license information.
+          Looked for: $(candidates.join ", ")"""
+
+    return LicenseEntry_
+        --name="Toit SDK"
+        --source="https://github.com/toitlang/toit"
+        --license-path=license-path
+        --license-name="SDK-LICENSES"
+        --version=system.vm-sdk-version
+        --revision=null
+
+  write-entry_ output/io.Buffer entry/LicenseEntry_:
+    if not file.is-file entry.license-path:
+      error "Package '$entry.name' has no top-level LICENSE file at '$entry.license-path'."
+
+    output.write """
+        ================================================================================
+        Package: $entry.name
+        Source: $entry.source
+        """
+    if entry.version: output.write "Version: $entry.version\n"
+    if entry.revision: output.write "Revision: $entry.revision\n"
+    output.write "License file: $entry.license-name\n"
+    output.write "================================================================================\n"
+    license-content := file.read-contents entry.license-path
+    output.write license-content
+    if license-content.is-empty or license-content.last != '\n':
+      output.write "\n"
+    output.write "\n"
+
+  static OUTPUT-OPTION ::= "output"
+  static INCLUDE-SDK-OPTION ::= "include-sdk"
+
+  static CLI-COMMAND ::=
+      cli.Command "licenses"
+          --help="""
+              Collects the top-level LICENSE files of a project and its dependencies.
+
+              The packages are taken from package.lock. Missing packages are downloaded
+                before their licenses are collected.
+              """
+          --options=[
+            cli.Flag INCLUDE-SDK-OPTION
+                --help="Include the licenses of the Toit SDK."
+                --default=true,
+            cli.OptionPath OUTPUT-OPTION
+                --short-name="o"
+                --help="Write the collected licenses to this file."
+                --required,
+          ]
+          --run=:: (LicensesCommand it).execute

--- a/tools/pkg/pkg.toit
+++ b/tools/pkg/pkg.toit
@@ -18,6 +18,7 @@ import system
 import cli show *
 
 import .commands.install
+import .commands.licenses
 import .commands.version
 import .commands.update
 import .commands.init
@@ -37,6 +38,7 @@ build-command -> Command:
           DescribeCommand.CLI-COMMAND,
           InitCommand.CLI-COMMAND,
           InstallCommand.CLI-COMMAND,
+          LicensesCommand.CLI-COMMAND,
           ListCommand.CLI-COMMAND,
           RegistryCommand.CLI-COMMAND,
           SearchCommand.CLI-COMMAND,
@@ -70,4 +72,3 @@ main arguments/List --cli/Cli?:
 OPTION-SDK-VERSION ::= "sdk-version"
 OPTION-PROJECT-ROOT ::= "project-root"
 OPTION-AUTO-SYNC ::= "auto-sync"
-


### PR DESCRIPTION
## Summary

- add `pkg licenses` to collect top-level license files for a project and its locked dependencies
- include package source, version, and revision metadata, with optional Toit SDK licenses
- ship the SDK license inventory as `SDK-LICENSES` and cover local, remote, transitive, SDK, and missing-license cases

## Tests

- `toit analyze -Werror tools/pkg/commands/licenses.toit tests/pkg/licenses-gold-test.toit`
- `toit run tests/pkg/licenses-gold-test.toit -- /usr/bin/toit`
- configured the CMake build and verified the generated `sdk/lib/toit/SDK-LICENSES` matches `debian/copyright`