### PR TITLE
feat(formatter): place multiline method return types

### DIFF
--- a/src/compiler/format_layout.h
+++ b/src/compiler/format_layout.h
@@ -40,6 +40,8 @@ struct FormatStyle {
 // access token events. Freezing makes the result immutable; syntax protection
 // then responds to its line topology without feeding punctuation back into
 // width selection.
+// Method return-type placement is the sole token-order exception and is owned
+// by format_return_type.cc before repairs run.
 
 // A zero-width position in a layout. Expression lowering records markers at
 // syntax boundaries; later phases can then reason about selected newlines

--- a/src/compiler/format_method.cc
+++ b/src/compiler/format_method.cc
@@ -206,10 +206,5 @@ LoweredMethodHeader lower_method_header(
       .lower(method);
 }
 
-SelectedPlan select_method_header(const LoweredMethodHeader& header,
-                                  int preferred_width) {
-  return select_layout(header.source_order_, preferred_width);
-}
-
 } // namespace compiler
 } // namespace toit

--- a/src/compiler/format_method.h
+++ b/src/compiler/format_method.h
@@ -31,7 +31,8 @@ class MethodHeaderLowering;
 // Logical pieces of a parsed method header plus its regular source-order
 // layout. The pieces are private so callers cannot assemble or select an
 // alternate token order themselves. `select_method_header` is the one normal
