### PR TITLE
pkg: support major dependency updates

### DIFF
--- a/tests/pkg/assets/major-update/gold/10-test.gold
+++ b/tests/pkg/assets/major-update/gold/10-test.gold
@@ -1,35 +1,33 @@
 OK
-[pkg, registry, add, test-reg, http://localhost:<[*PORT*]>/registry/git-pkgs]
+[pkg, init]
 ==================
 OK
-[pkg, list]
-test-reg (http://localhost:<[*PORT*]>/registry/git-pkgs (git))
-  pkg1 - 1.0.0
-  pkg2 - 1.0.0
-  pkg2 - 2.4.2
-  pkg3 - 3.1.2
-  pkg4 - 4.9.9
+[pkg, registry, add, test-reg, http://localhost:<[*PORT*]>/registry/git-pkgs]
 ==================
 OK
 [pkg, install, pkg1]
 Package 'localhost:<[*PORT*]>/pkg/pkg1@1.0.0' installed with prefix 'pkg1'.
 ==================
 OK
-[pkg, install, pkg2]
-Package 'localhost:<[*PORT*]>/pkg/pkg2@2.4.2' installed with prefix 'pkg2'.
+[pkg, install, pkg2@1]
+Package 'localhost:<[*PORT*]>/pkg/pkg2@1.0.0' installed with prefix 'pkg2'.
 ==================
-// Should have version 3.1.2 for pkg3
+// The direct dependency starts on major 1 while pkg1 still needs major 2.
 ==================
 == package.lock
 prefixes:
   pkg1: localhost_<[*PORT*]>/pkg/pkg1-1
-  pkg2: localhost_<[*PORT*]>/pkg/pkg2-2
+  pkg2: localhost_<[*PORT*]>/pkg/pkg2-1
 packages:
   localhost_<[*PORT*]>/pkg/pkg1-1:
     hash: <[*HASH*]>
     prefixes:
       pkg2: localhost_<[*PORT*]>/pkg/pkg2-2
     url: localhost:<[*PORT*]>/pkg/pkg1
+    version: 1.0.0
+  localhost_<[*PORT*]>/pkg/pkg2-1:
+    hash: <[*HASH*]>
+    url: localhost:<[*PORT*]>/pkg/pkg2
     version: 1.0.0
   localhost_<[*PORT*]>/pkg/pkg2-2:
     hash: <[*HASH*]>
@@ -49,28 +47,15 @@ dependencies:
     version: ^1.0.0
   pkg2:
     url: localhost:<[*PORT*]>/pkg/pkg2
-    version: ^2.4.2
+    version: ^1.0.0
 ==================
 OK
 [pkg, registry, add, test-reg2, http://localhost:<[*PORT*]>/registry/git-pkgs-newer-versions]
 ==================
 OK
-[pkg, list]
-test-reg (http://localhost:<[*PORT*]>/registry/git-pkgs (git))
-  pkg1 - 1.0.0
-  pkg2 - 1.0.0
-  pkg2 - 2.4.2
-  pkg3 - 3.1.2
-  pkg4 - 4.9.9
-test-reg2 (http://localhost:<[*PORT*]>/registry/git-pkgs-newer-versions (git))
-  pkg2 - 2.4.3
-  pkg2 - 3.0.0
-  pkg3 - 3.1.3
+[pkg, update, --major, pkg2@2]
 ==================
-OK
-[pkg, update, pkg2]
-==================
-// Only pkg2 changes; its compatible transitive dependency stays preferred.
+// An explicit major selects its newest solvable version.
 ==================
 == package.lock
 prefixes:
@@ -104,14 +89,14 @@ dependencies:
     version: ^2.4.3
 ==================
 OK
-[pkg, update]
+[pkg, update, --major, pkg2]
 ==================
-// Updating everything also updates pkg3.
+// An unqualified major update selects the newest solvable major.
 ==================
 == package.lock
 prefixes:
   pkg1: localhost_<[*PORT*]>/pkg/pkg1-1
-  pkg2: localhost_<[*PORT*]>/pkg/pkg2-2
+  pkg2: localhost_<[*PORT*]>/pkg/pkg2-3
 packages:
   localhost_<[*PORT*]>/pkg/pkg1-1:
     hash: <[*HASH*]>
@@ -125,10 +110,16 @@ packages:
       pre: localhost_<[*PORT*]>/pkg/pkg3-3
     url: localhost:<[*PORT*]>/pkg/pkg2
     version: 2.4.3
+  localhost_<[*PORT*]>/pkg/pkg2-3:
+    hash: <[*HASH*]>
+    prefixes:
+      pre: localhost_<[*PORT*]>/pkg/pkg3-3
+    url: localhost:<[*PORT*]>/pkg/pkg2
+    version: 3.0.0
   localhost_<[*PORT*]>/pkg/pkg3-3:
     hash: <[*HASH*]>
     url: localhost:<[*PORT*]>/pkg/pkg3
-    version: 3.1.3
+    version: 3.1.2
 ==================
 == package.yaml
 dependencies:
@@ -137,16 +128,12 @@ dependencies:
     version: ^1.0.0
   pkg2:
     url: localhost:<[*PORT*]>/pkg/pkg2
-    version: ^2.4.3
+    version: ^3.0.0
 ==================
 Aborted
-[pkg, update, missing]
-Error: No package with prefix 'missing'.
-==================
-OK
-[pkg, install, --local, local]
-Package 'local' installed with prefix 'local'.
+[pkg, update, --major]
+Error: The '--major' flag requires at least one package prefix.
 ==================
 Aborted
-[pkg, update, local]
-Error: Package with prefix 'local' is local and cannot be updated.
+[pkg, update, --major, pkg2@v2]
+Error: Invalid package selector 'pkg2@v2'. Expected 'prefix' or 'prefix@major'.

--- a/tests/pkg/assets/preferred/gold/20-test.gold
+++ b/tests/pkg/assets/preferred/gold/20-test.gold
@@ -55,6 +55,7 @@ test-reg (http://localhost:<[*PORT*]>/registry/git-pkgs (git))
   pkg4 - 4.9.9
 test-reg3 (http://localhost:<[*PORT*]>/registry/git-pkgs-newer-versions (git))
   pkg2 - 2.4.3
+  pkg2 - 3.0.0
   pkg3 - 3.1.3
 test-reg2 (<[*WORKING-DIR*]>/registry (local))
   bar - 2.0.1

--- a/tests/pkg/assets/shared/GIT-SERVE-PKGS/pkg2/v3.0.0/package.yaml
+++ b/tests/pkg/assets/shared/GIT-SERVE-PKGS/pkg2/v3.0.0/package.yaml
@@ -1,0 +1,6 @@
+name: pkg2
+description: git-package 2
+dependencies:
+  pre:
+    url: localhost:<[*PORT*]>/pkg/pkg3
+    version: ^3.0.0

--- a/tests/pkg/assets/shared/GIT-SERVE-PKGS/pkg2/v3.0.0/src/pkg2.toit
+++ b/tests/pkg/assets/shared/GIT-SERVE-PKGS/pkg2/v3.0.0/src/pkg2.toit
@@ -1,0 +1,6 @@
+// Copyright (C) 2026 Toit contributors.
+
+import pre.pkg3
+
+identify:
+  return "pkg2-3.0.0" + pre.identify

--- a/tests/pkg/assets/shared/GIT-SERVE-REGISTRIES/git-pkgs-newer-versions/1.0.0/pkg2/3.0.0/desc.yaml
+++ b/tests/pkg/assets/shared/GIT-SERVE-REGISTRIES/git-pkgs-newer-versions/1.0.0/pkg2/3.0.0/desc.yaml
@@ -1,0 +1,8 @@
+name: pkg2
+description: git-package 2
+url: localhost:<[*PORT*]>/pkg/pkg2
+version: 3.0.0
+dependencies:
+  - url: 'localhost:<[*PORT*]>/pkg/pkg3'
+    version: ^3.0.0
+hash: deadbeef1234567890abcdef1234567890abcdef

--- a/tests/pkg/major-update-gold-test.toit
+++ b/tests/pkg/major-update-gold-test.toit
@@ -1,0 +1,33 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import .gold-tester
+
+main args:
+  with-gold-tester args: test it
+
+test tester/GoldTester:
+  registry1 := "http://localhost:$tester.port$(AssetsBuilder.HTTP-REGISTRY-PREFIX)git-pkgs"
+  registry2 := "http://localhost:$tester.port$(AssetsBuilder.HTTP-REGISTRY-PREFIX)git-pkgs-newer-versions"
+
+  tester.gold "10-test" [
+    ["pkg", "init"],
+    ["pkg", "registry", "add", "test-reg", registry1],
+    ["pkg", "install", "pkg1"],
+    ["pkg", "install", "pkg2@1"],
+    ["// The direct dependency starts on major 1 while pkg1 still needs major 2."],
+    ["package.lock"],
+    ["package.yaml"],
+    ["pkg", "registry", "add", "test-reg2", registry2],
+    ["pkg", "update", "--major", "pkg2@2"],
+    ["// An explicit major selects its newest solvable version."],
+    ["package.lock"],
+    ["package.yaml"],
+    ["pkg", "update", "--major", "pkg2"],
+    ["// An unqualified major update selects the newest solvable major."],
+    ["package.lock"],
+    ["package.yaml"],
+    ["pkg", "update", "--major"],
+    ["pkg", "update", "--major", "pkg2@v2"],
+  ]

--- a/tools/pkg/commands/install.toit
+++ b/tools/pkg/commands/install.toit
@@ -86,16 +86,14 @@ class InstallCommand extends PkgProjectCommand:
     prefixes := []
     version-constraints := []
     packages.do: | package-string/string |
-      package-name := package-string
-      version-constraint/Constraint? := null
-      if package-string.contains "@":
-        parts := package-string.split "@"
-        if parts.size != 2:
-          error "Invalid package name '$package-string'. Must be of the form 'name@version'."
-        package-name = parts[0]
-        version-constraint-str := parts[1]
-        if version-constraint-str == "":
+      selector := parse-package-selector package-string --on-error=: | missing-version/bool |
+        if missing-version:
           error "Missing version after '@' in '$package-string'."
+        error "Invalid package name '$package-string'. Must be of the form 'name@version'."
+
+      package-name := selector.name
+      version-constraint/Constraint? := null
+      if version-constraint-str := selector.version:
         e := catch: version-constraint = Constraint.parse-range version-constraint-str
         if e:
           error "Invalid version constraint '$version-constraint-str' in '$package-string': $e"

--- a/tools/pkg/commands/update.toit
+++ b/tools/pkg/commands/update.toit
@@ -26,13 +26,17 @@ import .utils_
 
 class UpdateCommand extends PkgProjectCommand:
   prefixes/List
+  major/bool
 
   constructor invocation/cli.Invocation:
     prefixes = invocation[PREFIX]
+    major = invocation[MAJOR]
+    if major and prefixes.is-empty:
+      invocation.cli.ui.abort "The '--major' flag requires at least one package prefix."
     super invocation
 
   execute:
-    project.update prefixes --registries=registries
+    project.update prefixes --major=major --registries=registries
 
   static CLI-COMMAND ::=
       cli.Command "update"
@@ -44,10 +48,18 @@ class UpdateCommand extends PkgProjectCommand:
                 required by the selected versions.
 
               If no prefixes are given, updates all packages.
+              Use '--major' with one or more prefixes to allow incompatible
+                updates. A prefix can be followed by a major version, such as
+                'foo@2', to select the newest version in that major.
               """
+          --options=[
+              cli.Flag MAJOR
+                  --help="Allow selected packages to change major version."
+                  --default=false
+          ]
           --rest=[
               cli.Option PREFIX
-                  --help="The prefix of a package to update."
+                  --help="The prefix of a package to update, optionally followed by '@major'."
                   --type="prefix"
                   --multi
                   --completion=:: complete-dependency-prefixes it --project-root-option=OPTION-PROJECT-ROOT
@@ -55,3 +67,4 @@ class UpdateCommand extends PkgProjectCommand:
           --run=:: (UpdateCommand it).execute
 
   static PREFIX ::= "prefix"
+  static MAJOR ::= "major"

--- a/tools/pkg/project/project.toit
+++ b/tools/pkg/project/project.toit
@@ -210,9 +210,29 @@ class Project:
     lock-file.update --remove-prefix=prefix
     save
 
-  update prefixes/List --registries/Registries -> none:
+  update prefixes/List --major/bool=false --registries/Registries -> none:
+    if major and prefixes.is-empty:
+      ui_.abort "The '--major' flag requires at least one package prefix."
+
     urls-to-update := {}
-    prefixes.do: | prefix/string |
+    major-requests := {:}
+    prefixes.do: | selector/string |
+      prefix := selector
+      requested-major := -1
+      if major:
+        parsed-selector := parse-package-selector selector --on-error=: | _ |
+          ui_.abort "Invalid package selector '$selector'. Expected 'prefix' or 'prefix@major'."
+        prefix = parsed-selector.name
+        if version := parsed-selector.version:
+          parsed-major/int? := int.parse version --if-error=: null
+          if parsed-major == null or parsed-major < 0:
+            ui_.abort "Invalid package selector '$selector'. Expected 'prefix' or 'prefix@major'."
+          requested-major = parsed-major
+
+        if major-requests.contains prefix:
+          ui_.abort "Package prefix '$prefix' was specified more than once."
+        major-requests[prefix] = requested-major
+
       dependency/Map? := specification.dependencies.get prefix
       if not dependency:
         ui_.abort "No package with prefix '$prefix'."
@@ -221,12 +241,37 @@ class Project:
       urls-to-update.add dependency[Specification.URL-KEY_]
 
     with-package-cache-lock_: | fs-lock-token |
+      if major:
+        major-requests.do: | prefix/string requested-major/int |
+          dependency/Map := specification.dependencies[prefix]
+          dependency[Specification.VERSION-KEY_] = requested-major == -1
+              ? ">=0.0.0"
+              : "^$requested-major.0.0"
+
       solution := solve-and-download_
           --update-everything=prefixes.is-empty
           --urls-to-update=urls-to-update
           --registries=registries
           --fs-lock-token=fs-lock-token
+
+      major-versions := {:}
+      if major:
+        major-requests.do: | prefix/string _ |
+          dependency/Map := specification.dependencies[prefix]
+          url/string := dependency[Specification.URL-KEY_]
+          constraint := Constraint.parse dependency[Specification.VERSION-KEY_]
+          picked-version/SemanticVersion? := null
+          solution.packages[url].do: | version/SemanticVersion |
+            if constraint.satisfies version and
+                (not picked-version or version > picked-version):
+              picked-version = version
+          assert: picked-version != null
+          major-versions[prefix] = picked-version
+
       specification.update-remote-dependencies solution
+      major-versions.do: | prefix/string version/SemanticVersion |
+        dependency/Map := specification.dependencies[prefix]
+        dependency[Specification.VERSION-KEY_] = "^$version"
       save
 
   reusable-lock-file_ --recompute/bool -> LockFile?:

--- a/tools/pkg/utils.toit
+++ b/tools/pkg/utils.toit
@@ -19,6 +19,27 @@ import host.directory
 import fs
 import system
 
+class PackageSelector:
+  name/string
+  version/string?
+
+  constructor .name .version:
+
+/**
+Parses a package $selector consisting of a name and an optional version.
+
+Calls $on-error with whether the selector has a missing version.
+*/
+parse-package-selector selector/string [--on-error] -> PackageSelector:
+  parts := selector.split "@"
+  if parts.size > 2 or parts[0].is-empty:
+    on-error.call false
+    unreachable
+  if parts.size == 2 and parts[1].is-empty:
+    on-error.call true
+    unreachable
+  return PackageSelector parts[0] (parts.size == 2 ? parts[1] : null)
+
 flatten-list input/List -> List:
   list := List
   input.do:


### PR DESCRIPTION
## Summary

- add pkg update --major with required named dependencies
- support prefix@major selectors such as foo@2; foo@v2 is intentionally rejected
- temporarily widen selected constraints for solving, then persist a caret constraint at the chosen version
- cover explicit-major selection, newest-major selection, and simultaneous major versions

## Testing

- major-update-gold-test.toit
- update-gold-test.toit
- preferred-gold-test.toit
- completion-gold-test.toit
- complete tests/pkg suite

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>