### PR TITLE
feat(formatter): lower and repair expression layouts

### DIFF
--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -1,0 +1,278 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#include "format_expression.h"
+
+#include "../top.h"
+#include "ast.h"
+#include "sources.h"
+#include "token.h"
+
+namespace toit {
+namespace compiler {
+
+using namespace ast;
+
+namespace {
+
+Expression* peel_parentheses(Expression* expression) {
+  while (expression->is_Parenthesis()) {
+    expression = expression->as_Parenthesis()->expression();
+  }
+  return expression;
+}
+
+bool is_right_associative(Token::Kind kind) {
+  int precedence = Token::precedence(kind);
+  return precedence == PRECEDENCE_AND || precedence == PRECEDENCE_OR ||
+         precedence == PRECEDENCE_ASSIGNMENT;
+}
+
+bool is_logical(Token::Kind kind) {
+  int precedence = Token::precedence(kind);
+  return precedence == PRECEDENCE_AND || precedence == PRECEDENCE_OR;
+}
+
+class ExpressionLowering {
+ public:
+  ExpressionLowering(Source* source, LayoutBuilder* layouts,
+                     LogicalOperatorBindings* bindings,
+                     SyntaxProtection* syntax,
+                     const FormatStyle& style)
+      : source_(source)
+      , layouts_(layouts)
+      , bindings_(bindings)
+      , syntax_(syntax)
+      , style_(style) {}
+
+  LoweredExpression lower(Expression* expression, int outer_precedence) {
+    ASSERT(expression != null);
+
+    // Parenthesis nodes describe how the input happened to spell the tree.
+    // Precedence and line topology below describe how the output must spell
+    // it. Peeling here is the small canonicalization step discussed in the
+    // formatter design; it does not need a separate AST rewrite pass.
+    expression = peel_parentheses(expression);
+
+    LayoutMarker start = layouts_->marker();
+    LayoutMarker end = layouts_->marker();
+    Layout* contents = lower_contents(expression, outer_precedence);
+    LoweredExpression result = {
+        layouts_->concat(
+            {layouts_->mark(start), contents, layouts_->mark(end)}),
+        {start, end},
+    };
+    if (requires_parentheses_in(expression, outer_precedence)) {
+      syntax_->require_parentheses(result.span);
+    }
+    return result;
+  }
+
+ private:
+  Source* source_;
+  LayoutBuilder* layouts_;
+  LogicalOperatorBindings* bindings_;
+  SyntaxProtection* syntax_;
+  const FormatStyle& style_;
+
+  bool requires_parentheses_in(Expression* expression,
+                               int outer_precedence) const {
+    if (outer_precedence == PRECEDENCE_NONE) return false;
+    if (expression->is_Binary()) {
+      return Token::precedence(expression->as_Binary()->kind()) <=
+             outer_precedence;
+    }
+    if (expression->is_Call()) return PRECEDENCE_CALL <= outer_precedence;
+    if (expression->is_Unary()) {
+      int precedence = expression->as_Unary()->kind() == Token::NOT
+                           ? PRECEDENCE_NOT
+                           : PRECEDENCE_POSTFIX;
+      return precedence <= outer_precedence;
+    }
+    // Atoms do not need a made-up precedence above POSTFIX: their grammar
+    // category directly tells us that they fit every operator context. This
+    // explicit case also prevents an unsupported node from silently being
+    // treated as an atom.
+    if (is_atomic(expression)) return false;
+    if (expression->is_Error()) UNREACHABLE();
+    UNREACHABLE();
+  }
+
+  static bool is_atomic(Expression* expression) {
+    return expression->is_Identifier() || expression->is_LiteralNull() ||
+           expression->is_LiteralUndefined() ||
+           expression->is_LiteralBoolean() || expression->is_LiteralInteger() ||
+           expression->is_LiteralCharacter() ||
+           (expression->is_LiteralString() &&
+            !expression->as_LiteralString()->is_multiline()) ||
+           expression->is_LiteralFloat();
+  }
+
+  std::string source_text(Node* node) const {
+    Source::Range range = node->full_range();
+    ASSERT(range.is_valid());
+    int from = source_->offset_in_source(range.from());
+    int to = source_->offset_in_source(range.to());
+    ASSERT(from >= 0 && to >= from);
+    return std::string(reinterpret_cast<const char*>(source_->text()) + from,
+                       to - from);
+  }
+
+  Layout* lower_contents(Expression* expression, int outer_precedence) {
+    if (expression->is_Binary()) {
+      return lower_binary(expression->as_Binary(), outer_precedence);
+    }
+    if (expression->is_Unary()) {
+      return lower_unary(expression->as_Unary(), outer_precedence);
+    }
+    if (expression->is_Call()) {
+      return lower_call(expression->as_Call(), outer_precedence);
+    }
+
+    // Atomic nodes retain their exact token bytes. This preserves spelling
+    // choices that are data rather than layout, for example `0xff`, string
+    // escapes, and identifier dashes.
+    if (is_atomic(expression)) {
+      return layouts_->text(source_text(expression));
+    }
+
+    // Error nodes are malformed source, not an accidental atomic fallback.
+    // The end-to-end formatter will freeze their containing region verbatim.
+    // Every valid expression kind must be added explicitly above; reaching
+    // this point is a missing lowering rule rather than permission to copy an
+    // arbitrary subtree (which could retain source newlines or parentheses).
+    if (expression->is_Error()) UNREACHABLE();
+    UNREACHABLE();
+  }
+
+  Layout* lower_unary(Unary* unary, int outer_precedence) {
+    LoweredExpression operand = lower(unary->expression(), PRECEDENCE_POSTFIX);
+    std::vector<Layout*> parts;
+    std::string symbol = Token::symbol(unary->kind()).c_str();
+    if (unary->prefix()) {
+      parts.push_back(
+          layouts_->text(unary->kind() == Token::NOT ? symbol + " " : symbol));
+      parts.push_back(operand.layout);
+    } else {
+      parts.push_back(operand.layout);
+      parts.push_back(layouts_->text(symbol));
+    }
+
+    // `lower` compares this node's precedence with its context after the
+    // public expression span has been installed. No second marker pair is
+    // needed merely to parenthesize a unary expression.
+    return layouts_->concat(std::move(parts));
+  }
+
+  Layout* lower_binary(Binary* binary, int outer_precedence) {
+    Token::Kind kind = binary->kind();
+    int precedence = Token::precedence(kind);
+    bool right_associative = is_right_associative(kind);
+
+    // Equal-precedence protection is placed on the side that would otherwise
+    // reassociate. Thus `(a - b) - c` needs no parens, while `a - (b - c)`
+    // does. Right-associative operators mirror those contexts.
+    int left_context = right_associative ? precedence : precedence - 1;
+    int right_context = right_associative ? precedence - 1 : precedence;
+    if (precedence == PRECEDENCE_ASSIGNMENT) {
+      // The right side of an assignment is parsed as a full expression.
+      right_context = PRECEDENCE_NONE;
+    }
+
+    LoweredExpression left = lower(binary->left(), left_context);
+    LoweredExpression right = lower(binary->right(), right_context);
+    std::string symbol = Token::symbol(kind).c_str();
+    Layout* contents;
+    if (is_logical(kind)) {
+      // The regular layout uses the conventional leading-operator form. It
+      // deliberately offers a second legal gap after the operator, allowing a
+      // later repair to produce the preferred mixed-logical shape:
+      //
+      //     foo or
+      //         bar and gee
+      //
+      // If the narrow pattern does not match, this remains ordinary correct
+      // formatting rather than special logic embedded in generic lowering.
+      LayoutGap before_operator = layouts_->gap();
+      LayoutGap after_operator = layouts_->gap();
+      contents = layouts_->group(layouts_->concat({
+          left.layout,
+          layouts_->indent(style_.continuation_step,
+                           layouts_->concat({
+                               layouts_->line(before_operator),
+                               layouts_->text(symbol),
+                               layouts_->space(after_operator),
+                               right.layout,
+                           })),
+      }));
+      bindings_->record(binary, before_operator, after_operator);
+    } else {
+      // Other binary chains use a leading operator on continuation lines so
+      // their left-associative parse is visible.
+      contents = layouts_->group(layouts_->concat({
+          left.layout,
+          layouts_->indent(style_.continuation_step,
+                           layouts_->concat({
+                               layouts_->line(),
+                               layouts_->text(symbol + " "),
+                               right.layout,
+                           })),
+      }));
+    }
+
+    return contents;
+  }
+
+  Layout* lower_call(Call* call, int outer_precedence) {
+    LoweredExpression target = lower(call->target(), PRECEDENCE_POSTFIX);
+    std::vector<Layout*> parts = {target.layout};
+    for (Expression* argument_node : call->arguments()) {
+      LoweredExpression argument = lower(argument_node, PRECEDENCE_NONE);
+      parts.push_back(
+          layouts_->indent(style_.continuation_step, layouts_->concat({
+                                                         layouts_->line(),
+                                                         argument.layout,
+                                                     })));
+
+      // Calls consume following same-line expressions greedily. In
+      // `outer (inner 1)`, parentheses keep `inner 1` one argument. Once the
+      // argument moves to its own continuation line, indentation is already a
+      // delimiter and the canonical output can omit them.
+      if (peel_parentheses(argument_node)->is_Call()) {
+        syntax_->require_parentheses_unless_break_between(argument.span,
+                                                          target.span.end);
+      }
+    }
+    return layouts_->group(layouts_->concat(std::move(parts)));
+  }
+};
+
+} // namespace
+
+LoweredExpression lower_expression(Expression* expression, Source* source,
+                                   LayoutBuilder* layouts,
+                                   LogicalOperatorBindings* bindings,
+                                   SyntaxProtection* syntax,
+                                   const FormatStyle& style) {
+  ASSERT(source != null);
+  ASSERT(layouts != null);
+  ASSERT(bindings != null);
+  ASSERT(syntax != null);
+  return ExpressionLowering(source, layouts, bindings, syntax, style)
+      .lower(expression, PRECEDENCE_NONE);
+}
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_expression.h
+++ b/src/compiler/format_expression.h
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#pragma once
+
+#include "format_layout.h"
+#include "format_repair.h"
+#include "format_syntax.h"
+
+namespace toit {
+namespace compiler {
+
+class Source;
+
+namespace ast {
+class Expression;
+}
+
+struct LoweredExpression {
+  Layout* layout;
+  ExpressionSpan span;
+};
+
+// Lowers the expression into logical text and legal line-break choices.
+// Source parentheses and source newlines are deliberately not preferences and
+// therefore do not enter the returned Layout. Required parentheses are
+// recorded in `syntax` and materialized only after select_layout has run.
+//
+// This first slice supports atoms, unary/binary expressions, and ordinary
+// calls. Keeping the entry point narrow makes the architectural invariant
+// reviewable before suites, collections, and trivia add more layout shapes.
+LoweredExpression lower_expression(ast::Expression* expression, Source* source,
+                                   LayoutBuilder* layouts,
+                                   LogicalOperatorBindings* bindings,
+                                   SyntaxProtection* syntax,
+                                   const FormatStyle& style = FormatStyle());
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_layout.h
+++ b/src/compiler/format_layout.h
@@ -31,14 +31,15 @@ struct FormatStyle {
 
 // Formatter phase overview:
 //
-//   AST lowering -> Layout -> SelectedPlan -> FinalPlan
-//                                                + syntax insertions -> rendering
+//   AST lowering -> Layout -> SelectedPlan -> whitespace repairs -> FinalPlan
+//                                                               + syntax insertions -> rendering
 //
 // Layout selection measures logical tokens without synthesized punctuation.
 // The selected token events stay private, so later phases cannot accidentally
-// depend on or change their order. Freezing makes that selection immutable;
-// syntax protection then responds to its line topology without feeding
-// punctuation back into width selection.
+// depend on or change their order. Repairs can address exposed gaps but cannot
+// access token events. Freezing makes the result immutable; syntax protection
+// then responds to its line topology without feeding punctuation back into
+// width selection.
 
 // A zero-width position in a layout. Expression lowering records markers at
 // syntax boundaries; later phases can then reason about selected newlines
@@ -77,6 +78,7 @@ class LayoutGap {
   friend class LayoutBuilder;
   friend class LayoutSelector;
   friend class SelectedPlan;
+  friend class WhitespaceEdits;
 };
 
 enum class GapState {
@@ -149,12 +151,13 @@ class LayoutBuilder {
   int next_gap_ = 0;
 };
 
+class WhitespaceEdits;
 class FinalPlan;
 
 // A layout after every GROUP has selected its flat or broken form. This is the
-// concrete result of generic line selection. Token events are private and
-// have no relocation API, making preservation of token order an enforceable
-// invariant.
+// only mutable phase: aesthetic rules may change whitespace states that the
+// layout explicitly offered. Token events are private and have no relocation
+// API, making preservation of token order an enforceable invariant.
 class SelectedPlan {
  public:
   int line_of(LayoutMarker marker) const;
@@ -162,6 +165,10 @@ class SelectedPlan {
 
   bool can_select(LayoutGap gap, GapState state) const;
   bool is_selected(LayoutGap gap, GapState state) const;
+  // Returns false, without changing the plan, if two rules requested
+  // contradictory states. Callers can report `edits.conflicts()`.
+  bool apply(const WhitespaceEdits& edits);
+
   FinalPlan freeze() &&;
 
  private:
@@ -191,8 +198,8 @@ class SelectedPlan {
   friend std::string render_plan(const FinalPlan&, const class PlanInsertions&);
 };
 
-// Freezing closes layout selection. Later phases may inspect this final line
-// topology, but cannot mutate it.
+// Freezing closes the whitespace-repair phase. Later phases may inspect this
+// final line topology, but cannot mutate it.
 class FinalPlan {
  public:
   int line_of(LayoutMarker marker) const { return selected_.line_of(marker); }

--- a/src/compiler/format_repair.cc
+++ b/src/compiler/format_repair.cc
@@ -1,0 +1,144 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#include "format_repair.h"
+
+#include "../top.h"
+#include "ast.h"
+#include "token.h"
+
+#include <sstream>
+#include <unordered_map>
+
+namespace toit {
+namespace compiler {
+
+WhitespaceEdits::RequestResult WhitespaceEdits::request(
+    LayoutGap gap,
+    GapState state,
+    const std::string& rule) {
+  ASSERT(gap.is_valid());
+  ASSERT(!rule.empty());
+  auto existing = edits_.find(gap.id_);
+  if (existing == edits_.end()) {
+    edits_.insert({gap.id_, {state, rule}});
+    return ADDED;
+  }
+  if (existing->second.state == state) return ALREADY_REQUESTED;
+
+  std::ostringstream message;
+  message << "Whitespace rules '" << existing->second.rule << "' and '"
+          << rule << "' request different states for gap " << gap.id_;
+  conflicts_.push_back(message.str());
+  return CONFLICT;
+}
+
+bool SelectedPlan::apply(const WhitespaceEdits& edits) {
+  if (edits.has_conflict()) return false;
+  for (const auto& entry : edits.edits_) {
+    LayoutGap gap(entry.first);
+    ASSERT(can_select(gap, entry.second.state));
+    gap_event(gap).newline = entry.second.state == GapState::NEWLINE;
+  }
+  return true;
+}
+
+void LogicalOperatorBindings::record(ast::Binary* binary,
+                                     LayoutGap before_operator,
+                                     LayoutGap after_operator) {
+  ASSERT(binary != null);
+  ASSERT(before_operator.is_valid());
+  ASSERT(after_operator.is_valid());
+  binary_operators_.push_back({binary, before_operator, after_operator});
+}
+
+WhitespaceEdits FormatRepairs::propose(
+    const LogicalOperatorBindings& bindings,
+    const SelectedPlan& selected) {
+  WhitespaceEdits edits;
+  propose_mixed_logical_chain(bindings, selected, &edits);
+  return edits;
+}
+
+void FormatRepairs::propose_mixed_logical_chain(
+    const LogicalOperatorBindings& bindings,
+    const SelectedPlan& selected,
+    WhitespaceEdits* edits) {
+  ASSERT(edits != null);
+  std::unordered_map<ast::Binary*,
+                     const LogicalOperatorBindings::BinaryOperator*>
+      handles;
+  for (const LogicalOperatorBindings::BinaryOperator& binding :
+       bindings.binary_operators_) {
+    handles[binding.binary] = &binding;
+  }
+
+  for (const LogicalOperatorBindings::BinaryOperator& candidate :
+       bindings.binary_operators_) {
+    ast::Binary* binary = candidate.binary;
+
+    // The generic rule puts a broken operator at the start of its continuation:
+    //
+    //     foo
+    //         or bar
+    //             and gee
+    //
+    // For exactly `or` with an `and` on its right, this repair treats the
+    // tighter expression as a visual unit:
+    //
+    //     foo or
+    //         bar and gee
+    //
+    // If the shape or selected break does not match, the generic output
+    // remains unchanged and correct.
+    if (binary->kind() != Token::LOGICAL_OR) continue;
+    ast::Expression* right = binary->right();
+    while (right->is_Parenthesis()) {
+      right = right->as_Parenthesis()->expression();
+    }
+    if (!right->is_Binary() ||
+        right->as_Binary()->kind() != Token::LOGICAL_AND) continue;
+    if (!selected.is_selected(candidate.before_operator, GapState::NEWLINE)) {
+      continue;
+    }
+
+    ASSERT(selected.can_select(candidate.before_operator, GapState::FLAT));
+    ASSERT(selected.can_select(candidate.after_operator, GapState::NEWLINE));
+    edits->request(candidate.before_operator, GapState::FLAT,
+                   "mixed-logical-chain");
+    edits->request(candidate.after_operator, GapState::NEWLINE,
+                   "mixed-logical-chain");
+
+    // Moving the break after `or` changes the local width pressure that made
+    // the nested `and` break. Explicitly flatten both of its gaps so the rule
+    // produces the complete example above without rerunning generic selection.
+    // The preferred width is soft, so this local choice cannot create an
+    // invalid result merely because it extends past that preference.
+    ast::Binary* inner_and = right->as_Binary();
+    auto found = handles.find(inner_and);
+    ASSERT(found != handles.end());
+    if (found == handles.end()) continue;
+    const LogicalOperatorBindings::BinaryOperator* inner = found->second;
+    ASSERT(selected.can_select(inner->before_operator, GapState::FLAT));
+    ASSERT(selected.can_select(inner->after_operator, GapState::FLAT));
+    edits->request(inner->before_operator, GapState::FLAT,
+                   "mixed-logical-chain");
+    edits->request(inner->after_operator, GapState::FLAT,
+                   "mixed-logical-chain");
+  }
+}
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_repair.h
+++ b/src/compiler/format_repair.h
@@ -1,0 +1,97 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "format_layout.h"
+
+namespace toit {
+namespace compiler {
+
+namespace ast {
+class Binary;
+}
+
+class WhitespaceEdits {
+ public:
+  enum RequestResult {
+    ADDED,
+    ALREADY_REQUESTED,
+    CONFLICT,
+  };
+
+  // `rule` is retained for diagnostics. Two rules may request the same state,
+  // but contradictory requests are recorded instead of making rule order
+  // observable.
+  RequestResult request(LayoutGap gap, GapState state, const std::string& rule);
+
+  bool has_conflict() const { return !conflicts_.empty(); }
+  const std::vector<std::string>& conflicts() const { return conflicts_; }
+
+ private:
+  struct Edit {
+    GapState state;
+    std::string rule;
+  };
+
+  std::unordered_map<int, Edit> edits_;
+  std::vector<std::string> conflicts_;
+
+  friend class SelectedPlan;
+};
+
+// Layout sites deliberately offered by logical-expression lowering for later
+// whitespace repair. The name is intentionally narrow: these are
+// policy-neutral handles, but they are not a universal description of every
+// binary expression.
+class LogicalOperatorBindings {
+ public:
+  void record(ast::Binary* binary, LayoutGap before_operator,
+              LayoutGap after_operator);
+
+ private:
+  struct BinaryOperator {
+    ast::Binary* binary;
+    LayoutGap before_operator;
+    LayoutGap after_operator;
+  };
+
+  std::vector<BinaryOperator> binary_operators_;
+
+  friend class FormatRepairs;
+};
+
+// Matches narrowly chosen AST/layout shapes after generic selection. Each
+// named rule contributes whitespace requests to one shared edit set. Rules do
+// not abort on conflicts: the caller receives the complete conflict report and
+// SelectedPlan::apply rejects it atomically.
+class FormatRepairs {
+ public:
+  static WhitespaceEdits propose(const LogicalOperatorBindings& bindings,
+                                 const SelectedPlan& selected);
+
+ private:
+  static void propose_mixed_logical_chain(
+      const LogicalOperatorBindings& bindings,
+      const SelectedPlan& selected,
+      WhitespaceEdits* edits);
+};
+
+} // namespace compiler
+} // namespace toit

--- a/tests/ctest/format-expression-input.toit
+++ b/tests/ctest/format-expression-input.toit
@@ -1,0 +1,17 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+inner value: value
+outer value: value
+
+sample a b c foo bar gee alpha beta:
+  outer (inner 1)
+  (a + b) * c
+  foo or bar and gee
+  (foo or bar) and gee
+  alpha or
+      beta
+
+main:
+  sample 1 2 3 true false true false true

--- a/tests/ctest/format-expression-test.cc
+++ b/tests/ctest/format-expression-test.cc
@@ -1,0 +1,267 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <cstring>
+#include <memory>
+
+#include "../../src/compiler/ast.h"
+#include "../../src/compiler/diagnostic.h"
+#include "../../src/compiler/filesystem_local.h"
+#include "../../src/compiler/format_expression.h"
+#include "../../src/compiler/parser.h"
+#include "../../src/compiler/scanner.h"
+#include "../../src/compiler/symbol_canonicalizer.h"
+#include "../../src/top.h"
+#include "format-test-source.h"
+
+namespace toit {
+namespace compiler {
+
+struct ParsedExpression {
+  std::unique_ptr<FormatTestSource> source;
+  std::unique_ptr<SymbolCanonicalizer> symbols;
+  ast::Expression* expression;
+};
+
+static ParsedExpression parse_expression(const std::string& expression,
+                                         SourceManager* sources) {
+  std::string program = "sample:\n  ";
+  for (char c : expression) {
+    program += c;
+    if (c == '\n') program += "  ";
+  }
+  program += '\n';
+
+  ParsedExpression result;
+  result.source.reset(new FormatTestSource(program));
+  result.symbols.reset(new SymbolCanonicalizer());
+  NullDiagnostics diagnostics(sources);
+  Scanner scanner(result.source.get(), result.symbols.get(), &diagnostics);
+  Parser parser(result.source.get(), &scanner, &diagnostics);
+  ast::Unit* unit = parser.parse_unit();
+  if (diagnostics.encountered_error()
+      || unit->declarations().length() != 1) exit(1);
+  ast::Method* method = unit->declarations()[0]->as_Method();
+  if (method == null || method->body()->expressions().length() != 1) exit(1);
+  result.expression = method->body()->expressions()[0];
+  return result;
+}
+
+static ast::Expression* peel_parentheses(ast::Expression* expression) {
+  while (expression->is_Parenthesis()) {
+    expression = expression->as_Parenthesis()->expression();
+  }
+  return expression;
+}
+
+static bool same_symbol(Symbol left, Symbol right) {
+  return std::strcmp(left.c_str(), right.c_str()) == 0;
+}
+
+// This comparator deliberately covers exactly the expression kinds supported
+// by format_expression.cc. Adding a lowering rule without extending this
+// safety check makes the reparse test fail instead of silently weakening it.
+static bool equivalent_expression(ast::Expression* left,
+                                  ast::Expression* right) {
+  left = peel_parentheses(left);
+  right = peel_parentheses(right);
+  if (left->is_Identifier() && right->is_Identifier()) {
+    return same_symbol(left->as_Identifier()->data(),
+                       right->as_Identifier()->data());
+  }
+  if (left->is_LiteralInteger() && right->is_LiteralInteger()) {
+    return left->as_LiteralInteger()->is_negated()
+               == right->as_LiteralInteger()->is_negated()
+        && same_symbol(left->as_LiteralInteger()->data(),
+                       right->as_LiteralInteger()->data());
+  }
+  if (left->is_LiteralNull() && right->is_LiteralNull()) return true;
+  if (left->is_LiteralUndefined() && right->is_LiteralUndefined()) return true;
+  if (left->is_LiteralBoolean() && right->is_LiteralBoolean()) {
+    return left->as_LiteralBoolean()->value()
+        == right->as_LiteralBoolean()->value();
+  }
+  if (left->is_LiteralCharacter() && right->is_LiteralCharacter()) {
+    return same_symbol(left->as_LiteralCharacter()->data(),
+                       right->as_LiteralCharacter()->data());
+  }
+  if (left->is_LiteralString() && right->is_LiteralString()) {
+    return left->as_LiteralString()->is_multiline()
+               == right->as_LiteralString()->is_multiline()
+        && same_symbol(left->as_LiteralString()->data(),
+                       right->as_LiteralString()->data());
+  }
+  if (left->is_LiteralFloat() && right->is_LiteralFloat()) {
+    return left->as_LiteralFloat()->is_negated()
+               == right->as_LiteralFloat()->is_negated()
+        && same_symbol(left->as_LiteralFloat()->data(),
+                       right->as_LiteralFloat()->data());
+  }
+  if (left->is_Unary() && right->is_Unary()) {
+    ast::Unary* left_unary = left->as_Unary();
+    ast::Unary* right_unary = right->as_Unary();
+    return left_unary->kind() == right_unary->kind()
+        && left_unary->prefix() == right_unary->prefix()
+        && equivalent_expression(left_unary->expression(),
+                                 right_unary->expression());
+  }
+  if (left->is_Binary() && right->is_Binary()) {
+    ast::Binary* left_binary = left->as_Binary();
+    ast::Binary* right_binary = right->as_Binary();
+    return left_binary->kind() == right_binary->kind()
+        && equivalent_expression(left_binary->left(), right_binary->left())
+        && equivalent_expression(left_binary->right(), right_binary->right());
+  }
+  if (left->is_Call() && right->is_Call()) {
+    ast::Call* left_call = left->as_Call();
+    ast::Call* right_call = right->as_Call();
+    if (left_call->is_call_primitive() != right_call->is_call_primitive()
+        || !equivalent_expression(left_call->target(), right_call->target())) {
+      return false;
+    }
+    if (left_call->arguments().length() != right_call->arguments().length()) {
+      return false;
+    }
+    for (int i = 0; i < left_call->arguments().length(); i++) {
+      if (!equivalent_expression(left_call->arguments()[i],
+                                 right_call->arguments()[i])) return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+static void expect(const char* expected, const std::string& actual) {
+  if (actual == expected) return;
+  fprintf(stderr, "Expected:\n---\n%s\n---\nActual:\n---\n%s\n---\n", expected,
+          actual.c_str());
+  exit(1);
+}
+
+static std::string render_expression(ast::Expression* expression,
+                                     Source* source, int preferred_width,
+                                     bool apply_repairs = true) {
+  LayoutBuilder layouts;
+  LogicalOperatorBindings bindings;
+  SyntaxProtection syntax;
+  LoweredExpression lowered =
+      lower_expression(expression, source, &layouts, &bindings, &syntax);
+  SelectedPlan selected = select_layout(lowered.layout, preferred_width);
+  if (apply_repairs) {
+    WhitespaceEdits edits = FormatRepairs::propose(bindings, selected);
+    if (!selected.apply(edits)) exit(1);
+  }
+  FinalPlan final = std::move(selected).freeze();
+  return render_plan(final, syntax.resolve(final));
+}
+
+static void test_conflicting_repairs_are_rejected_atomically() {
+  LayoutBuilder builder;
+  LayoutGap gap = builder.gap();
+  Layout* layout = builder.group(builder.concat({
+      builder.text("left"),
+      builder.line(gap),
+      builder.text("right"),
+  }));
+  SelectedPlan selected = select_layout(layout, 100);
+
+  WhitespaceEdits edits;
+  if (edits.request(gap, GapState::FLAT, "first-rule") !=
+      WhitespaceEdits::ADDED) exit(1);
+  if (edits.request(gap, GapState::FLAT, "compatible-rule") !=
+      WhitespaceEdits::ALREADY_REQUESTED) exit(1);
+  if (edits.request(gap, GapState::NEWLINE, "conflicting-rule") !=
+      WhitespaceEdits::CONFLICT) exit(1);
+  if (!edits.has_conflict() || edits.conflicts().size() != 1) exit(1);
+  if (selected.apply(edits)) exit(1);
+
+  // A conflict is detected before the plan is touched; the generic choice is
+  // still available for diagnostics or safe fallback behavior.
+  expect("left right", render_plan(std::move(selected).freeze()));
+}
+
+static void test_parsed_expressions(Source* source,
+                                    ast::Unit* unit,
+                                    SourceManager* sources) {
+  ASSERT(unit->declarations().length() == 4);
+  ast::Method* sample = unit->declarations()[2]->as_Method();
+  ASSERT(sample != null);
+  List<ast::Expression*> expressions = sample->body()->expressions();
+  ASSERT(expressions.length() == 5);
+
+  // Source parentheses disappear from the logical layout. They return only
+  // when the selected topology needs them to keep the nested call together.
+  expect("outer (inner 1)", render_expression(expressions[0], source, 20));
+  expect("outer\n    inner 1", render_expression(expressions[0], source, 11));
+
+  // Precedence protection is independent of line selection. The source tree
+  // is `(a + b) * c`; after peeling source parens, the syntax pass reconstructs
+  // the one pair required to preserve that tree.
+  // Its logical width is nine; the reconstructed parens are deliberately not
+  // counted even though they make the physical result eleven columns wide.
+  expect("(a + b) * c", render_expression(expressions[1], source, 9));
+
+  // Breaking the lower-precedence `or` first keeps the tighter `and` group
+  // together and places the continuation at a fixed four-space indent. The
+  // generic plan remains regular and correct; the post-selection matcher owns
+  // the complete aesthetic adjustment.
+  expect("foo\n    or bar\n        and gee",
+         render_expression(expressions[2], source, 16, false));
+  expect("foo or\n    bar and gee",
+         render_expression(expressions[2], source, 16));
+
+  // Canonicalization removes redundant source parens, not meaningful tree
+  // structure. The lower-precedence `or` must be protected when it is the
+  // left operand of `and`.
+  expect("(foo or bar) and gee",
+         render_expression(expressions[3], source, 100));
+
+  // The input split after `or` is not retained as a preference. With room for
+  // the canonical flat form, selection joins it again.
+  expect("alpha or beta", render_expression(expressions[4], source, 100));
+
+  // Reparse representative flat and broken results, compare their trees, and
+  // format the reparsed trees again. This catches both semantic changes and
+  // non-idempotent layout decisions without counting source parens as nodes.
+  const int widths[] = {20, 11, 9, 16, 100, 100};
+  const int indices[] = {0, 0, 1, 2, 3, 4};
+  for (int i = 0; i < 6; i++) {
+    ast::Expression* original = expressions[indices[i]];
+    std::string rendered = render_expression(original, source, widths[i]);
+    ParsedExpression reparsed = parse_expression(rendered, sources);
+    if (!equivalent_expression(original, reparsed.expression)) exit(1);
+    expect(rendered.c_str(),
+           render_expression(reparsed.expression,
+                             reparsed.source.get(),
+                             widths[i]));
+  }
+}
+
+} // namespace compiler
+} // namespace toit
+
+int main(int argc, char** argv) {
+  toit::throwing_new_allowed = true;
+  ASSERT(argc == 2);
+
+  toit::compiler::FilesystemLocal filesystem;
+  toit::compiler::SourceManager sources(&filesystem);
+  toit::compiler::NullDiagnostics diagnostics(&sources);
+  toit::compiler::SourceManager::LoadResult loaded =
+      sources.load_file(argv[1], toit::compiler::Package::invalid());
+  ASSERT(loaded.status == toit::compiler::SourceManager::LoadResult::OK);
+
+  toit::compiler::SymbolCanonicalizer symbols;
+  toit::compiler::Scanner scanner(loaded.source, &symbols, &diagnostics);
+  toit::compiler::Parser parser(loaded.source, &scanner, &diagnostics);
+  toit::compiler::ast::Unit* unit = parser.parse_unit();
+  ASSERT(!diagnostics.encountered_error());
+
+  toit::compiler::test_conflicting_repairs_are_rejected_atomically();
+  toit::compiler::test_parsed_expressions(loaded.source, unit, &sources);
+  return 0;
+}

--- a/tests/ctest/format-test-source.h
+++ b/tests/ctest/format-test-source.h
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#pragma once
+
+#include <string>
+
+#include "../../src/compiler/sources.h"
+
+namespace toit {
+namespace compiler {
+
+// An in-memory Source for semantic formatter tests. It lets tests reparse the
+// exact rendered bytes without depending on temporary-file behavior across
+// host platforms.
+class FormatTestSource : public Source {
+ public:
+  explicit FormatTestSource(const std::string& text) : text_(text) {}
+
+  const char* absolute_path() const override { return "///format-test.toit"; }
+  Package package() const override { return Package::invalid(); }
+  std::string error_path() const override { return absolute_path(); }
+  const uint8* text() const override {
+    return reinterpret_cast<const uint8*>(text_.data());
+  }
+  Range range(int from, int to) const override {
+    return Range(Position::from_token(from), Position::from_token(to));
+  }
+  int size() const override { return static_cast<int>(text_.size()); }
+  int offset_in_source(Position position) const override {
+    int offset = position.token();
+    return 0 <= offset && offset <= size() ? offset : -1;
+  }
+  bool is_lsp_marker_at(int offset) override {
+    USE(offset);
+    return false;
+  }
+  void text_range_without_marker(int from,
+                                 int to,
+                                 const uint8** text_from,
+                                 const uint8** text_to) override {
+    *text_from = text() + from;
+    *text_to = text() + to;
+  }
+
+ private:
+  std::string text_;
+};
+
+} // namespace compiler
+} // namespace toit


### PR DESCRIPTION
Part 3 of the formatter rewrite stack. Based on #3135.

This lowers parsed expressions into logical tokens and layout choices before reconstructing only the parentheses required by the selected result.

Important boundaries in this revision:

- source parentheses and source newlines are not layout preferences;
- atoms are handled explicitly, without a synthetic precedence above postfix;
- expression lowering exposes narrowly named logical-operator gaps, not a purportedly universal binding model;
- each aesthetic matcher is a named rule that can request whitespace changes only;
- all rule requests are collected, and contradictory requests reject the edit set atomically instead of making rule order observable.

The first matcher formats a broken mixed logical chain as:

```toit
foo or
    bar and gee
```

Unmatched shapes retain the generic, correct leading-operator layout.

Parsed tests cover redundant and required parentheses, greedy nested calls, source-newline removal, generic output before repair, conflicting repairs, and repaired mixed logical chains. Representative results are reparsed, compared structurally with the input expression, and formatted again to verify idempotence.

Stack: 3/5. The next PR adds generic parsed method-header lowering without token reordering.
