### PR TITLE
rmt: expose DMA-backed channels

### DIFF
--- a/lib/rmt.toit
+++ b/lib/rmt.toit
@@ -23,6 +23,9 @@ The ESP32P4, ESP32S2 and ESP32S3 each have 4 TX and 4 RX channels.
 The number of bytes per memory block is 256 on the ESP32 and ESP32S2. It is
   192 on the ESP32C3, ESP32C6, ESP32P4, and ESP32S3.
 
+RMT DMA is available on the ESP32P4 and ESP32S3. DMA-capable channels consume
+  an internal DMA channel and internal RAM, so DMA is disabled by default.
+
 # Examples
 
 ## Pulse
@@ -701,6 +704,9 @@ On the ESP32C3, ESP32C6, ESP32P4, and ESP32S3 it is 192.
 */
 BYTES-PER-MEMORY-BLOCK/int ::= rmt-bytes-per-memory-block_
 
+/** Whether this ESP32 variant supports RMT channels backed by DMA. */
+DMA-SUPPORTED/bool ::= rmt-supports-dma_
+
 /**
 An RMT channel.
 */
@@ -773,6 +779,9 @@ class In extends Channel_:
   /** The number of memory-blocks. */
   memory-blocks_/int
 
+  /** Whether this channel uses DMA. */
+  dma/bool
+
   /**
   Constructs an input channel on the given $pin.
 
@@ -782,13 +791,15 @@ class In extends Channel_:
   The $resolution is the frequency of the clock that the RMT controller uses to
     sample the input signal. It ranges from 312500Hz (312.5KHz) to 80000000Hz (80MHz).
 
-  The $memory-blocks parameter specifies how many RMT memory blocks are assigned to this channel.
-    Each memory-block has $BYTES-PER-MEMORY-BLOCK bytes. They are in continuous memory and
-    there are only a limited number of them. Since each signal is 2 bytes long, the number of
-    signals that can be received is $memory-blocks * $BYTES-PER-MEMORY-BLOCK / 2.
+  The $memory-blocks parameter specifies the receive capacity in units of RMT
+    memory blocks. Each unit has $BYTES-PER-MEMORY-BLOCK bytes. Since each signal
+    is 2 bytes long, the number of signals that can be received is
+    $memory-blocks * $BYTES-PER-MEMORY-BLOCK / 2.
 
-  Input channels can only receive as many signals (in one sequence) as there is space
-    in the memory blocks.
+  If $dma is false, these are dedicated hardware memory blocks and only a small
+    number are available. If $dma is true, $memory-blocks instead sizes an
+    internal-RAM DMA buffer and can be much larger. DMA is only supported on
+    some chips, including the ESP32P4 and ESP32S3.
 
   Passing a $gpio.Pin as $pin is deprecated; provide the integer GPIO number
     instead. The $gpio.Pin form will be removed in a future release.
@@ -797,14 +808,22 @@ class In extends Channel_:
   // __TYPE-MIGRATION__ pin: int
   constructor pin/any
       --resolution/int
-      --memory-blocks/int=1:
+      --memory-blocks/int=1
+      --.dma/bool=false:
     if not 1 <= memory-blocks: throw "INVALID_ARGUMENT"
 
     this.resolution = resolution
     memory-blocks_ = memory-blocks
     // Each hw symbol is 4 bytes (2 signals).
     hw-symbols := (memory-blocks * BYTES-PER-MEMORY-BLOCK) >> 2
-    resource := rmt-channel-new_ resource-group_ (gpio.to-pin-num_ pin) resolution hw-symbols Channel_.CHANNEL-KIND-INPUT_ false
+    resource := rmt-channel-new_
+        resource-group_
+        (gpio.to-pin-num_ pin)
+        resolution
+        hw-symbols
+        Channel_.CHANNEL-KIND-INPUT_
+        false
+        dma
     super.from-sub_ resource
 
   /** Closes the channel. */
@@ -902,12 +921,16 @@ class Out extends Channel_:
     emit the output signal. It ranges from 312500Hz (312.5KHz) to 80000000Hz (80MHz). Signals
     are specified in ticks of this frequency.
 
