### PR TITLE
uart: restore signal inversion

### DIFF
--- a/src/resources/uart_esp32.cc
+++ b/src/resources/uart_esp32.cc
@@ -486,6 +486,12 @@ PRIMITIVE(create) {
   err = uart_set_pin(port, tx, rx, rts, cts);
   if (err != ESP_OK) return Primitive::os_error(err, process);
 
+  uint32_t inverse_mask = 0;
+  if ((options & 1) != 0) inverse_mask |= UART_SIGNAL_TXD_INV;
+  if ((options & 2) != 0) inverse_mask |= UART_SIGNAL_RXD_INV;
+  err = uart_set_line_inverse(port, inverse_mask);
+  if (err != ESP_OK) return Primitive::os_error(err, process);
+
   // Newer ESP-IDF's `uart_set_pin` no longer enables an internal pull-up on the
   // RX pin (older versions did `GPIO_PULLUP_ONLY`). Without it the RX line
   // floats while the peer isn't driving and dips below the logic threshold,

--- a/tests/hw/esp32/pixel-strip-board1.toit
+++ b/tests/hw/esp32/pixel-strip-board1.toit
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the tests/LICENSE file.
 
-// ARG: rmt
+// ARG: rmt uart
 
 import expect show *
 import gpio
@@ -13,14 +13,24 @@ import .test
 
 main args:
   run-test:
-    expect-equals "rmt" args[0]
+    backend := args[0]
+    expect (["rmt", "uart"].contains backend)
 
     ready := gpio.Pin READY-PIN --input --pull-down
-    strip := PixelStrip.rmt PIXELS --pin=DATA-PIN
+    strip/PixelStrip := ?
+    if backend == "rmt":
+      strip = PixelStrip.rmt PIXELS --pin=DATA-PIN
+    else:
+      strip = PixelStrip.uart PIXELS --pin=DATA-PIN
 
     try:
-      ready.wait-for 1
-      strip.output RED GREEN BLUE
+      3.repeat:
+        ready.wait-for 1
+        strip.output RED GREEN BLUE
+        // UART output is buffered. Give it time to reach the wire before the
+        //   next frame or close tears down the peripheral.
+        sleep --ms=1
+        ready.wait-for 0
     finally:
       strip.close
       ready.close

--- a/tests/hw/esp32/pixel-strip-board2.toit
+++ b/tests/hw/esp32/pixel-strip-board2.toit
@@ -8,8 +8,9 @@ import rmt
 import .pixel-strip-shared
 import .test
 
-main _:
+main args:
   run-test:
+    backend := args[0]
     input := rmt.In
         DATA-PIN
         --memory-blocks=RMT-MEMORY-BLOCKS
@@ -17,10 +18,13 @@ main _:
     ready := gpio.Pin READY-PIN --output
 
     try:
-      input.start-reading --max-ns=50_000
-      ready.set 1
-      signals := input.wait-for-data
-      validate-capture signals
+      3.repeat:
+        input.start-reading --max-ns=50_000
+        ready.set 1
+        signals := input.wait-for-data
+        validate-capture signals backend
+        ready.set 0
+        sleep --ms=1
     finally:
       ready.set 0
       ready.close

--- a/tests/hw/esp32/pixel-strip-shared.toit
+++ b/tests/hw/esp32/pixel-strip-shared.toit
@@ -30,26 +30,31 @@ EXPECTED-GRB ::= #[
   0x69, 0x96, 0xde,
 ]
 
-EXPECTED-BIT-COUNT ::= PIXELS * BYTES-PER-PIXEL * 8
 // The final low period turns into the RMT end marker because the line never
 //   transitions high again after the frame.
-EXPECTED-TRANSITION-COUNT ::= EXPECTED-BIT-COUNT * 2 - 1
+EXPECTED-BIT-COUNT ::= PIXELS * BYTES-PER-PIXEL * 8
 
 expect-close-to expected/int actual/int --transition/int:
   expect (expected - actual).abs <= TIMING-SLACK-TICKS
       --message="Transition $transition: expected $expected ticks, got $actual ticks"
 
-validate-capture signals/rmt.Signals:
+validate-capture signals/rmt.Signals backend/string:
   transition-count := signals.size
   while transition-count > 0 and (signals.period (transition-count - 1)) == 0:
     transition-count--
 
-  expect-equals EXPECTED-TRANSITION-COUNT transition-count
   expect signals.size > transition-count
       --message="RMT capture has no end marker"
+  expect transition-count % 2 == 1
+      --message="Pixel stream ended midway through a bit: $signals"
+
+  bit-count := (transition-count + 1) / 2
+  expect bit-count >= EXPECTED-BIT-COUNT
+      --message="Expected at least $EXPECTED-BIT-COUNT bits, got $bit-count: $signals"
+  extra-bit-count := bit-count - EXPECTED-BIT-COUNT
 
   decoded := ByteArray EXPECTED-GRB.size
-  EXPECTED-BIT-COUNT.repeat: | bit-index |
+  bit-count.repeat: | bit-index |
     high-index := bit-index * 2
     low-index := high-index + 1
     high-ticks := signals.period high-index
@@ -57,17 +62,23 @@ validate-capture signals/rmt.Signals:
     expect-equals 1 (signals.level high-index)
 
     bit := high-ticks > 10 ? 1 : 0
-    expected-high := bit == 0 ? 7 : 14
+    expected-high := backend == "rmt"
+        ? (bit == 0 ? 7 : 14)
+        : (bit == 0 ? 8 : 16)
     expect-close-to expected-high high-ticks --transition=high-index
     if low-index < transition-count:
       low-ticks := signals.period low-index
-      expected-low := bit == 0 ? 16 : 12
+      expected-low := backend == "rmt"
+          ? (bit == 0 ? 16 : 12)
+          : (bit == 0 ? 16 : 8)
       expect-equals 0 (signals.level low-index)
       expect-close-to expected-low low-ticks --transition=low-index
 
-    byte-index := bit-index / 8
-    bit-offset := 7 - bit-index % 8
-    decoded[byte-index] |= bit << bit-offset
+    if bit-index >= extra-bit-count:
+      expected-bit-index := bit-index - extra-bit-count
+      byte-index := expected-bit-index / 8
+      bit-offset := 7 - expected-bit-index % 8
+      decoded[byte-index] |= bit << bit-offset
 
   expect-bytes-equal EXPECTED-GRB decoded
 


### PR DESCRIPTION
Stacked on #3124.

Restores application of the UART TX/RX inversion options after configuring the pins. The regression was exposed by extending the pixel-strip hardware smoke test to UART.

The test now sends three consecutive frames, validates all pulse timings, and compares the final requested pixel bits so harmless leading encoded padding is accepted.

Tested with RMT and UART on ESP32 and ESP32-S3.