### PR TITLE
feat(formatter): add token-order-preserving layout plans

### DIFF
--- a/src/compiler/format_layout.cc
+++ b/src/compiler/format_layout.cc
@@ -1,0 +1,369 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#include "../top.h"
+
+#include "format_layout.h"
+
+#include <limits>
+#include <utility>
+
+namespace toit {
+namespace compiler {
+
+Layout* LayoutBuilder::allocate(Layout::Kind kind) {
+  layouts_.push_back(std::unique_ptr<Layout>(new Layout(kind)));
+  return layouts_.back().get();
+}
+
+Layout* LayoutBuilder::text(const std::string& text) {
+  ASSERT(text.find('\n') == std::string::npos);
+  Layout* result = allocate(Layout::TEXT);
+  result->text_ = text;
+  return result;
+}
+
+Layout* LayoutBuilder::concat(std::vector<Layout*> children) {
+  Layout* result = allocate(Layout::CONCAT);
+  result->children_ = std::move(children);
+  return result;
+}
+
+Layout* LayoutBuilder::group(Layout* child) {
+  ASSERT(child != null);
+  Layout* result = allocate(Layout::GROUP);
+  result->child_ = child;
+  return result;
+}
+
+Layout* LayoutBuilder::indent(int spaces, Layout* child) {
+  ASSERT(spaces >= 0);
+  ASSERT(child != null);
+  Layout* result = allocate(Layout::INDENT);
+  result->indentation_ = spaces;
+  result->child_ = child;
+  return result;
+}
+
+LayoutGap LayoutBuilder::gap() { return LayoutGap(next_gap_++); }
+
+Layout* LayoutBuilder::line(const std::string& flat_separator) {
+  return line(gap(), flat_separator);
+}
+
+Layout* LayoutBuilder::line(LayoutGap gap, const std::string& flat_separator) {
+  ASSERT(gap.is_valid());
+  ASSERT(flat_separator.find('\n') == std::string::npos);
+  Layout* result = allocate(Layout::LINE);
+  result->text_ = flat_separator;
+  result->gap_ = gap;
+  return result;
+}
+
+Layout* LayoutBuilder::space(LayoutGap gap, const std::string& separator) {
+  ASSERT(gap.is_valid());
+  ASSERT(separator.find('\n') == std::string::npos);
+  Layout* result = allocate(Layout::SPACE);
+  result->text_ = separator;
+  result->gap_ = gap;
+  return result;
+}
+
+Layout* LayoutBuilder::hardline() { return allocate(Layout::HARDLINE); }
+
+LayoutMarker LayoutBuilder::marker() { return LayoutMarker(next_marker_++); }
+
+Layout* LayoutBuilder::mark(LayoutMarker marker) {
+  ASSERT(marker.is_valid());
+  Layout* result = allocate(Layout::MARK);
+  result->marker_ = marker;
+  return result;
+}
+
+class LayoutSelector {
+ public:
+  explicit LayoutSelector(int preferred_width)
+      : preferred_width_(preferred_width < 0 ? 0 : preferred_width) {}
+
+  SelectedPlan select(Layout* root) {
+    ASSERT(root != null);
+    append(root, 0, BROKEN);
+    return std::move(result_);
+  }
+
+ private:
+  enum Mode { FLAT, BROKEN };
+
+  // HARDLINE makes a flat rendering impossible. Saturating widths at this
+  // sentinel avoids overflow; it is not a hard source width.
+  static const int INFINITE_WIDTH = std::numeric_limits<int>::max() / 4;
+
+  int preferred_width_;
+  int logical_column_ = 0;
+  SelectedPlan result_;
+  std::unordered_map<Layout*, int> flat_widths_;
+
+  static int add_width(int left, int right) {
+    if (left >= INFINITE_WIDTH || right >= INFINITE_WIDTH) {
+      return INFINITE_WIDTH;
+    }
+    if (left > INFINITE_WIDTH - right) return INFINITE_WIDTH;
+    return left + right;
+  }
+
+  int flat_width(Layout* layout) {
+    auto existing = flat_widths_.find(layout);
+    if (existing != flat_widths_.end()) return existing->second;
+
+    int result;
+    switch (layout->kind_) {
+    case Layout::TEXT:
+    case Layout::LINE:
+    case Layout::SPACE:
+      result = layout->text_.size() >= static_cast<size_t>(INFINITE_WIDTH)
+                   ? INFINITE_WIDTH
+                   : static_cast<int>(layout->text_.size());
+      break;
+    case Layout::MARK:
+      result = 0;
+      break;
+    case Layout::CONCAT:
+      result = 0;
+      for (Layout* child : layout->children_) {
+        result = add_width(result, flat_width(child));
+      }
+      break;
+    case Layout::GROUP:
+    case Layout::INDENT:
+      result = flat_width(layout->child_);
+      break;
+    case Layout::HARDLINE:
+      result = INFINITE_WIDTH;
+      break;
+    default:
+      UNREACHABLE();
+    }
+    flat_widths_[layout] = result;
+    return result;
+  }
+
+  void append_text(const std::string& text) {
+    SelectedPlan::Event event;
+    event.kind = SelectedPlan::Event::TEXT;
+    event.text = text;
+    result_.events_.push_back(std::move(event));
+    int width = text.size() >= static_cast<size_t>(INFINITE_WIDTH)
+                    ? INFINITE_WIDTH
+                    : static_cast<int>(text.size());
+    logical_column_ = add_width(logical_column_, width);
+  }
+
+  void append_gap(LayoutGap gap, const std::string& text, int indentation,
+                  bool newline, bool can_flat, bool can_newline) {
+    SelectedPlan::Event event;
+    event.kind = SelectedPlan::Event::GAP;
+    event.text = text;
+    event.indentation = indentation;
+    event.newline = newline;
+    event.can_flat = can_flat;
+    event.can_newline = can_newline;
+    event.gap = gap;
+    int index = result_.events_.size();
+    result_.events_.push_back(std::move(event));
+    if (gap.is_valid()) {
+      if (gap.id_ >= static_cast<int>(result_.gap_indices_.size())) {
+        result_.gap_indices_.resize(gap.id_ + 1, -1);
+      }
+      ASSERT(result_.gap_indices_[gap.id_] == -1);
+      result_.gap_indices_[gap.id_] = index;
+    }
+    if (newline) {
+      logical_column_ = indentation;
+    } else {
+      int width = text.size() >= static_cast<size_t>(INFINITE_WIDTH)
+                      ? INFINITE_WIDTH
+                      : static_cast<int>(text.size());
+      logical_column_ = add_width(logical_column_, width);
+    }
+  }
+
+  void append(Layout* layout, int indentation, Mode mode) {
+    switch (layout->kind_) {
+    case Layout::TEXT:
+      append_text(layout->text_);
+      return;
+    case Layout::CONCAT:
+      for (Layout* child : layout->children_)
+        append(child, indentation, mode);
+      return;
+    case Layout::GROUP: {
+      // A flat parent commits all descendant LINE nodes to their flat form.
+      // Otherwise nested groups could contradict the parent's width choice.
+      if (mode == FLAT) {
+        append(layout->child_, indentation, FLAT);
+        return;
+      }
+      int available = preferred_width_ - logical_column_;
+      if (available < 0) available = 0;
+      Mode child_mode = flat_width(layout->child_) <= available ? FLAT : BROKEN;
+      append(layout->child_, indentation, child_mode);
+      return;
+    }
+    case Layout::INDENT:
+      append(layout->child_, indentation + layout->indentation_, mode);
+      return;
+    case Layout::LINE:
+      append_gap(layout->gap_, layout->text_, indentation, mode == BROKEN, true,
+                 true);
+      return;
+    case Layout::SPACE:
+      append_gap(layout->gap_, layout->text_, indentation, false, true, true);
+      return;
+    case Layout::HARDLINE:
+      append_gap(LayoutGap(), "", indentation, true, false, true);
+      return;
+    case Layout::MARK: {
+      SelectedPlan::Event event;
+      event.kind = SelectedPlan::Event::MARK;
+      event.marker = layout->marker_;
+      int index = result_.events_.size();
+      result_.events_.push_back(std::move(event));
+      if (layout->marker_.id_ >=
+          static_cast<int>(result_.marker_indices_.size())) {
+        result_.marker_indices_.resize(layout->marker_.id_ + 1, -1);
+      }
+      ASSERT(result_.marker_indices_[layout->marker_.id_] == -1);
+      result_.marker_indices_[layout->marker_.id_] = index;
+      return;
+    }
+    default:
+      UNREACHABLE();
+    }
+  }
+};
+
+const int LayoutSelector::INFINITE_WIDTH;
+
+int SelectedPlan::marker_index(LayoutMarker marker) const {
+  ASSERT(marker.is_valid());
+  ASSERT(marker.id_ < static_cast<int>(marker_indices_.size()));
+  int index = marker_indices_[marker.id_];
+  ASSERT(index >= 0);
+  return index;
+}
+
+const SelectedPlan::Event& SelectedPlan::gap_event(LayoutGap gap) const {
+  ASSERT(gap.is_valid());
+  ASSERT(gap.id_ < static_cast<int>(gap_indices_.size()));
+  int index = gap_indices_[gap.id_];
+  ASSERT(index >= 0);
+  return events_[index];
+}
+
+SelectedPlan::Event& SelectedPlan::gap_event(LayoutGap gap) {
+  return const_cast<Event&>(
+      static_cast<const SelectedPlan*>(this)->gap_event(gap));
+}
+
+int SelectedPlan::line_of(LayoutMarker marker) const {
+  int stop = marker_index(marker);
+  int line = 0;
+  for (int i = 0; i < stop; i++) {
+    if (events_[i].kind == Event::GAP && events_[i].newline) line++;
+  }
+  return line;
+}
+
+bool SelectedPlan::has_break_between(LayoutMarker first,
+                                     LayoutMarker second) const {
+  int begin = marker_index(first);
+  int end = marker_index(second);
+  ASSERT(begin <= end);
+  for (int i = begin + 1; i < end; i++) {
+    if (events_[i].kind == Event::GAP && events_[i].newline) return true;
+  }
+  return false;
+}
+
+bool SelectedPlan::can_select(LayoutGap gap, GapState state) const {
+  const Event& event = gap_event(gap);
+  ASSERT(event.kind == Event::GAP);
+  return state == GapState::FLAT ? event.can_flat : event.can_newline;
+}
+
+bool SelectedPlan::is_selected(LayoutGap gap, GapState state) const {
+  ASSERT(can_select(gap, state));
+  return gap_event(gap).newline == (state == GapState::NEWLINE);
+}
+
+FinalPlan SelectedPlan::freeze() && { return FinalPlan(std::move(*this)); }
+
+void PlanInsertions::insert_before(LayoutMarker marker,
+                                   const std::string& text) {
+  ASSERT(marker.is_valid());
+  ASSERT(text.find('\n') == std::string::npos);
+  insertions_[marker.id_].before.push_back(text);
+}
+
+void PlanInsertions::insert_after(LayoutMarker marker,
+                                  const std::string& text) {
+  ASSERT(marker.is_valid());
+  ASSERT(text.find('\n') == std::string::npos);
+  insertions_[marker.id_].after.push_back(text);
+}
+
+const PlanInsertions::AtMarker* PlanInsertions::at(LayoutMarker marker) const {
+  auto found = insertions_.find(marker.id_);
+  return found == insertions_.end() ? null : &found->second;
+}
+
+SelectedPlan select_layout(Layout* root, int preferred_width) {
+  return LayoutSelector(preferred_width).select(root);
+}
+
+std::string render_plan(const FinalPlan& plan,
+                        const PlanInsertions& insertions) {
+  std::string result;
+  for (const SelectedPlan::Event& event : plan.selected_.events_) {
+    switch (event.kind) {
+    case SelectedPlan::Event::TEXT:
+      result += event.text;
+      break;
+    case SelectedPlan::Event::GAP:
+      if (event.newline) {
+        result += '\n';
+        result.append(event.indentation, ' ');
+      } else {
+        result += event.text;
+      }
+      break;
+    case SelectedPlan::Event::MARK: {
+      const PlanInsertions::AtMarker* found = insertions.at(event.marker);
+      if (found == null) break;
+      for (const std::string& text : found->before)
+        result += text;
+      for (const std::string& text : found->after)
+        result += text;
+      break;
+    }
+    default:
+      UNREACHABLE();
+    }
+  }
+  return result;
+}
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_layout.h
+++ b/src/compiler/format_layout.h
@@ -1,0 +1,234 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#pragma once
+
+#include <initializer_list>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace toit {
+namespace compiler {
+
+struct FormatStyle {
+  int continuation_step = 4;
+};
+
+// Formatter phase overview:
+//
+//   AST lowering -> Layout -> SelectedPlan -> FinalPlan -> rendering
+//
+// Layout selection measures logical tokens without synthesized punctuation.
+// The selected token events stay private, so later phases cannot accidentally
+// depend on or change their order. Freezing makes that selection immutable.
+
+// A zero-width position in a layout. Expression lowering records markers at
+// syntax boundaries; later phases can then reason about selected newlines
+// without searching rendered text.
+class LayoutMarker {
+ public:
+  LayoutMarker() : id_(-1) {}
+
+  bool is_valid() const { return id_ >= 0; }
+
+ private:
+  explicit LayoutMarker(int id) : id_(id) {}
+
+  int id_;
+
+  friend class LayoutBuilder;
+  friend class LayoutSelector;
+  friend class SelectedPlan;
+  friend class PlanInsertions;
+};
+
+// Identifies one whitespace decision. Handles are deliberately restricted to
+// whitespace: no ordinary post-selection pass gets a handle with which it
+// could move or replace a token.
+class LayoutGap {
+ public:
+  LayoutGap() : id_(-1) {}
+
+  bool is_valid() const { return id_ >= 0; }
+
+ private:
+  explicit LayoutGap(int id) : id_(id) {}
+
+  int id_;
+
+  friend class LayoutBuilder;
+  friend class LayoutSelector;
+  friend class SelectedPlan;
+};
+
+enum class GapState {
+  // Emit the gap's separator. It is normally one space, but may be empty.
+  FLAT,
+  NEWLINE,
+};
+
+// A tree of logical tokens and possible whitespace. It contains neither
+// source parentheses nor synthesized parentheses: layout selection should
+// measure the program's logical text, while syntax protection runs later.
+//
+// LINE follows its surrounding GROUP. SPACE starts flat even when that group
+// breaks, but still exposes a legal newline for an aesthetic repair. HARDLINE
+// is structural and can never be flattened.
+class Layout {
+ public:
+  enum Kind {
+    TEXT,
+    CONCAT,
+    GROUP,
+    INDENT,
+    LINE,
+    SPACE,
+    HARDLINE,
+    MARK,
+  };
+
+ private:
+  explicit Layout(Kind kind) : kind_(kind) {}
+
+  Kind kind_;
+  std::string text_;
+  std::vector<Layout*> children_;
+  Layout* child_ = nullptr;
+  int indentation_ = 0;
+  LayoutMarker marker_;
+  LayoutGap gap_;
+
+  friend class LayoutBuilder;
+  friend class LayoutSelector;
+};
+
+// Owns Layout nodes and supplies the small vocabulary used by lowering.
+// Pointers returned by the builder remain valid for its lifetime.
+class LayoutBuilder {
+ public:
+  Layout* text(const std::string& text);
+  Layout* concat(std::vector<Layout*> children);
+  Layout* concat(std::initializer_list<Layout*> children) {
+    return concat(std::vector<Layout*>(children));
+  }
+  Layout* group(Layout* child);
+  Layout* indent(int spaces, Layout* child);
+
+  LayoutGap gap();
+  Layout* line(const std::string& flat_separator = " ");
+  Layout* line(LayoutGap gap, const std::string& flat_separator = " ");
+  Layout* space(LayoutGap gap, const std::string& separator = " ");
+  Layout* hardline();
+
+  LayoutMarker marker();
+  Layout* mark(LayoutMarker marker);
+
+ private:
+  Layout* allocate(Layout::Kind kind);
+
+  std::vector<std::unique_ptr<Layout>> layouts_;
+  int next_marker_ = 0;
+  int next_gap_ = 0;
+};
+
+class FinalPlan;
+
+// A layout after every GROUP has selected its flat or broken form. This is the
+// concrete result of generic line selection. Token events are private and
+// have no relocation API, making preservation of token order an enforceable
+// invariant.
+class SelectedPlan {
+ public:
+  int line_of(LayoutMarker marker) const;
+  bool has_break_between(LayoutMarker first, LayoutMarker second) const;
+
+  bool can_select(LayoutGap gap, GapState state) const;
+  bool is_selected(LayoutGap gap, GapState state) const;
+  FinalPlan freeze() &&;
+
+ private:
+  struct Event {
+    enum Kind { TEXT, GAP, MARK };
+
+    Kind kind;
+    std::string text;
+    int indentation = 0;
+    bool newline = false;
+    bool can_flat = false;
+    bool can_newline = false;
+    LayoutGap gap;
+    LayoutMarker marker;
+  };
+
+  const Event& gap_event(LayoutGap gap) const;
+  Event& gap_event(LayoutGap gap);
+  int marker_index(LayoutMarker marker) const;
+
+  std::vector<Event> events_;
+  std::vector<int> marker_indices_;
+  std::vector<int> gap_indices_;
+
+  friend class FinalPlan;
+  friend class LayoutSelector;
+  friend std::string render_plan(const FinalPlan&, const class PlanInsertions&);
+};
+
+// Freezing closes layout selection. Later phases may inspect this final line
+// topology, but cannot mutate it.
+class FinalPlan {
+ public:
+  int line_of(LayoutMarker marker) const { return selected_.line_of(marker); }
+  bool has_break_between(LayoutMarker first, LayoutMarker second) const {
+    return selected_.has_break_between(first, second);
+  }
+
+ private:
+  explicit FinalPlan(SelectedPlan selected) : selected_(std::move(selected)) {}
+
+  SelectedPlan selected_;
+
+  friend class SelectedPlan;
+  friend std::string render_plan(const FinalPlan&, const class PlanInsertions&);
+};
+
+// Text added after line selection lives beside, rather than inside, the final
+// plan. Insertions are restricted to single-line text and therefore cannot
+// retroactively influence width or line selection.
+class PlanInsertions {
+ public:
+  void insert_before(LayoutMarker marker, const std::string& text);
+  void insert_after(LayoutMarker marker, const std::string& text);
+
+ private:
+  struct AtMarker {
+    std::vector<std::string> before;
+    std::vector<std::string> after;
+  };
+
+  const AtMarker* at(LayoutMarker marker) const;
+  std::unordered_map<int, AtMarker> insertions_;
+
+  friend std::string render_plan(const FinalPlan&, const PlanInsertions&);
+};
+
+SelectedPlan select_layout(Layout* root, int preferred_width);
+std::string render_plan(const FinalPlan& plan,
+                        const PlanInsertions& insertions = PlanInsertions());
+
+} // namespace compiler
+} // namespace toit

--- a/tests/ctest/format-layout-test.cc
+++ b/tests/ctest/format-layout-test.cc
@@ -1,0 +1,117 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../src/compiler/format_layout.h"
+#include "../../src/top.h"
+
+namespace toit {
+namespace compiler {
+
+static void expect(const char* expected, const std::string& actual) {
+  if (actual == expected) return;
+  fprintf(stderr, "Expected:\n---\n%s\n---\nActual:\n---\n%s\n---\n", expected,
+          actual.c_str());
+  exit(1);
+}
+
+static std::string select_and_render(Layout* layout, int preferred_width) {
+  return render_plan(
+      std::move(select_layout(layout, preferred_width)).freeze());
+}
+
+static void test_group_selects_flat_or_broken() {
+  LayoutBuilder builder;
+  Layout* layout = builder.group(builder.concat({
+      builder.text("send"),
+      builder.indent(4, builder.concat({
+                            builder.line(),
+                            builder.text("argument"),
+                        })),
+  }));
+
+  expect("send argument", select_and_render(layout, 20));
+  expect("send\n    argument", select_and_render(layout, 10));
+}
+
+static void test_preferred_width_is_not_a_hard_limit() {
+  LayoutBuilder builder;
+  Layout* indivisible = builder.text("one-very-long-identifier");
+
+  // There is no legal place to split this token. The formatter emits it
+  // unchanged instead of inventing a hard-width failure mode.
+  expect("one-very-long-identifier", select_and_render(indivisible, 5));
+}
+
+static void test_markers_follow_selected_lines() {
+  LayoutBuilder builder;
+  LayoutMarker outer_start = builder.marker();
+  LayoutMarker inner_start = builder.marker();
+  LayoutMarker inner_end = builder.marker();
+  Layout* nested_call = builder.group(builder.concat({
+      builder.mark(outer_start),
+      builder.text("foo"),
+      builder.indent(4, builder.concat({
+                            builder.line(),
+                            builder.mark(inner_start),
+                            builder.text("bar 1"),
+                            builder.mark(inner_end),
+                        })),
+  }));
+
+  SelectedPlan flat = select_layout(nested_call, 20);
+  ASSERT(!flat.has_break_between(outer_start, inner_start));
+  ASSERT(flat.line_of(outer_start) == flat.line_of(inner_start));
+
+  SelectedPlan broken = select_layout(nested_call, 6);
+  ASSERT(broken.has_break_between(outer_start, inner_start));
+  ASSERT(broken.line_of(outer_start) != broken.line_of(inner_start));
+}
+
+static void test_inserted_syntax_never_changes_a_break_decision() {
+  LayoutBuilder builder;
+  LayoutMarker start = builder.marker();
+  LayoutMarker end = builder.marker();
+  Layout* layout = builder.group(builder.concat({
+      builder.text("abc "),
+      builder.mark(start),
+      builder.text("def"),
+      builder.mark(end),
+  }));
+
+  FinalPlan selected = std::move(select_layout(layout, 7)).freeze();
+  PlanInsertions insertions;
+  insertions.insert_before(start, "(((");
+  insertions.insert_before(end, ")))");
+
+  // The physical result is wider than seven columns by design. Synthesized
+  // protection is absent from the logical width used for line selection.
+  expect("abc (((def)))", render_plan(selected, insertions));
+}
+
+static void test_hardline_preserves_structural_boundaries() {
+  LayoutBuilder builder;
+  Layout* statements = builder.concat({
+      builder.text("first"),
+      builder.hardline(),
+      builder.text("second"),
+  });
+
+  expect("first\nsecond", select_and_render(statements, 100));
+}
+
+} // namespace compiler
+} // namespace toit
+
+int main() {
+  toit::throwing_new_allowed = true;
+  toit::compiler::test_group_selects_flat_or_broken();
+  toit::compiler::test_preferred_width_is_not_a_hard_limit();
+  toit::compiler::test_markers_follow_selected_lines();
+  toit::compiler::test_inserted_syntax_never_changes_a_break_decision();
+  toit::compiler::test_hardline_preserves_structural_boundaries();
+  return 0;
+}


### PR DESCRIPTION
Part 1 of the formatter rewrite stack.

This introduces token-order-preserving layout selection and the invariants used by later formatter phases:

- layouts contain logical tokens and explicit whitespace choices;
- preferred width guides group selection but is not a hard limit;
- selected token events are private and have no relocation API;
- markers and gaps are indexed during selection;
- freezing makes the selected topology immutable;
- late single-line insertions cannot feed back into width selection.

There is deliberately no region, slot, generic move operation, or repair API in this PR. The architecture overview grows in later stack entries as those phases are introduced.

Tests cover flat and broken groups, soft width, marker topology, hard lines, and post-selection insertion.

Stack: 1/5. The next PR adds syntax protection against the frozen line topology.