-  The $memory-blocks parameter specifies how many RMT memory blocks are assigned to this channel.
-    Each memory-block has $BYTES-PER-MEMORY-BLOCK bytes. They are in continuous memory and
-    there are only a limited number of them. Since each signal is 2 bytes long, the number of
-    signals that can be stored in each block is $memory-blocks * $BYTES-PER-MEMORY-BLOCK / 2.
+  The $memory-blocks parameter specifies the channel buffer capacity in units of
+    RMT memory blocks. Each unit has $BYTES-PER-MEMORY-BLOCK bytes. Since each
+    signal is 2 bytes long, the number of signals that can be stored in each
+    block is $memory-blocks * $BYTES-PER-MEMORY-BLOCK / 2.
   Generally, output channels don't need extra blocks as interrupts will copy data into
     the buffer when necessary.
+
+  If $dma is true, $memory-blocks sizes an internal-RAM DMA buffer instead of
+    allocating dedicated RMT memory blocks. DMA is only supported on some chips,
+    including the ESP32P4 and ESP32S3, and consumes an internal DMA channel.
 
   If $open-drain is set and $pull-up is true, the internal pull-up resistor is enabled.
 
@@ -923,13 +946,21 @@ class Out extends Channel_:
       --resolution/int
       --memory-blocks/int=1
       --open-drain/bool=false
-      --pull-up/bool=false:
+      --pull-up/bool=false
+      --dma/bool=false:
     if not 1 <= memory-blocks: throw "INVALID_ARGUMENT"
 
     // Each hw symbol is 4 bytes (2 signals).
     hw-symbols := (memory-blocks * BYTES-PER-MEMORY-BLOCK) >> 2
     kind := open-drain ? Channel_.CHANNEL-KIND-OUTPUT-OPEN-DRAIN_ : Channel_.CHANNEL-KIND-OUTPUT_
-    resource := rmt-channel-new_ resource-group_ (gpio.to-pin-num_ pin) resolution hw-symbols kind pull-up
+    resource := rmt-channel-new_
+        resource-group_
+        (gpio.to-pin-num_ pin)
+        resolution
+        hw-symbols
+        kind
+        pull-up
+        dma
     // For the new (integer) API the primitive applies the pull when it owns the
     // pin. For a deprecated $gpio.Pin the pin owns its own configuration.
     if open-drain and pin is gpio.Pin:
@@ -1311,10 +1342,13 @@ resource-group_ ::= rmt-init_
 rmt-bytes-per-memory-block_:
   #primitive.rmt.bytes-per-memory-block
 
+rmt-supports-dma_:
+  #primitive.rmt.supports-dma
+
 rmt-init_:
   #primitive.rmt.init
 
-rmt-channel-new_ resource-group pin-num/int resolution/int symbols/int kind/int pull-up/bool:
+rmt-channel-new_ resource-group pin-num/int resolution/int symbols/int kind/int pull-up/bool with-dma/bool:
   #primitive.rmt.channel-new
 
 rmt-channel-delete_ resource-group resource:

