### PR TITLE
tests: add pixel-strip RMT smoke test

### DIFF
--- a/tests/hw/esp32/README.md
+++ b/tests/hw/esp32/README.md
@@ -28,8 +28,8 @@ IO2, IO4, and IO16 must stay unconnected.
 
 Connect board 1 to board 2 as follows:
 - GND - GND
-- IO22 - IO23
-- IO23 - IO22
+- IO22 - IO22
+- IO23 - IO23
 
 On board2:
 - IO19 -> HC-SR04 Echo

--- a/tests/hw/esp32/package.lock
+++ b/tests/hw/esp32/package.lock
@@ -1,10 +1,11 @@
-sdk: ^2.0.0-alpha.180
+sdk: ^2.0.0-alpha.181
 prefixes:
   bme280: bme280-driver
   bmp280: bmp280-driver
   dhtxx: toit-dhtxx
   ds18b20: toit-ds18b20
   hc_sr04: toit-hc-sr04
+  pixel_strip: toit-pixel-strip
 packages:
   bme280-driver:
     url: github.com/toitware/bme280-driver
@@ -40,6 +41,11 @@ packages:
     name: hc-sr04
     version: 2.2.0
     hash: b0cfb0df9e657a699f909e0aa5d37979b9e96fa2
+  toit-pixel-strip:
+    url: github.com/toitware/toit-pixel-strip
+    name: pixel_strip
+    version: 1.3.0
+    hash: 4e7a6027bf6da42a56f052abe8cf33b8b834be55
   toit-sensors:
     url: github.com/toitware/toit-sensors
     name: sensors

--- a/tests/hw/esp32/package.lock
+++ b/tests/hw/esp32/package.lock
@@ -44,8 +44,8 @@ packages:
   toit-pixel-strip:
     url: github.com/toitware/toit-pixel-strip
     name: pixel_strip
-    version: 1.3.0
-    hash: 4e7a6027bf6da42a56f052abe8cf33b8b834be55
+    version: 1.4.0
+    hash: e7b0942f6cdc8f5575a3d7e78b74fef1544117c5
   toit-sensors:
     url: github.com/toitware/toit-sensors
     name: sensors

--- a/tests/hw/esp32/package.yaml
+++ b/tests/hw/esp32/package.yaml
@@ -16,4 +16,4 @@ dependencies:
     version: ^2.2.0
   pixel_strip:
     url: github.com/toitware/toit-pixel-strip
-    version: ^1.3.0
+    version: ^1.4.0

--- a/tests/hw/esp32/package.yaml
+++ b/tests/hw/esp32/package.yaml
@@ -14,3 +14,6 @@ dependencies:
   hc_sr04:
     url: github.com/lask/toit-hc-sr04
     version: ^2.2.0
+  pixel_strip:
+    url: github.com/toitware/toit-pixel-strip
+    version: ^1.3.0

--- a/tests/hw/esp32/pixel-strip-board1.toit
+++ b/tests/hw/esp32/pixel-strip-board1.toit
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+// ARG: rmt
+
+import expect show *
+import gpio
+import pixel_strip show PixelStrip
+
+import .pixel-strip-shared
+import .test
+
+main args:
+  run-test:
+    expect-equals "rmt" args[0]
+
+    data := gpio.Pin.out DATA-PIN
+    ready := gpio.Pin READY-PIN --input --pull-down
+    strip := PixelStrip.rmt PIXELS --pin=data
+
+    try:
+      ready.wait-for 1
+      strip.output RED GREEN BLUE
+    finally:
+      strip.close
+      data.close
+      ready.close

--- a/tests/hw/esp32/pixel-strip-board1.toit
+++ b/tests/hw/esp32/pixel-strip-board1.toit
@@ -15,14 +15,12 @@ main args:
   run-test:
     expect-equals "rmt" args[0]
 
-    data := gpio.Pin.out DATA-PIN
     ready := gpio.Pin READY-PIN --input --pull-down
-    strip := PixelStrip.rmt PIXELS --pin=data
+    strip := PixelStrip.rmt PIXELS --pin=DATA-PIN
 
     try:
       ready.wait-for 1
       strip.output RED GREEN BLUE
     finally:
       strip.close
-      data.close
       ready.close

--- a/tests/hw/esp32/pixel-strip-board2.toit
+++ b/tests/hw/esp32/pixel-strip-board2.toit
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import gpio
+import rmt
+
+import .pixel-strip-shared
+import .test
+
+main _:
+  run-test:
+    input := rmt.In
+        DATA-PIN
+        --memory-blocks=RMT-MEMORY-BLOCKS
+        --resolution=RESOLUTION
+    ready := gpio.Pin READY-PIN --output
+
+    try:
+      input.start-reading --max-ns=50_000
+      ready.set 1
+      signals := input.wait-for-data
+      validate-capture signals
+    finally:
+      ready.set 0
+      ready.close
+      input.close