-// entry point for selecting the regular source-order layout.
+// entry point; its implementation in format_return_type.cc owns the sole
+// formatter exception that may choose a different token order.
 class LoweredMethodHeader {
  private:
   LoweredMethodHeader(LayoutBuilder* layouts,
@@ -75,8 +76,9 @@ class LoweredMethodHeader {
 //         first
 //         second -> ReturnType:
 //
-// Trivia is not part of this prototype slice yet. Keeping the parsed pieces
-// separate makes their ownership explicit when trivia is added later.
+// Trivia is not part of this prototype slice yet. When it is added, trivia
+// around `->` must belong to semantic header pieces rather than source gaps so
+// the dedicated placement pass can carry comments without changing them.
 LoweredMethodHeader lower_method_header(
     ast::Method* method,
     Source* source,
@@ -85,9 +87,10 @@ LoweredMethodHeader lower_method_header(
     SyntaxProtection* syntax,
     const FormatStyle& style = FormatStyle());
 
-// Selects the complete method header in source order. Low-level Layout
-// selection remains public for focused phase tests, but callers cannot bypass
-// this entry point through LoweredMethodHeader.
+// Selects the complete method header, including the specialized return-type
+// placement policy when parameters break. Low-level Layout selection remains
+// public for focused phase tests, but callers cannot access either header
+// candidate through LoweredMethodHeader.
 SelectedPlan select_method_header(const LoweredMethodHeader& header,
                                   int preferred_width);
 

--- a/src/compiler/format_return_type.cc
+++ b/src/compiler/format_return_type.cc
@@ -1,0 +1,67 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#include "format_method.h"
+
+#include "../top.h"
+
+namespace toit {
+namespace compiler {
+
+// This file is the only formatter implementation allowed to construct a
+// token order different from the AST's ordinary source order.
+SelectedPlan select_method_header(const LoweredMethodHeader& header,
+                                  int preferred_width) {
+  ASSERT(header.source_order_ != null);
+  SelectedPlan regular = select_layout(header.source_order_, preferred_width);
+  if (header.return_type_ == null ||
+      !regular.has_break_between(header.parameters_start_,
+                                 header.parameters_end_)) {
+    return regular;
+  }
+
+  // Generic selection found multiline parameters. Build the one exceptional
+  // order directly from semantic header pieces:
+  //
+  //     foo -> ReturnType
+  //         first
+  //         second
+  //     :
+  //
+  // No general Layout or SelectedPlan API can express token relocation.
+  std::vector<Layout*> forced_parameters;
+  for (Layout* parameter : header.parameters_) {
+    forced_parameters.push_back(header.layouts_->hardline());
+    forced_parameters.push_back(parameter);
+  }
+  Layout* parameter_lines = header.layouts_->indent(
+      header.continuation_step_,
+      header.layouts_->concat(std::move(forced_parameters)));
+  std::vector<Layout*> reordered = {
+      header.name_,
+      header.layouts_->text(" -> "),
+      header.return_type_,
+      parameter_lines,
+  };
+  if (header.has_colon_) {
+    reordered.push_back(header.layouts_->hardline());
+    reordered.push_back(header.layouts_->text(":"));
+  }
+  return select_layout(header.layouts_->concat(std::move(reordered)),
+                       preferred_width);
+}
+
+} // namespace compiler
+} // namespace toit

--- a/tests/ctest/format-method-test.cc
+++ b/tests/ctest/format-method-test.cc
@@ -118,8 +118,9 @@ static std::string render_header(ast::Method* method, Source* source,
   LoweredMethodHeader lowered =
       lower_method_header(method, source, &layouts, &bindings, &syntax);
 
-  // Method lowering feeds the same selection, whitespace-repair, freezing,
-  // and syntax-insertion pipeline as expressions.
+  // Return-type placement is deliberately the only selection entry point that
+  // may choose a different token order. Everything after it is whitespace-only
+  // repair, freezing, and syntax insertion, just as for expressions.
   SelectedPlan selected = select_method_header(lowered, preferred_width);
   WhitespaceEdits edits = FormatRepairs::propose(bindings, selected);
   if (!selected.apply(edits)) exit(1);
@@ -145,14 +146,14 @@ static void test_parsed_method_headers(Source* source,
   ast::Method* operator_name = unit->declarations()[6]->as_Method();
 
   expect("flat first second -> int:", render_header(flat, source, 100));
-  expect("flat\n    first\n    second -> int:",
+  expect("flat -> int\n    first\n    second\n:",
          render_header(flat, source, 20));
 
   // Input newlines and the input position of `->` do not become preferences.
   // Both ASTs receive the same canonical token order for the selected shape.
   expect("source-split first second -> int:",
          render_header(source_split, source, 100));
-  expect("source-split\n    first\n    second -> int:",
+  expect("source-split -> int\n    first\n    second\n:",
          render_header(source_split, source, 24));
 
   // Without a return type there is no structural exception. Generic selection
@@ -163,15 +164,16 @@ static void test_parsed_method_headers(Source* source,
   // components. Their spelling does not create separate layout policies.
   expect("shapes value/string? --named=1 [block] -> int?:",
          render_header(shapes, source, 100));
-  expect("shapes\n"
+  expect("shapes -> int?\n"
          "    value/string?\n"
          "    --named=1\n"
-         "    [block] -> int?:",
+         "    [block]\n"
+         ":",
          render_header(shapes, source, 30));
 
   expect("static declaration value -> int:",
          render_header(declaration, source, 100));
-  expect("static declaration\n    value -> int:",
+  expect("static declaration -> int\n    value\n:",
          render_header(declaration, source, 24));
 
   expect("operator [] index -> int:",
@@ -181,9 +183,10 @@ static void test_parsed_method_headers(Source* source,
   expect("operator-name -> int:",
          render_header(operator_name, source, 100));
 
-  // Exact strings are not enough: reparse both flat and broken headers,
-  // compare their semantic header trees, and format them a second time to
-  // verify idempotence.
+  // Return placement is the one formatter phase allowed to change token
+  // order, so exact strings are not enough. Reparse both ordinary and
+  // reordered headers, compare their semantic header trees, and format them a
+  // second time to verify idempotence.
   ast::Method* methods[] = {
       flat, flat, source_split, source_split, plain,
       shapes, declaration, index, constructor, operator_name,


### PR DESCRIPTION
Part 5 of the formatter rewrite stack. Based on #3139.

This isolates the formatter's one token-order exception in `format_return_type.cc`.

Generic method lowering still constructs and first selects the ordinary source-order header. Only when the selected parameter span is multiline does this pass construct the explicit return-first order:

```toit
foo -> ReturnType
    first
    second
:
```

Flat parameters retain the ordinary form:

```toit
foo first second -> ReturnType:
```

The exception consumes private semantic method pieces through the single `select_method_header` entry point. No general Layout, SelectedPlan, or repair API gains a relocation operation, and no other formatter component can assemble an alternative method-header order.

The method tests reparse both ordinary and reordered headers, compare their semantic header trees, and format them a second time to verify idempotence. Compiler analysis also passes for both formatter fixtures.

Stack: 5/5.