--- a/src/compiler/propagation/type_primitive_rmt.cc
+++ b/src/compiler/propagation/type_primitive_rmt.cc
@@ -21,6 +21,7 @@ namespace compiler {
 MODULE_TYPES(rmt, MODULE_RMT)
 
 TYPE_PRIMITIVE_INT(bytes_per_memory_block)
+TYPE_PRIMITIVE_BOOL(supports_dma)
 TYPE_PRIMITIVE_ANY(init)
 TYPE_PRIMITIVE_ANY(channel_new)
 TYPE_PRIMITIVE_ANY(channel_delete)

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -481,8 +481,9 @@ namespace toit {
 
 #define MODULE_RMT(PRIMITIVE)                \
   PRIMITIVE(bytes_per_memory_block, 0)       \
+  PRIMITIVE(supports_dma, 0)                 \
   PRIMITIVE(init, 0)                         \
-  PRIMITIVE(channel_new, 6)                  \
+  PRIMITIVE(channel_new, 7)                  \
   PRIMITIVE(channel_delete, 2)               \
   PRIMITIVE(enable, 1)                       \
   PRIMITIVE(disable, 1)                      \

--- a/src/resources/rmt_esp32.cc
+++ b/src/resources/rmt_esp32.cc
@@ -167,17 +167,20 @@ class RmtResource : public EventQueueResource {
   RmtResource(RmtResourceGroup* group,
               rmt_channel_handle_t handle,
               bool is_tx,
+              bool with_dma,
               RmtInOut* in_out,
               QueueHandle_t queue)
       : EventQueueResource(group, queue)
       , handle_(handle)
       , is_tx_(is_tx)
+      , with_dma_(with_dma)
       , in_out_(in_out) {}
 
   ~RmtResource() override;
 
   rmt_channel_handle_t handle() const { return handle_; }
   bool is_tx() const { return is_tx_; }
+  bool with_dma() const { return with_dma_; }
 
   GpioPins& owned_pins() { return owned_pins_; }
 
@@ -202,6 +205,7 @@ class RmtResource : public EventQueueResource {
   rmt_channel_handle_t handle_;
   State state_ = DISABLED;
   bool is_tx_;
+  bool with_dma_;
   RmtInOut* in_out_;
   // GPIO pins reserved by this channel. Empty when the pin was provided as a
   // (deprecated) gpio.Pin that owns its own reservation.
@@ -643,6 +647,14 @@ PRIMITIVE(bytes_per_memory_block) {
   return Smi::from(SOC_RMT_MEM_WORDS_PER_CHANNEL * sizeof(word));
 }
 
+PRIMITIVE(supports_dma) {
+#ifdef SOC_RMT_SUPPORT_DMA
+  return BOOL(SOC_RMT_SUPPORT_DMA);
+#else
+  return process->false_object();
+#endif
+}
+
 PRIMITIVE(init) {
   ByteArray* proxy = process->object_heap()->allocate_proxy();
   if (proxy == null) FAIL(ALLOCATION_FAILED);
@@ -655,7 +667,7 @@ PRIMITIVE(init) {
 }
 
 PRIMITIVE(channel_new) {
-  ARGS(RmtResourceGroup, resource_group, int, pin_num, uint32, resolution, uint32, block_symbols, int, kind, bool, pull_up)
+  ARGS(RmtResourceGroup, resource_group, int, pin_num, uint32, resolution, uint32, block_symbols, int, kind, bool, pull_up, bool, with_dma)
 
   if (block_symbols == 0) FAIL(INVALID_ARGUMENT);
 
@@ -709,7 +721,7 @@ PRIMITIVE(channel_new) {
       .intr_priority = 0,
       .flags = {
         .invert_out = false,
-        .with_dma = false,
+        .with_dma = with_dma,
         .io_loop_back = true,
         .io_od_mode = open_drain,
         .allow_pd = false,
@@ -726,7 +738,7 @@ PRIMITIVE(channel_new) {
       .intr_priority = 0,
       .flags = {
         .invert_in = false,
-        .with_dma = false,
+        .with_dma = with_dma,
         .io_loop_back = false,
         .allow_pd = false,
       },
@@ -738,7 +750,7 @@ PRIMITIVE(channel_new) {
   if (err != ESP_OK) return Primitive::os_error(err, process);
   Defer delete_channel { [&] { if (!handed_to_resource) rmt_del_channel(handle); } };
 
-  RmtResource* resource = new (resource_memory) RmtResource(resource_group, handle, is_tx, in_out, queue);
+  RmtResource* resource = new (resource_memory) RmtResource(resource_group, handle, is_tx, with_dma, in_out, queue);
   handed_to_resource = true;
 
   if (is_tx) {
@@ -939,8 +951,16 @@ PRIMITIVE(start_receive) {
 
   bool successful_return = false;
 
-  const int caps_flags = RMT_MEM_ALLOC_CAPS;
-  uint8* buffer = unvoid_cast<uint8*>(heap_caps_malloc(max_size, caps_flags));
+  int caps_flags = RMT_MEM_ALLOC_CAPS;
+  uint8* buffer;
+  if (resource->with_dma()) {
+    caps_flags |= MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA;
+    // The DMA alignment requirement is chip-specific. The supported RMT DMA
+    // chips require at most a 64-byte aligned internal buffer.
+    buffer = unvoid_cast<uint8*>(heap_caps_aligned_alloc(64, max_size, caps_flags));
+  } else {
+    buffer = unvoid_cast<uint8*>(heap_caps_malloc(max_size, caps_flags));
+  }
   if (buffer == null) FAIL(MALLOC_FAILED);
   in->set_buffer(buffer);
   in->set_received(-1);

--- a/tests/hw/esp32/pixel-strip-board1.toit
+++ b/tests/hw/esp32/pixel-strip-board1.toit
@@ -29,7 +29,7 @@ main args:
         strip.output RED GREEN BLUE
         // UART output is buffered. Give it time to reach the wire before the
         //   next frame or close tears down the peripheral.
-        sleep --ms=1
+        sleep --ms=10
         ready.wait-for 0
     finally:
       strip.close

--- a/tests/hw/esp32/pixel-strip-board2.toit
+++ b/tests/hw/esp32/pixel-strip-board2.toit
@@ -15,6 +15,7 @@ main args:
         DATA-PIN
         --memory-blocks=RMT-MEMORY-BLOCKS
         --resolution=RESOLUTION
+        --dma=rmt.DMA-SUPPORTED
     ready := gpio.Pin READY-PIN --output
 
     try:

--- a/tests/hw/esp32/pixel-strip-shared.toit
+++ b/tests/hw/esp32/pixel-strip-shared.toit
@@ -7,32 +7,37 @@ import rmt
 
 import .variants
 
-PIXELS ::= 7
 BYTES-PER-PIXEL ::= 3
 RESOLUTION ::= 20_000_000
 TIMING-SLACK-TICKS ::= 3
 
 DATA-PIN ::= Variant.CURRENT.pixel-strip-data-pin
 READY-PIN ::= Variant.CURRENT.pixel-strip-ready-pin
-RMT-MEMORY-BLOCKS ::= Variant.CURRENT.rmt-in-channel-count
+BASE-RED ::= #[0x00, 0xff, 0x80, 0x01, 0xaa, 0x55, 0x96]
+BASE-GREEN ::= #[0xff, 0x00, 0x7f, 0xfe, 0x55, 0xaa, 0x69]
+BASE-BLUE ::= #[0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde]
 
-RED ::= #[0x00, 0xff, 0x80, 0x01, 0xaa, 0x55, 0x96]
-GREEN ::= #[0xff, 0x00, 0x7f, 0xfe, 0x55, 0xaa, 0x69]
-BLUE ::= #[0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde]
+// Classic ESP32 RMT input has no DMA. Keep its test within dedicated RMT
+//   memory, while DMA-capable variants exercise a frame that requires
+//   peripheral rebuffering in every pixel-strip backend.
+PIXELS ::= rmt.DMA-SUPPORTED ? 200 : BASE-RED.size
 
-EXPECTED-GRB ::= #[
-  0xff, 0x00, 0x12,
-  0x00, 0xff, 0x34,
-  0x7f, 0x80, 0x56,
-  0xfe, 0x01, 0x78,
-  0x55, 0xaa, 0x9a,
-  0xaa, 0x55, 0xbc,
-  0x69, 0x96, 0xde,
-]
+RED ::= ByteArray PIXELS: BASE-RED[it % BASE-RED.size]
+GREEN ::= ByteArray PIXELS: BASE-GREEN[it % BASE-GREEN.size]
+BLUE ::= ByteArray PIXELS: BASE-BLUE[it % BASE-BLUE.size]
+
+EXPECTED-GRB ::= ByteArray PIXELS * BYTES-PER-PIXEL:
+  pixel-index := it / BYTES-PER-PIXEL
+  component := it % BYTES-PER-PIXEL
+  component == 0
+      ? GREEN[pixel-index]
+      : component == 1 ? RED[pixel-index] : BLUE[pixel-index]
 
 // The final low period turns into the RMT end marker because the line never
 //   transitions high again after the frame.
 EXPECTED-BIT-COUNT ::= PIXELS * BYTES-PER-PIXEL * 8
+RMT-CAPTURE-BYTES ::= EXPECTED-BIT-COUNT * 2 * rmt.Signals.BYTES-PER-SIGNAL
+RMT-MEMORY-BLOCKS ::= (RMT-CAPTURE-BYTES + rmt.BYTES-PER-MEMORY-BLOCK - 1) / rmt.BYTES-PER-MEMORY-BLOCK
 
 expect-close-to expected/int actual/int --transition/int:
   expect (expected - actual).abs <= TIMING-SLACK-TICKS
@@ -46,11 +51,11 @@ validate-capture signals/rmt.Signals backend/string:
   expect signals.size > transition-count
       --message="RMT capture has no end marker"
   expect transition-count % 2 == 1
-      --message="Pixel stream ended midway through a bit: $signals"
+      --message="Pixel stream ended midway through a bit"
 
   bit-count := (transition-count + 1) / 2
   expect bit-count >= EXPECTED-BIT-COUNT
-      --message="Expected at least $EXPECTED-BIT-COUNT bits, got $bit-count: $signals"
+      --message="Expected at least $EXPECTED-BIT-COUNT bits, got $bit-count"
   extra-bit-count := bit-count - EXPECTED-BIT-COUNT
 
   decoded := ByteArray EXPECTED-GRB.size

--- a/tests/hw/esp32/rmt-dma-test.toit
+++ b/tests/hw/esp32/rmt-dma-test.toit
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+import rmt
+
+import .test
+import .variants
+
+RESOLUTION ::= 20_000_000
+PERIOD ::= 10
+
+// This is the number of transitions required for a 200-pixel RGBW frame. The
+//   odd count ensures that the transmitter finishes high, creating a final
+//   falling edge before the RMT end marker.
+SIGNAL-COUNT ::= 200 * 4 * 8 * 2 - 1
+CAPTURE-SIGNAL-COUNT ::= SIGNAL-COUNT + 1
+CAPTURE-BYTES ::= CAPTURE-SIGNAL-COUNT * rmt.Signals.BYTES-PER-SIGNAL
+RX-MEMORY-BLOCKS ::= (CAPTURE-BYTES + rmt.BYTES-PER-MEMORY-BLOCK - 1) / rmt.BYTES-PER-MEMORY-BLOCK
+
+test-long-dma-capture --tx-dma/bool:
+  pin-in := Variant.CURRENT.rmt-pin1
+  pin-out := Variant.CURRENT.rmt-pin2
+
+  input := rmt.In
+      pin-in
+      --resolution=RESOLUTION
+      --memory-blocks=RX-MEMORY-BLOCKS
+      --dma
+  output := rmt.Out
+      pin-out
+      --resolution=RESOLUTION
+      --memory-blocks=(tx-dma ? 8 : 1)
+      --dma=tx-dma
+  signals := rmt.Signals.alternating SIGNAL-COUNT --first-level=1: PERIOD
+
+  try:
+    input.start-reading --min-ns=1 --max-ns=50_000
+    output.write signals --done-level=0
+    captured := input.wait-for-data
+
+    expect-equals CAPTURE-SIGNAL-COUNT captured.size
+    SIGNAL-COUNT.repeat:
+      expect-equals PERIOD (captured.period it)
+      expect-equals (1 - it % 2) (captured.level it)
+    expect-equals 0 (captured.period SIGNAL-COUNT)
+  finally:
+    output.close
+    input.close
+
+main:
+  run-test:
+    if rmt.DMA-SUPPORTED:
+      // First isolate RX DMA behind an ordinary RMT transmitter, then exercise
+      //   TX and RX DMA together across many DMA-buffer boundaries.
+      test-long-dma-capture --no-tx-dma
+      test-long-dma-capture --tx-dma


### PR DESCRIPTION
Adds opt-in DMA-backed RMT input and output channels, exposes runtime capability detection, and allocates DMA-capable aligned receive buffers. Extends the pixel-strip hardware test to capture 200 RGB pixels on ESP32-S3 and adds an independent 25.6 KB RMT DMA transition test.\n\nHardware validation:\n- ESP32-S3: ordinary TX -> DMA RX, DMA TX -> DMA RX\n- ESP32-S3: 200-pixel RMT and UART package output, three frames each\n- ESP32: 7-pixel RMT and UART fallback tests\n- ESP32 and ESP32-S3 firmware builds\n- Toit analyzer with warnings as errors