### PR TITLE
pkg: unwind aborts before exiting

### DIFF
--- a/tests/pkg/abort-cleanup-test.toit
+++ b/tests/pkg/abort-cleanup-test.toit
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+import fs
+import host.directory
+import host.file
+import host.pipe
+
+main args/List:
+  expect-equals 1 args.size
+  toit-exe/string := args[0]
+  tmp-dir := directory.mkdtemp "/tmp/pkg-abort-cleanup-"
+  try:
+    local-dir := fs.join tmp-dir "local"
+    directory.mkdir --recursive (fs.join local-dir "src")
+    file.write-contents --path=(fs.join tmp-dir "package.yaml") "# Toit Package File.\n"
+    file.write-contents --path=(fs.join local-dir "package.yaml") """
+        name: local
+        description: Local package with an unavailable dependency.
+        dependencies:
+          missing:
+            url: invalid.local/missing
+            version: ^1.0.0
+        """
+
+    exit-code := pipe.run-program [
+      toit-exe,
+      "pkg",
+      "--project-root=$tmp-dir",
+      "--no-auto-sync",
+      "install",
+      "--local",
+      local-dir,
+    ]
+    expect-equals 1 exit-code
+    expect-not (file.is-directory (fs.join tmp-dir ".packages/.lock"))
+  finally:
+    directory.rmdir --recursive --force tmp-dir

--- a/tools/package.lock
+++ b/tools/package.lock
@@ -20,8 +20,8 @@ packages:
   pkg-cli:
     url: github.com/toitlang/pkg-cli
     name: cli
-    version: 2.16.0
-    hash: 8b57ca731ab1798a2a97c4afc1ea464072cf2cbb
+    version: 2.17.0
+    hash: 8f58b041d55440916a2527899df505f6c6259b20
     prefixes:
       desktop: pkg-desktop
       fs: pkg-fs

--- a/tools/package.yaml
+++ b/tools/package.yaml
@@ -7,7 +7,7 @@ dependencies:
     version: ^1.11.0
   cli:
     url: github.com/toitlang/pkg-cli
-    version: ^2.16.0
+    version: ^2.17.0
   desktop:
     url: github.com/toitlang/pkg-desktop
     version: ^1.1.0


### PR DESCRIPTION
## Summary

- update the tool dependency from pkg-cli 2.16.0 to 2.17.0
- rely on the CLI package default abort behavior to unwind finalizers before Command.run exits with status 1
- add a real child-process regression test proving an abort releases the package-cache file lock

The temporary package-manager-specific Ui subclass and outer catch are no longer needed now that the behavior is provided by pkg-cli itself.

## Testing

- full SDK build with pkg-cli 2.17.0
- info-test and abort-cleanup-test
- complete tests/pkg suite: 50/50 passed

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>