### PR TITLE
uart: flush only complete try-writes

### DIFF
--- a/lib/uart.toit
+++ b/lib/uart.toit
@@ -445,11 +445,16 @@ class UartWriter extends io.Writer:
   If $break-length is greater than 0, an additional break signal is added after
     the data is written. The duration of the break signal is bit-duration * $break-length,
     where bit-duration is the duration it takes to write one bit at the current baud rate.
+
+  If $flush is true and the complete requested slice is accepted, waits until
+    those bytes have left the physical pins. A partial write does not flush:
+    the caller still has bytes to enqueue, and draining between chunks would
+    introduce an on-wire gap.
   */
   try-write data/io.Data from/int=0 to/int=data.byte-size --break-length/int=0 --flush/bool=false -> int:
     if is-closed_: throw "WRITER_CLOSED"
     result := port_.try-write_ data from to --break-length=break-length
-    if flush and (result > 0 or data.byte-size == 0): this.flush
+    if flush and result == to - from: this.flush
     return result
 
   try-write_ data/io.Data from/int to/int --break-length/int=0 -> int:


### PR DESCRIPTION
## Summary

- flush `UartWriter.try-write --flush` only when the complete requested slice was accepted
- document that partial writes stay buffered so callers can enqueue the remainder without an on-wire gap

The related `write` loop behavior is already on master through #3095, so this PR contains only the remaining part of e03a61c from #3075.

## Testing

- `toit analyze -Werror lib/uart.toit`