### PR TITLE
pkg: emit structured search results as JSON

### DIFF
--- a/tests/pkg/assets/search/gold/search.gold
+++ b/tests/pkg/assets/search/gold/search.gold
@@ -108,6 +108,12 @@ OK
 [pkg, search, sub]
 sub - 3.1.4
 ==================
+// Structured output uses the same package representation as pkg list.
+==================
+OK
+[pkg, search, foo, --output-format=json]
+[{"foo":{"description":"Description of foo.","version":"5.0.3","license":"MIT","url":"localhost:<[*PORT*]>/pkg/foo","hash":22222222222}}]
+==================
 // Find all packages:
 ==================
 OK

--- a/tests/pkg/gold-tester.toit
+++ b/tests/pkg/gold-tester.toit
@@ -233,7 +233,9 @@ class GoldTester:
         if (pkg-args.any: it == "--verbose"):
           ui-level = Ui.VERBOSE-LEVEL
           pkg-args.remove "--verbose"
-        test-ui := TestUi --quiet=false --level=ui-level
+        json-output := pkg-args.contains "--output-format=json"
+        if json-output: pkg-args.remove "--output-format=json"
+        test-ui := TestUi --quiet=false --level=ui-level --json=json-output
         log.set-default test-ui.logger
         cli := Cli "pkg" --ui=test-ui
         e := catch --trace=(: it is not TestAbort):
@@ -242,7 +244,9 @@ class GoldTester:
         if e and e is not TestAbort:
           print-on-stderr_ "Command failed: $e"
           expect e is TestAbort
+        if json-output: json.decode test-ui.stdout.to-byte-array
         full-output := test-ui.stdout + test-ui.stderr
+        if json-output and not full-output.ends-with "\n": full-output += "\n"
         outputs.add "$exit-status\n$command-line\n$full-output"
       else:
         throw "Unknown command: $command"

--- a/tests/pkg/search-gold-test.toit
+++ b/tests/pkg/search-gold-test.toit
@@ -40,6 +40,8 @@ test tester/GoldTester:
     ["// The bar and sub package didn't change"],
     ["pkg", "search", "bar"],
     ["pkg", "search", "sub"],
+    ["// Structured output uses the same package representation as pkg list."],
+    ["pkg", "search", "foo", "--output-format=json"],
     ["// Find all packages:"],
     ["pkg", "search", ""],
   ]

--- a/tools/pkg/commands/list.toit
+++ b/tools/pkg/commands/list.toit
@@ -92,7 +92,7 @@ class ListCommand extends PkgCommand:
           a.ref-hash.compare-to b.ref-hash
 
     if ui.wants-structured:
-      ui.emit-list --result descriptions
+      ui.emit-list --result (descriptions.map: verbose-description it)
       return
 
     if ui.wants-human and descriptions.is-empty:


### PR DESCRIPTION
## Summary

- convert package descriptions to structured maps before emitting JSON search results
- make the gold-test harness decode JSON output so malformed output fails immediately
- cover verbose package search in JSON mode

## Testing

- search-gold-test.toit
- complete tests/pkg suite

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>