### PR TITLE
pkg: document lockfile package IDs

### DIFF
--- a/tests/pkg/install-gold-test.toit
+++ b/tests/pkg/install-gold-test.toit
@@ -3,6 +3,7 @@
 // be found in the tests/LICENSE file.
 
 import encoding.json
+import encoding.yaml
 import expect show *
 import host.directory
 import host.file
@@ -34,6 +35,15 @@ test tester/GoldTester:
     ["pkg", "install"],
     ["package.lock"],
   ]
+
+  lock/Map := yaml.decode (file.read-contents "$tester.working-dir/package.lock")
+  target-id/string := lock["prefixes"]["target"]
+  target-sub-id/string := lock["packages"][target-id]["prefixes"]["sub"]
+  bar-id/string := lock["prefixes"]["bar"]
+  bar-sub-id/string := lock["packages"][bar-id]["prefixes"]["sub"]
+  expect (target-sub-id.ends-with "/pkg/sub-2")
+  expect (bar-sub-id.ends-with "/pkg/sub-3")
+  expect-not-equals target-sub-id bar-sub-id
 
   foo-version := "1.2.3"
   foo-path := tester.package-cache-path "pkg/foo" --version=foo-version

--- a/tools/pkg/project/lock.toit
+++ b/tools/pkg/project/lock.toit
@@ -256,6 +256,8 @@ class LockFileBuilder:
 
     used := {}
     url-id-prefixes-map_ = solution_.packages.map: | url/string _ |
+      // Different URLs can normalize to the same lock-file ID prefix. Add a
+      // collision suffix before the major-version suffix is added below.
       candidate := to-valid-package-id_ url
       counter := 2
       id := candidate
@@ -298,7 +300,9 @@ class LockFileBuilder:
         name := specification.name
         hash := project_.hash-for --url=url --version=version --registries=registries
         id-prefix := url-id-prefixes-map_[url]
-        // We simply use the url + major version as key.
+        // Major versions are separate solver packages and may coexist in one
+        // lock file. Always include the major so an ID remains stable if a
+        // second major version is introduced later.
         id := "$id-prefix-$version.major"
         used-ids.add id
 
@@ -316,6 +320,8 @@ class LockFileBuilder:
 
     compute-local-id := : | path/string |
       local-ids.get path --init=:
+        // Local packages have no version to distinguish them. Use their
+        // basename and add a suffix when it collides with another package ID.
         id := (fs.split path).last
         counter := 2
         while used-ids.contains id:


### PR DESCRIPTION
## Summary

- document that remote package IDs carry a stable major-version suffix because multiple majors can coexist
- document numeric disambiguators for normalized URL and local basename collisions
- assert the distinct major-version IDs in the install regression test

## Testing

- install-gold-test.toit
- complete tests/pkg suite

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>