### PR TITLE
pkg: refresh dependencies of local packages

### DIFF
--- a/tests/pkg/assets/install/gold/15-local-change.gold
+++ b/tests/pkg/assets/install/gold/15-local-change.gold
@@ -1,0 +1,35 @@
+// Target should now use sub-2, while bar should continue to use sub-3.
+==================
+OK
+[pkg, install]
+==================
+== package.lock
+sdk: ^0.1.30
+prefixes:
+  bar: localhost_<[*PORT*]>/pkg/bar-2
+  foo: localhost_<[*PORT*]>/pkg/foo-1
+  target: target
+packages:
+  localhost_<[*PORT*]>/pkg/bar-2:
+    hash: <[*HASH*]>
+    prefixes:
+      foo: localhost_<[*PORT*]>/pkg/foo-1
+      sub: localhost_<[*PORT*]>/pkg/sub-3
+    url: localhost:<[*PORT*]>/pkg/bar
+    version: 2.0.1
+  localhost_<[*PORT*]>/pkg/foo-1:
+    hash: <[*HASH*]>
+    url: localhost:<[*PORT*]>/pkg/foo
+    version: 1.2.3
+  localhost_<[*PORT*]>/pkg/sub-2:
+    hash: <[*HASH*]>
+    url: localhost:<[*PORT*]>/pkg/sub
+    version: 2.0.0
+  localhost_<[*PORT*]>/pkg/sub-3:
+    hash: <[*HASH*]>
+    url: localhost:<[*PORT*]>/pkg/sub
+    version: 3.1.4
+  target:
+    path: target
+    prefixes:
+      sub: localhost_<[*PORT*]>/pkg/sub-2

--- a/tests/pkg/install-gold-test.toit
+++ b/tests/pkg/install-gold-test.toit
@@ -20,6 +20,21 @@ test tester/GoldTester:
     ["exec", "main.toit"],
   ]
 
+  file.write-contents --path="$tester.working-dir/target/package.yaml" """
+      name: target
+      description: desc
+      dependencies:
+        sub:
+          url: localhost:$tester.port/pkg/sub
+          version: ^2.0.0
+      """
+
+  tester.gold "15-local-change" [
+    ["// Target should now use sub-2, while bar should continue to use sub-3."],
+    ["pkg", "install"],
+    ["package.lock"],
+  ]
+
   foo-version := "1.2.3"
   foo-path := tester.package-cache-path "pkg/foo" --version=foo-version
   expect (file.is-directory foo-path)

--- a/tools/pkg/project/lock.toit
+++ b/tools/pkg/project/lock.toit
@@ -206,6 +206,9 @@ class LockFile:
     return repository-packages.every: | package/RepositoryPackage |
       package.is-downloaded
 
+  has-local-packages -> bool:
+    return packages.any: it is LocalPackage
+
   install --fs-lock-token/Object:
     (packages.filter : it is RepositoryPackage).do: | package/RepositoryPackage |
       package.ensure-downloaded --fs-lock-token=fs-lock-token

--- a/tools/pkg/project/project.toit
+++ b/tools/pkg/project/project.toit
@@ -219,13 +219,18 @@ class Project:
       specification.update-remote-dependencies solution
       save
 
+  reusable-lock-file_ --recompute/bool -> LockFile?:
+    candidate := lock-file
+    if recompute or not candidate or candidate.has-local-packages: return null
+    return candidate
+
   install --recompute/bool --registries/Registries -> none:
-    if not recompute and lock-file and lock-file.is-downloaded:
-      return
+    reusable-lock-file := reusable-lock-file_ --recompute=recompute
+    if reusable-lock-file and reusable-lock-file.is-downloaded: return
 
     with-package-cache-lock_: | fs-lock-token |
-      if not recompute and lock-file:
-        lock-file.install --fs-lock-token=fs-lock-token
+      if reusable-lock-file:
+        reusable-lock-file.install --fs-lock-token=fs-lock-token
         return
 
       solution := solve-and-download_


### PR DESCRIPTION
## Summary

- recompute dependency solutions when a project contains local packages
- retain the existing lockfile fast paths for projects containing only remote packages
- cover a changed local package that introduces a dependency on another major version

## Testing

- install-gold-test.toit
- complete tests/pkg suite

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>