### PR TITLE
feat(formatter): protect syntax after freezing layout

### DIFF
--- a/src/compiler/format_layout.h
+++ b/src/compiler/format_layout.h
@@ -31,11 +31,14 @@ struct FormatStyle {
 
 // Formatter phase overview:
 //
-//   AST lowering -> Layout -> SelectedPlan -> FinalPlan -> rendering
+//   AST lowering -> Layout -> SelectedPlan -> FinalPlan
+//                                                + syntax insertions -> rendering
 //
 // Layout selection measures logical tokens without synthesized punctuation.
 // The selected token events stay private, so later phases cannot accidentally
-// depend on or change their order. Freezing makes that selection immutable.
+// depend on or change their order. Freezing makes that selection immutable;
+// syntax protection then responds to its line topology without feeding
+// punctuation back into width selection.
 
 // A zero-width position in a layout. Expression lowering records markers at
 // syntax boundaries; later phases can then reason about selected newlines
@@ -206,9 +209,9 @@ class FinalPlan {
   friend std::string render_plan(const FinalPlan&, const class PlanInsertions&);
 };
 
-// Text added after line selection lives beside, rather than inside, the final
-// plan. Insertions are restricted to single-line text and therefore cannot
-// retroactively influence width or line selection.
+// Syntax added after line selection lives beside, rather than inside, the
+// final plan. Insertions are restricted to single-line text and therefore
+// cannot retroactively influence width or line selection.
 class PlanInsertions {
  public:
   void insert_before(LayoutMarker marker, const std::string& text);

--- a/src/compiler/format_syntax.cc
+++ b/src/compiler/format_syntax.cc
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#include "format_syntax.h"
+
+#include "../top.h"
+
+namespace toit {
+namespace compiler {
+
+void SyntaxProtection::require_parentheses(ExpressionSpan expression) {
+  ASSERT(expression.start.is_valid());
+  ASSERT(expression.end.is_valid());
+  requirements_.push_back({expression, Requirement::ALWAYS, LayoutMarker()});
+}
+
+void SyntaxProtection::require_parentheses_unless_break_between(
+    ExpressionSpan expression, LayoutMarker delimiter_start) {
+  ASSERT(expression.start.is_valid());
+  ASSERT(expression.end.is_valid());
+  ASSERT(delimiter_start.is_valid());
+  requirements_.push_back(
+      {expression, Requirement::UNLESS_BREAK_BETWEEN, delimiter_start});
+}
+
+PlanInsertions SyntaxProtection::resolve(const FinalPlan& plan) const {
+  PlanInsertions result;
+  for (const Requirement& requirement : requirements_) {
+    // Validate both insertion boundaries even for an unconditional rule. A
+    // stale lowering marker should fail here rather than disappear silently
+    // during rendering.
+    plan.line_of(requirement.expression.start);
+    plan.line_of(requirement.expression.end);
+    bool needed;
+    switch (requirement.condition) {
+    case Requirement::ALWAYS:
+      needed = true;
+      break;
+    case Requirement::UNLESS_BREAK_BETWEEN:
+      needed = !plan.has_break_between(requirement.delimiter_start,
+                                       requirement.expression.start);
+      break;
+    default:
+      UNREACHABLE();
+    }
+    if (!needed) continue;
+
+    // Both characters are inserted before their boundary marker. With nested
+    // spans, marker order supplies the right nesting automatically:
+    // outer-start, inner-start, inner-end, outer-end becomes `((x))`.
+    result.insert_before(requirement.expression.start, "(");
+    result.insert_before(requirement.expression.end, ")");
+  }
+  return result;
+}
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_syntax.h
+++ b/src/compiler/format_syntax.h
@@ -1,0 +1,88 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#pragma once
+
+#include <vector>
+
+#include "format_layout.h"
+
+namespace toit {
+namespace compiler {
+
+// The zero-width boundaries of one expression in a Layout tree. Keeping the
+// boundaries separate from the expression's text is what lets lowering omit
+// redundant source parentheses without losing the place where canonical ones
+// may later be inserted.
+//
+// For example, the inner expression has the same span in both layouts below:
+//
+//     foo (bar 1)
+//          ^^^^^
+//
+//     foo
+//         bar 1
+//         ^^^^^
+//
+// Only the selected line topology differs.
+struct ExpressionSpan {
+  LayoutMarker start;
+  LayoutMarker end;
+};
+
+// Collects grammar constraints while the AST is lowered, then resolves them
+// against a frozen plan. This is deliberately not a second pretty-printing
+// pass: its separate result contains only single-line insertions at recorded
+// boundaries. It cannot move text or reconsider a line break.
+class SyntaxProtection {
+ public:
+  // Use for grammar rules independent of wrapping, such as precedence:
+  //
+  //     (a + b) * c
+  void require_parentheses(ExpressionSpan expression);
+
+  // Use when a newline itself is a delimiter. A nested call argument is the
+  // motivating Toit example:
+  //
+  //     foo (bar 1)       // Same line: parens keep this one argument.
+  //
+  //     foo
+  //         bar 1         // Newline already starts a new argument.
+  //
+  // `delimiter_start` is normally the end of the outer call's target.
+  // Parentheses are inserted unless a selected newline between that marker
+  // and the nested expression already acts as the delimiter.
+  void require_parentheses_unless_break_between(ExpressionSpan expression,
+                                                LayoutMarker delimiter_start);
+
+  PlanInsertions resolve(const FinalPlan& plan) const;
+
+ private:
+  struct Requirement {
+    enum Condition {
+      ALWAYS,
+      UNLESS_BREAK_BETWEEN,
+    };
+
+    ExpressionSpan expression;
+    Condition condition;
+    LayoutMarker delimiter_start;
+  };
+
+  std::vector<Requirement> requirements_;
+};
+
+} // namespace compiler
+} // namespace toit

--- a/tests/ctest/format-syntax-test.cc
+++ b/tests/ctest/format-syntax-test.cc
@@ -1,0 +1,97 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../src/compiler/format_layout.h"
+#include "../../src/compiler/format_syntax.h"
+#include "../../src/top.h"
+
+namespace toit {
+namespace compiler {
+
+static void expect(const char* expected, const std::string& actual) {
+  if (actual == expected) return;
+  fprintf(stderr, "Expected:\n---\n%s\n---\nActual:\n---\n%s\n---\n", expected,
+          actual.c_str());
+  exit(1);
+}
+
+static void test_precedence_protection_is_unconditional() {
+  LayoutBuilder builder;
+  LayoutMarker start = builder.marker();
+  LayoutMarker end = builder.marker();
+  Layout* multiplication = builder.concat({
+      builder.mark(start),
+      builder.text("a + b"),
+      builder.mark(end),
+      builder.text(" * c"),
+  });
+
+  SyntaxProtection syntax;
+  syntax.require_parentheses({start, end});
+  FinalPlan selected = std::move(select_layout(multiplication, 100)).freeze();
+  PlanInsertions insertions = syntax.resolve(selected);
+
+  expect("(a + b) * c", render_plan(selected, insertions));
+}
+
+static void test_nested_call_uses_the_selected_line_as_delimiter() {
+  LayoutBuilder builder;
+  LayoutMarker target_end = builder.marker();
+  LayoutMarker argument_start = builder.marker();
+  LayoutMarker argument_end = builder.marker();
+  Layout* call = builder.group(builder.concat({
+      builder.text("foo"),
+      builder.mark(target_end),
+      builder.indent(4, builder.concat({
+                            builder.line(),
+                            builder.mark(argument_start),
+                            builder.text("bar 1"),
+                            builder.mark(argument_end),
+                        })),
+  }));
+
+  SyntaxProtection syntax;
+  syntax.require_parentheses_unless_break_between(
+      {argument_start, argument_end}, target_end);
+
+  FinalPlan flat = std::move(select_layout(call, 20)).freeze();
+  expect("foo (bar 1)", render_plan(flat, syntax.resolve(flat)));
+
+  FinalPlan broken = std::move(select_layout(call, 6)).freeze();
+  expect("foo\n    bar 1", render_plan(broken, syntax.resolve(broken)));
+}
+
+static void test_protection_does_not_turn_a_preference_into_a_limit() {
+  LayoutBuilder builder;
+  LayoutMarker start = builder.marker();
+  LayoutMarker end = builder.marker();
+  Layout* expression = builder.concat({
+      builder.mark(start),
+      builder.text("seven77"),
+      builder.mark(end),
+  });
+
+  SyntaxProtection syntax;
+  syntax.require_parentheses({start, end});
+  FinalPlan selected = std::move(select_layout(expression, 7)).freeze();
+
+  // The logical expression fits exactly. Required punctuation may make the
+  // physical line wider because preferred_width is intentionally not a hard
+  // limit and selection has already finished.
+  expect("(seven77)", render_plan(selected, syntax.resolve(selected)));
+}
+
+} // namespace compiler
+} // namespace toit
+
+int main() {
+  toit::throwing_new_allowed = true;
+  toit::compiler::test_precedence_protection_is_unconditional();
+  toit::compiler::test_nested_call_uses_the_selected_line_as_delimiter();
+  toit::compiler::test_protection_does_not_turn_a_preference_into_a_limit();
+  return 0;
+}


### PR DESCRIPTION
Part 2 of the formatter rewrite stack. Based on #3134.

This records grammar requirements while lowering and resolves them only after layout has been frozen.

Two cases are covered initially:

- unconditional parentheses required by precedence;
- parentheses required unless a selected newline already delimits a greedy nested call.

Syntax insertions are stored separately from the final layout plan. They cannot change width, line selection, whitespace, or token order. The API names state the actual condition (`require_parentheses_unless_break_between`) instead of referring indirectly to shared lines.

Tests show both forms of a nested call and verify that required punctuation may exceed the preferred width without causing layout to be reconsidered.

Stack: 2/5. The next PR adds expression lowering and named whitespace-only repairs.
