### PR TITLE
i2s: emit silence after transmit underruns

### DIFF
--- a/src/resources/i2s_esp32.cc
+++ b/src/resources/i2s_esp32.cc
@@ -281,6 +281,9 @@ PRIMITIVE(create) {
   i2s_role_t role = is_master ? I2S_ROLE_MASTER : I2S_ROLE_SLAVE;
 
   i2s_chan_config_t channel_config = I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_AUTO, role);
+  // The DMA descriptors form a ring. Clear a transmitted buffer before the
+  // callback wakes a writer, so underruns emit silence without racing refill.
+  channel_config.auto_clear_before_cb = true;
   i2s_chan_handle_t tx_handle = null;
   i2s_chan_handle_t rx_handle = null;
   if (tx_num != -1 && rx_num != -1) {

--- a/tests/hw/esp32/i2s-underrun-test.toit
+++ b/tests/hw/esp32/i2s-underrun-test.toit
@@ -1,0 +1,69 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+import i2s
+
+import .test
+import .variants
+
+SAMPLE-RATE ::= 10_000
+SAMPLE-SIZE ::= 16
+MARKER-SIZE ::= 960
+CAPTURE-SIZE ::= 20_000
+
+main:
+  run-test:
+    output := i2s.Bus
+        --master=false
+        --tx=Variant.CURRENT.i2s-data1
+        --sck=Variant.CURRENT.i2s-clk1
+        --ws=Variant.CURRENT.i2s-ws1
+    input := i2s.Bus
+        --master
+        --rx=Variant.CURRENT.i2s-data2
+        --sck=Variant.CURRENT.i2s-clk2
+        --ws=Variant.CURRENT.i2s-ws2
+
+    try:
+      output.configure
+          --sample-rate=SAMPLE-RATE
+          --bits-per-sample=SAMPLE-SIZE
+          --format=i2s.Bus.FORMAT-PCM-SHORT
+      input.configure
+          --sample-rate=SAMPLE-RATE
+          --bits-per-sample=SAMPLE-SIZE
+          --format=i2s.Bus.FORMAT-PCM-SHORT
+
+      // One default ESP-IDF DMA descriptor. If transmitted descriptors are
+      //   not cleared before they cycle through the DMA ring, this marker
+      //   repeats and is counted several times in the capture below.
+      marker := ByteArray MARKER-SIZE: 0xff
+      expect-equals marker.size (output.preload marker)
+
+      output.start
+      input.start
+
+      buffer := ByteArray 2_048
+      received := 0
+      nonzero := 0
+      while received < CAPTURE-SIZE:
+        count := input.read buffer
+        remaining := CAPTURE-SIZE - received
+        if count > remaining: count = remaining
+        count.repeat:
+          if buffer[it] != 0: nonzero++
+        received += count
+
+      while (output.errors --underrun) == 0:
+        sleep --ms=10
+
+      // Classic ESP32 can lose the first stereo frame while the master and
+      //   slave start. The upper bound is what detects stale DMA replay.
+      expect nonzero >= MARKER-SIZE - 4
+      expect nonzero <= MARKER-SIZE
+      expect-equals 0 (input.errors --overrun)
+    finally:
+      output.close
+      input.close


### PR DESCRIPTION
Configures ESP-IDF to clear each transmitted DMA buffer before notifying the Toit writer. When the producer falls behind, I2S now continues clocking zeros instead of replaying stale samples from the DMA ring.

Adds a same-board hardware regression test that preloads one 960-byte marker, captures 20 KB, and verifies that the marker occurs only once. Without this change, the marker was observed four times.

Hardware validation:
- ESP32 and ESP32-S3: independent I2S underrun regression
- ESP32 and ESP32-S3: existing continuous Philips-16 I2S test
- ESP32 and ESP32-S3: pixel-strip package I2S output using the local package fix, three frames each
- ESP32 and ESP32-S3 firmware builds
- Toit analyzer