### PR TITLE
tests: stress pixel strip DMA output

### DIFF
--- a/tests/hw/esp32/pixel-strip-board1.toit
+++ b/tests/hw/esp32/pixel-strip-board1.toit
@@ -23,10 +23,14 @@ main args:
     else:
       strip = PixelStrip.uart PIXELS --pin=DATA-PIN
 
+    red := ByteArray PIXELS
+    green := ByteArray PIXELS
+    blue := ByteArray PIXELS
     try:
-      3.repeat:
+      FRAME-COUNT.repeat: | frame |
         ready.wait-for 1
-        strip.output RED GREEN BLUE
+        fill-frame frame red green blue
+        strip.output red green blue
         // UART output is buffered. Give it time to reach the wire before the
         //   next frame or close tears down the peripheral.
         sleep --ms=10

--- a/tests/hw/esp32/pixel-strip-board2.toit
+++ b/tests/hw/esp32/pixel-strip-board2.toit
@@ -19,11 +19,11 @@ main args:
     ready := gpio.Pin READY-PIN --output
 
     try:
-      3.repeat:
+      FRAME-COUNT.repeat: | frame |
         input.start-reading --max-ns=50_000
         ready.set 1
         signals := input.wait-for-data
-        validate-capture signals backend
+        validate-capture signals backend frame
         ready.set 0
         sleep --ms=1
     finally:

--- a/tests/hw/esp32/pixel-strip-shared.toit
+++ b/tests/hw/esp32/pixel-strip-shared.toit
@@ -8,30 +8,40 @@ import rmt
 import .variants
 
 BYTES-PER-PIXEL ::= 3
+FRAME-COUNT ::= 8
 RESOLUTION ::= 20_000_000
 TIMING-SLACK-TICKS ::= 3
 
 DATA-PIN ::= Variant.CURRENT.pixel-strip-data-pin
 READY-PIN ::= Variant.CURRENT.pixel-strip-ready-pin
-BASE-RED ::= #[0x00, 0xff, 0x80, 0x01, 0xaa, 0x55, 0x96]
-BASE-GREEN ::= #[0xff, 0x00, 0x7f, 0xfe, 0x55, 0xaa, 0x69]
-BASE-BLUE ::= #[0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde]
 
 // Classic ESP32 RMT input has no DMA. Keep its test within dedicated RMT
-//   memory, while DMA-capable variants exercise a frame that requires
-//   peripheral rebuffering in every pixel-strip backend.
-PIXELS ::= rmt.DMA-SUPPORTED ? 200 : BASE-RED.size
+//   memory, while DMA-capable variants exercise a 1,000-pixel frame that
+//   requires peripheral rebuffering in every pixel-strip backend.
+PIXELS ::= rmt.DMA-SUPPORTED ? 1_000 : 7
 
-RED ::= ByteArray PIXELS: BASE-RED[it % BASE-RED.size]
-GREEN ::= ByteArray PIXELS: BASE-GREEN[it % BASE-GREEN.size]
-BLUE ::= ByteArray PIXELS: BASE-BLUE[it % BASE-BLUE.size]
+red-value pixel/int frame/int -> int:
+  return (pixel * 17 + frame * 29 + 1) & 0xff
 
-EXPECTED-GRB ::= ByteArray PIXELS * BYTES-PER-PIXEL:
-  pixel-index := it / BYTES-PER-PIXEL
-  component := it % BYTES-PER-PIXEL
-  component == 0
-      ? GREEN[pixel-index]
-      : component == 1 ? RED[pixel-index] : BLUE[pixel-index]
+green-value pixel/int frame/int -> int:
+  return (pixel * 31 + frame * 13 + 0x55) & 0xff
+
+blue-value pixel/int frame/int -> int:
+  return (pixel * 7 + frame * 47 + 0xaa) & 0xff
+
+fill-frame frame/int red/ByteArray green/ByteArray blue/ByteArray -> none:
+  PIXELS.repeat: | pixel |
+    red[pixel] = red-value pixel frame
+    green[pixel] = green-value pixel frame
+    blue[pixel] = blue-value pixel frame
+
+expected-grb frame/int -> ByteArray:
+  return ByteArray PIXELS * BYTES-PER-PIXEL:
+    pixel := it / BYTES-PER-PIXEL
+    component := it % BYTES-PER-PIXEL
+    component == 0
+        ? green-value pixel frame
+        : component == 1 ? red-value pixel frame : blue-value pixel frame
 
 // The final low period turns into the RMT end marker because the line never
 //   transitions high again after the frame.