--- a/tests/hw/esp32/pixel-strip-shared.toit
+++ b/tests/hw/esp32/pixel-strip-shared.toit
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+import rmt
+
+import .variants
+
+PIXELS ::= 7
+BYTES-PER-PIXEL ::= 3
+RESOLUTION ::= 20_000_000
+TIMING-SLACK-TICKS ::= 3
+
+DATA-PIN ::= Variant.CURRENT.pixel-strip-data-pin
+READY-PIN ::= Variant.CURRENT.pixel-strip-ready-pin
+RMT-MEMORY-BLOCKS ::= Variant.CURRENT.rmt-in-channel-count
+
+RED ::= #[0x00, 0xff, 0x80, 0x01, 0xaa, 0x55, 0x96]
+GREEN ::= #[0xff, 0x00, 0x7f, 0xfe, 0x55, 0xaa, 0x69]
+BLUE ::= #[0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde]
+
+EXPECTED-GRB ::= #[
+  0xff, 0x00, 0x12,
+  0x00, 0xff, 0x34,
+  0x7f, 0x80, 0x56,
+  0xfe, 0x01, 0x78,
+  0x55, 0xaa, 0x9a,
+  0xaa, 0x55, 0xbc,
+  0x69, 0x96, 0xde,
+]
+
+EXPECTED-BIT-COUNT ::= PIXELS * BYTES-PER-PIXEL * 8
+// The final low period turns into the RMT end marker because the line never
+//   transitions high again after the frame.
+EXPECTED-TRANSITION-COUNT ::= EXPECTED-BIT-COUNT * 2 - 1
+
+expect-close-to expected/int actual/int --transition/int:
+  expect (expected - actual).abs <= TIMING-SLACK-TICKS
+      --message="Transition $transition: expected $expected ticks, got $actual ticks"
+
+validate-capture signals/rmt.Signals:
+  transition-count := signals.size
+  while transition-count > 0 and (signals.period (transition-count - 1)) == 0:
+    transition-count--
+
+  expect-equals EXPECTED-TRANSITION-COUNT transition-count
+  expect signals.size > transition-count
+      --message="RMT capture has no end marker"
+
+  decoded := ByteArray EXPECTED-GRB.size
+  EXPECTED-BIT-COUNT.repeat: | bit-index |
+    high-index := bit-index * 2
+    low-index := high-index + 1
+    high-ticks := signals.period high-index
+
+    expect-equals 1 (signals.level high-index)
+
+    bit := high-ticks > 10 ? 1 : 0
+    expected-high := bit == 0 ? 7 : 14
+    expect-close-to expected-high high-ticks --transition=high-index
+    if low-index < transition-count:
+      low-ticks := signals.period low-index
+      expected-low := bit == 0 ? 16 : 12
+      expect-equals 0 (signals.level low-index)
+      expect-close-to expected-low low-ticks --transition=low-index
+
+    byte-index := bit-index / 8
+    bit-offset := 7 - bit-index % 8
+    decoded[byte-index] |= bit << bit-offset
+
+  expect-bytes-equal EXPECTED-GRB decoded
+
+  signals.size.repeat: | index |
+    if index >= transition-count:
+      expect-equals 0 (signals.period index)

--- a/tests/hw/esp32/variants.toit
+++ b/tests/hw/esp32/variants.toit
@@ -177,6 +177,12 @@ abstract class Variant:
   abstract board-connection-pin5 -> int
   abstract board-connection-pin6 -> int
 
+  /** The cross-board data pin used by the pixel-strip tests. */
+  pixel-strip-data-pin -> int: return board-connection-pin1
+
+  /** The cross-board synchronization pin used by the pixel-strip tests. */
+  pixel-strip-ready-pin -> int: return board-connection-pin2
+
   /**
   The cross-board pins used by the two-board i2s tests.
 
@@ -424,8 +430,8 @@ IO2, IO4, and IO16 must stay unconnected.
 
 Connect the two boards.
 - GND (board1) - GND (board2)
-- IO22 (board1) - IO23 (board2)
-- IO23 (board1) - IO22 (board2)
+- IO22 (board1) - IO22 (board2)
+- IO23 (board1) - IO23 (board2)
 - IO16 (board1) - IO16 (board2)
 - IO27 (board1) - IO27 (board2)
 - IO17 (board1) - IO17 (board2)
@@ -541,8 +547,8 @@ IO6, IO7, and IO8 must stay unconnected.
 
 Connect the two boards.
 - GND (board1) - GND (board2)
-- IO04 (board1) - IO05 (board2)
-- IO05 (board1) - IO04 (board2)
+- IO04 (board1) - IO04 (board2)
+- IO05 (board1) - IO05 (board2)
 - IO21 (board1) - IO21 (board2)
 - IO17 (board1) - IO17 (board2)
 - IO47 (board1) - IO47 (board2)


### PR DESCRIPTION
Adds a two-board ESP32 hardware smoke test for the released toit-pixel-strip package. One board emits a seven-pixel frame and the second captures it with RMT, checking GRB data and pulse timing.

The rig uses direct data and ready connections.

Tested on ESP32 and ESP32-S3.