@@ -43,7 +53,7 @@ expect-close-to expected/int actual/int --transition/int:
   expect (expected - actual).abs <= TIMING-SLACK-TICKS
       --message="Transition $transition: expected $expected ticks, got $actual ticks"
 
-validate-capture signals/rmt.Signals backend/string:
+validate-capture signals/rmt.Signals backend/string frame/int:
   transition-count := signals.size
   while transition-count > 0 and (signals.period (transition-count - 1)) == 0:
     transition-count--
@@ -58,7 +68,8 @@ validate-capture signals/rmt.Signals backend/string:
       --message="Expected at least $EXPECTED-BIT-COUNT bits, got $bit-count"
   extra-bit-count := bit-count - EXPECTED-BIT-COUNT
 
-  decoded := ByteArray EXPECTED-GRB.size
+  expected := expected-grb frame
+  decoded := ByteArray expected.size
   bit-count.repeat: | bit-index |
     high-index := bit-index * 2
     low-index := high-index + 1
@@ -85,7 +96,7 @@ validate-capture signals/rmt.Signals backend/string:
       bit-offset := 7 - expected-bit-index % 8
       decoded[byte-index] |= bit << bit-offset
 
-  expect-bytes-equal EXPECTED-GRB decoded
+  expect-bytes-equal expected decoded
 
   signals.size.repeat: | index |
     if index >= transition-count:

--- a/tests/hw/esp32/rmt-dma-test.toit
+++ b/tests/hw/esp32/rmt-dma-test.toit
@@ -10,11 +10,12 @@ import .variants
 
 RESOLUTION ::= 20_000_000
 PERIOD ::= 10
+PIXELS ::= 1_000
 
-// This is the number of transitions required for a 200-pixel RGBW frame. The
+// This is the number of transitions required for a 1,000-pixel RGBW frame. The
 //   odd count ensures that the transmitter finishes high, creating a final
 //   falling edge before the RMT end marker.
-SIGNAL-COUNT ::= 200 * 4 * 8 * 2 - 1
+SIGNAL-COUNT ::= PIXELS * 4 * 8 * 2 - 1
 CAPTURE-SIGNAL-COUNT ::= SIGNAL-COUNT + 1
 CAPTURE-BYTES ::= CAPTURE-SIGNAL-COUNT * rmt.Signals.BYTES-PER-SIGNAL
 RX-MEMORY-BLOCKS ::= (CAPTURE-BYTES + rmt.BYTES-PER-MEMORY-BLOCK - 1) / rmt.BYTES-PER-MEMORY-BLOCK


### PR DESCRIPTION
## Summary

- expand the raw RMT DMA test to a 1,000-pixel RGBW-equivalent stream (64,000 transitions / 128 KB capture)
- exercise the pixel-strip package with eight changing frames, like an animation rather than repeated static output
- use 1,000 RGB pixels on DMA-capable ESP32-S3 boards while retaining the seven-pixel classic ESP32 smoke test
- validate the last complete frame bits so backends may emit permitted leading data

## Testing

- `rmt-dma-test.toit-esp32s3`
- `pixel-strip-board1.toit-esp32s3-rmt`
- `pixel-strip-board1.toit-esp32s3-uart`
- `pixel-strip-board1.toit-esp32-rmt`
- `pixel-strip-board1.toit-esp32-uart`
- Toit analyzer with warnings as errors for the changed test programs

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
