### PR TITLE
feat(formatter): lower method headers in source order

### DIFF
--- a/src/compiler/format_method.cc
+++ b/src/compiler/format_method.cc
@@ -1,0 +1,215 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#include "format_method.h"
+
+#include "../top.h"
+#include "ast.h"
+#include "sources.h"
+
+#include <cstring>
+
+namespace toit {
+namespace compiler {
+
+class MethodHeaderLowering {
+ public:
+  MethodHeaderLowering(Source* source,
+                       LayoutBuilder* layouts,
+                       LogicalOperatorBindings* bindings,
+                       SyntaxProtection* syntax,
+                       const FormatStyle& style)
+      : source_(source)
+      , layouts_(layouts)
+      , bindings_(bindings)
+      , syntax_(syntax)
+      , style_(style) {}
+
+  LoweredMethodHeader lower(ast::Method* method) {
+    ASSERT(method != null);
+
+    std::vector<Layout*> name_parts;
+    if (method->is_abstract()) name_parts.push_back(layouts_->text("abstract "));
+    if (method->is_static()) name_parts.push_back(layouts_->text("static "));
+    name_parts.push_back(layouts_->text(method_name(method->name_or_dot())));
+    Layout* name = layouts_->concat(std::move(name_parts));
+    if (method->is_setter()) {
+      name = layouts_->concat({name, layouts_->text("=")});
+    }
+
+    std::vector<Layout*> parameters;
+    for (ast::Parameter* parameter : method->parameters()) {
+      parameters.push_back(lower_parameter(parameter));
+    }
+
+    Layout* return_type = method->return_type() == null
+        ? null
+        : lower_type(method->return_type());
+    LayoutMarker parameters_start = layouts_->marker();
+    LayoutMarker parameters_end = layouts_->marker();
+    Layout* regular_parameters = regular_parameter_list(
+        parameters, parameters_start, parameters_end);
+
+    std::vector<Layout*> source_order = {name, regular_parameters};
+    if (return_type != null) {
+      // This is the only ordering generic method lowering constructs. It is
+      // correct even when the group breaks; the dedicated pass may later
+      // construct a different ordering from the private semantic pieces.
+      source_order.push_back(layouts_->text(" -> "));
+      source_order.push_back(return_type);
+    }
+    bool has_colon = method->body() != null;
+    if (has_colon) source_order.push_back(layouts_->text(":"));
+
+    Layout* source_order_layout =
+        layouts_->group(layouts_->concat(std::move(source_order)));
+    return LoweredMethodHeader(layouts_, source_order_layout, name,
+                               std::move(parameters), return_type, has_colon,
+                               parameters_start, parameters_end,
+                               style_.continuation_step);
+  }
+
+ private:
+  Source* source_;
+  LayoutBuilder* layouts_;
+  LogicalOperatorBindings* bindings_;
+  SyntaxProtection* syntax_;
+  const FormatStyle& style_;
+
+  std::string source_text(ast::Node* node) const {
+    Source::Range range = node->full_range();
+    ASSERT(range.is_valid());
+    int from = source_->offset_in_source(range.from());
+    int to = source_->offset_in_source(range.to());
+    ASSERT(from >= 0 && to >= from);
+    return std::string(reinterpret_cast<const char*>(source_->text()) + from,
+                       to - from);
+  }
+
+  std::string qualified_name(ast::Expression* name) const {
+    if (name->is_Identifier()) return name->as_Identifier()->data().c_str();
+    if (name->is_Dot()) {
+      ast::Dot* dot = name->as_Dot();
+      return qualified_name(dot->receiver()) + "." + dot->name()->data().c_str();
+    }
+    if (name->is_Error()) UNREACHABLE();
+    UNREACHABLE();
+  }
+
+  std::string method_name(ast::Expression* name) const {
+    if (!name->is_Identifier()) return qualified_name(name);
+
+    ast::Identifier* identifier = name->as_Identifier();
+    std::string canonical = identifier->data().c_str();
+    // Ordinary identifiers have exactly their canonical bytes as their range.
+    // Operator identifier ranges also include the `operator` keyword. This
+    // comparison avoids treating a legal method such as `operator-name` as an
+    // operator merely because its spelling starts with those characters.
+    return source_text(name) == canonical
+        ? canonical
+        : std::string("operator ") + canonical;
+  }
+
+  Layout* lower_type(ast::Expression* type) {
+    if (type->is_Identifier()) {
+      return layouts_->text(type->as_Identifier()->data().c_str());
+    }
+    if (type->is_Dot()) {
+      ast::Dot* dot = type->as_Dot();
+      return layouts_->concat({lower_type(dot->receiver()),
+                               layouts_->text("."),
+                               layouts_->text(dot->name()->data().c_str())});
+    }
+    if (type->is_Nullable()) {
+      return layouts_->concat({lower_type(type->as_Nullable()->type()),
+                               layouts_->text("?")});
+    }
+    if (type->is_Error()) UNREACHABLE();
+    UNREACHABLE();
+  }
+
+  std::string field_prefix(ast::Parameter* parameter) const {
+    ASSERT(parameter->is_field_storing());
+    int name_from = source_->offset_in_source(
+        parameter->name()->full_range().from());
+    const char* text = reinterpret_cast<const char*>(source_->text());
+    // The parser requires both spellings to be attached. Looking immediately
+    // before the name is therefore token-precise and cannot be confused by a
+    // comment or by another occurrence of the word `this` in the parameter.
+    if (name_from >= 5 && std::memcmp(text + name_from - 5, "this.", 5) == 0) {
+      return "this.";
+    }
+    ASSERT(name_from >= 1 && text[name_from - 1] == '.');
+    return ".";
+  }
+
+  Layout* lower_parameter(ast::Parameter* parameter) {
+    std::vector<Layout*> parts;
+    if (parameter->is_block()) parts.push_back(layouts_->text("["));
+    if (parameter->is_named()) parts.push_back(layouts_->text("--"));
+    if (parameter->is_field_storing()) {
+      parts.push_back(layouts_->text(field_prefix(parameter)));
+    }
+    parts.push_back(layouts_->text(parameter->name()->data().c_str()));
+    if (parameter->type() != null) {
+      parts.push_back(layouts_->text("/"));
+      parts.push_back(lower_type(parameter->type()));
+    }
+    if (parameter->default_value() != null) {
+      parts.push_back(layouts_->text("="));
+      parts.push_back(lower_expression(parameter->default_value(), source_,
+                                        layouts_, bindings_, syntax_, style_)
+                          .layout);
+    }
+    if (parameter->is_block()) parts.push_back(layouts_->text("]"));
+    return layouts_->concat(std::move(parts));
+  }
+
+  Layout* regular_parameter_list(const std::vector<Layout*>& parameters,
+                                 LayoutMarker start,
+                                 LayoutMarker end) {
+    std::vector<Layout*> parts = {layouts_->mark(start)};
+    for (Layout* parameter : parameters) {
+      parts.push_back(layouts_->line());
+      parts.push_back(parameter);
+    }
+    parts.push_back(layouts_->mark(end));
+    return layouts_->indent(style_.continuation_step,
+                            layouts_->concat(std::move(parts)));
+  }
+};
+
+LoweredMethodHeader lower_method_header(
+    ast::Method* method,
+    Source* source,
+    LayoutBuilder* layouts,
+    LogicalOperatorBindings* bindings,
+    SyntaxProtection* syntax,
+    const FormatStyle& style) {
+  ASSERT(source != null);
+  ASSERT(layouts != null);
+  ASSERT(bindings != null);
+  ASSERT(syntax != null);
+  return MethodHeaderLowering(source, layouts, bindings, syntax, style)
+      .lower(method);
+}
+
+SelectedPlan select_method_header(const LoweredMethodHeader& header,
+                                  int preferred_width) {
+  return select_layout(header.source_order_, preferred_width);
+}
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_method.h
+++ b/src/compiler/format_method.h
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#pragma once
+
+#include <vector>
+
+#include "format_expression.h"
+
+namespace toit {
+namespace compiler {
+
+namespace ast {
+class Method;
+}
+
+class MethodHeaderLowering;
+
+// Logical pieces of a parsed method header plus its regular source-order
+// layout. The pieces are private so callers cannot assemble or select an
+// alternate token order themselves. `select_method_header` is the one normal
+// entry point for selecting the regular source-order layout.
+class LoweredMethodHeader {
+ private:
+  LoweredMethodHeader(LayoutBuilder* layouts,
+                      Layout* source_order,
+                      Layout* name,
+                      std::vector<Layout*> parameters,
+                      Layout* return_type,
+                      bool has_colon,
+                      LayoutMarker parameters_start,
+                      LayoutMarker parameters_end,
+                      int continuation_step)
+      : layouts_(layouts)
+      , source_order_(source_order)
+      , name_(name)
+      , parameters_(std::move(parameters))
+      , return_type_(return_type)
+      , has_colon_(has_colon)
+      , parameters_start_(parameters_start)
+      , parameters_end_(parameters_end)
+      , continuation_step_(continuation_step) {}
+
+  LayoutBuilder* layouts_;
+  Layout* source_order_;
+  Layout* name_;
+  std::vector<Layout*> parameters_;
+  Layout* return_type_;
+  bool has_colon_;
+  LayoutMarker parameters_start_;
+  LayoutMarker parameters_end_;
+  int continuation_step_;
+
+  friend class MethodHeaderLowering;
+  friend SelectedPlan select_method_header(const LoweredMethodHeader&,
+                                           int preferred_width);
+};
+
+// Lowers actual parsed header components and constructs only their regular,
+// source-order layout:
+//
+//     foo
+//         first
+//         second -> ReturnType:
+//
+// Trivia is not part of this prototype slice yet. Keeping the parsed pieces
+// separate makes their ownership explicit when trivia is added later.
+LoweredMethodHeader lower_method_header(
+    ast::Method* method,
+    Source* source,
+    LayoutBuilder* layouts,
+    LogicalOperatorBindings* bindings,
+    SyntaxProtection* syntax,
+    const FormatStyle& style = FormatStyle());
+
+// Selects the complete method header in source order. Low-level Layout
+// selection remains public for focused phase tests, but callers cannot bypass
+// this entry point through LoweredMethodHeader.
+SelectedPlan select_method_header(const LoweredMethodHeader& header,
+                                  int preferred_width);
+
+} // namespace compiler
+} // namespace toit

--- a/tests/ctest/format-method-input.toit
+++ b/tests/ctest/format-method-input.toit
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+flat first second -> int:
+  return 0
+
+source-split
+    first
+    -> int
+    second
+:
+  return 0
+
+plain first second:
+  null
+
+shapes value/string? --named=1 [block] -> int?:
+  return 0
+
+class Holder:
+  static declaration value -> int:
+    return value
+
+  operator [] index -> int:
+    return index
+
+class Fields:
+  value/any
+  other/any
+
+  constructor this.value .other:
+    null
+
+operator-name -> int:
+  return 0
+
+main:
+  null

--- a/tests/ctest/format-method-test.cc
+++ b/tests/ctest/format-method-test.cc
@@ -1,0 +1,223 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <cstring>
+#include <memory>
+
+#include "../../src/compiler/ast.h"
+#include "../../src/compiler/diagnostic.h"
+#include "../../src/compiler/filesystem_local.h"
+#include "../../src/compiler/format_method.h"
+#include "../../src/compiler/parser.h"
+#include "../../src/compiler/scanner.h"
+#include "../../src/compiler/symbol_canonicalizer.h"
+#include "../../src/top.h"
+#include "format-test-source.h"
+
+namespace toit {
+namespace compiler {
+
+struct ParsedMethod {
+  std::unique_ptr<FormatTestSource> source;
+  std::unique_ptr<SymbolCanonicalizer> symbols;
+  ast::Method* method;
+};
+
+static ParsedMethod parse_header(const std::string& header,
+                                 SourceManager* sources) {
+  if (header.empty() || header.back() != ':') exit(1);
+  ParsedMethod result;
+  result.source.reset(new FormatTestSource(header + "\n  null\n"));
+  result.symbols.reset(new SymbolCanonicalizer());
+  NullDiagnostics diagnostics(sources);
+  Scanner scanner(result.source.get(), result.symbols.get(), &diagnostics);
+  Parser parser(result.source.get(), &scanner, &diagnostics);
+  ast::Unit* unit = parser.parse_unit();
+  if (diagnostics.encountered_error() || unit->declarations().length() != 1) {
+    exit(1);
+  }
+  result.method = unit->declarations()[0]->as_Method();
+  if (result.method == null) exit(1);
+  return result;
+}
+
+static bool same_symbol(Symbol left, Symbol right) {
+  return std::strcmp(left.c_str(), right.c_str()) == 0;
+}
+
+static bool equivalent_header_expression(ast::Expression* left,
+                                         ast::Expression* right) {
+  if (left == null || right == null) return left == right;
+  if (left->is_Identifier() && right->is_Identifier()) {
+    return same_symbol(left->as_Identifier()->data(),
+                       right->as_Identifier()->data());
+  }
+  if (left->is_Dot() && right->is_Dot()) {
+    return equivalent_header_expression(left->as_Dot()->receiver(),
+                                        right->as_Dot()->receiver())
+        && equivalent_header_expression(left->as_Dot()->name(),
+                                        right->as_Dot()->name());
+  }
+  if (left->is_Nullable() && right->is_Nullable()) {
+    return equivalent_header_expression(left->as_Nullable()->type(),
+                                        right->as_Nullable()->type());
+  }
+  if (left->is_LiteralInteger() && right->is_LiteralInteger()) {
+    return same_symbol(left->as_LiteralInteger()->data(),
+                       right->as_LiteralInteger()->data());
+  }
+  return false;
+}
+
+static bool equivalent_parameter(ast::Parameter* left,
+                                 ast::Parameter* right) {
+  return left->is_named() == right->is_named()
+      && left->is_field_storing() == right->is_field_storing()
+      && left->is_block() == right->is_block()
+      && equivalent_header_expression(left->name(), right->name())
+      && equivalent_header_expression(left->type(), right->type())
+      && equivalent_header_expression(left->default_value(),
+                                      right->default_value());
+}
+
+static bool equivalent_header(ast::Method* left, ast::Method* right) {
+  if (left->is_setter() != right->is_setter() ||
+      left->is_static() != right->is_static() ||
+      left->is_abstract() != right->is_abstract() ||
+      !equivalent_header_expression(left->name_or_dot(),
+                                    right->name_or_dot()) ||
+      !equivalent_header_expression(left->return_type(),
+                                    right->return_type()) ||
+      left->parameters().length() != right->parameters().length()) {
+    return false;
+  }
+  for (int i = 0; i < left->parameters().length(); i++) {
+    if (!equivalent_parameter(left->parameters()[i], right->parameters()[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static void expect(const char* expected, const std::string& actual) {
+  if (actual == expected) return;
+  fprintf(stderr, "Expected:\n---\n%s\n---\nActual:\n---\n%s\n---\n", expected,
+          actual.c_str());
+  exit(1);
+}
+
+static std::string render_header(ast::Method* method, Source* source,
+                                 int preferred_width) {
+  LayoutBuilder layouts;
+  LogicalOperatorBindings bindings;
+  SyntaxProtection syntax;
+  LoweredMethodHeader lowered =
+      lower_method_header(method, source, &layouts, &bindings, &syntax);
+
+  // Method lowering feeds the same selection, whitespace-repair, freezing,
+  // and syntax-insertion pipeline as expressions.
+  SelectedPlan selected = select_method_header(lowered, preferred_width);
+  WhitespaceEdits edits = FormatRepairs::propose(bindings, selected);
+  if (!selected.apply(edits)) exit(1);
+  FinalPlan final = std::move(selected).freeze();
+  return render_plan(final, syntax.resolve(final));
+}
+
+static void test_parsed_method_headers(Source* source,
+                                       ast::Unit* unit,
+                                       SourceManager* sources) {
+  ASSERT(unit->declarations().length() == 8);
+  ast::Method* flat = unit->declarations()[0]->as_Method();
+  ast::Method* source_split = unit->declarations()[1]->as_Method();
+  ast::Method* plain = unit->declarations()[2]->as_Method();
+  ast::Method* shapes = unit->declarations()[3]->as_Method();
+  ast::Class* holder = unit->declarations()[4]->as_Class();
+  ASSERT(holder != null && holder->members().length() == 2);
+  ast::Method* declaration = holder->members()[0]->as_Method();
+  ast::Method* index = holder->members()[1]->as_Method();
+  ast::Class* fields = unit->declarations()[5]->as_Class();
+  ASSERT(fields != null && fields->members().length() == 3);
+  ast::Method* constructor = fields->members()[2]->as_Method();
+  ast::Method* operator_name = unit->declarations()[6]->as_Method();
+
+  expect("flat first second -> int:", render_header(flat, source, 100));
+  expect("flat\n    first\n    second -> int:",
+         render_header(flat, source, 20));
+
+  // Input newlines and the input position of `->` do not become preferences.
+  // Both ASTs receive the same canonical token order for the selected shape.
+  expect("source-split first second -> int:",
+         render_header(source_split, source, 100));
+  expect("source-split\n    first\n    second -> int:",
+         render_header(source_split, source, 24));
+
+  // Without a return type there is no structural exception. Generic selection
+  // keeps source token order and merely breaks the parameter gaps.
+  expect("plain\n    first\n    second:", render_header(plain, source, 12));
+
+  // Named, block, typed, and defaulted parameters are ordinary parameter
+  // components. Their spelling does not create separate layout policies.
+  expect("shapes value/string? --named=1 [block] -> int?:",
+         render_header(shapes, source, 100));
+  expect("shapes\n"
+         "    value/string?\n"
+         "    --named=1\n"
+         "    [block] -> int?:",
+         render_header(shapes, source, 30));
+
+  expect("static declaration value -> int:",
+         render_header(declaration, source, 100));
+  expect("static declaration\n    value -> int:",
+         render_header(declaration, source, 24));
+
+  expect("operator [] index -> int:",
+         render_header(index, source, 100));
+  expect("constructor this.value .other:",
+         render_header(constructor, source, 100));
+  expect("operator-name -> int:",
+         render_header(operator_name, source, 100));
+
+  // Exact strings are not enough: reparse both flat and broken headers,
+  // compare their semantic header trees, and format them a second time to
+  // verify idempotence.
+  ast::Method* methods[] = {
+      flat, flat, source_split, source_split, plain,
+      shapes, declaration, index, constructor, operator_name,
+  };
+  int widths[] = {100, 20, 100, 24, 12, 30, 24, 100, 100, 100};
+  for (int i = 0; i < 10; i++) {
+    std::string rendered = render_header(methods[i], source, widths[i]);
+    ParsedMethod reparsed = parse_header(rendered, sources);
+    if (!equivalent_header(methods[i], reparsed.method)) exit(1);
+    expect(rendered.c_str(),
+           render_header(reparsed.method, reparsed.source.get(), widths[i]));
+  }
+}
+
+} // namespace compiler
+} // namespace toit
+
+int main(int argc, char** argv) {
+  toit::throwing_new_allowed = true;
+  ASSERT(argc == 2);
+
+  toit::compiler::FilesystemLocal filesystem;
+  toit::compiler::SourceManager sources(&filesystem);
+  toit::compiler::NullDiagnostics diagnostics(&sources);
+  toit::compiler::SourceManager::LoadResult loaded =
+      sources.load_file(argv[1], toit::compiler::Package::invalid());
+  ASSERT(loaded.status == toit::compiler::SourceManager::LoadResult::OK);
+
+  toit::compiler::SymbolCanonicalizer symbols;
+  toit::compiler::Scanner scanner(loaded.source, &symbols, &diagnostics);
+  toit::compiler::Parser parser(loaded.source, &scanner, &diagnostics);
+  toit::compiler::ast::Unit* unit = parser.parse_unit();
+  ASSERT(!diagnostics.encountered_error());
+
+  toit::compiler::test_parsed_method_headers(loaded.source, unit, &sources);
+  return 0;
+}


### PR DESCRIPTION
Part 4 of the formatter rewrite stack. Based on #3137.

This adds parsed method-header lowering while deliberately retaining ordinary source token order in every selected shape:

```toit
foo
    first
    second -> ReturnType:
```

Names, qualified and nullable types, parameters, defaults, and modifiers are lowered from AST structure. The two places that must distinguish parser spellings use exact attached source bytes; they do not strip whitespace, search for substrings, or infer syntax from prefixes.

Named, block, typed, defaulted, and field-storing parameters all use the same generic parameter layout. The return type is still an ordinary trailing header component in this PR.

Tests cover flat and broken headers, ignored source newlines, methods without return types, the parameter variants above, static and operator methods, the legal `operator-name` identifier, and both field-storing spellings. Every representative result is reparsed, compared structurally with the original header, and formatted again to verify idempotence.

Stack: 4/5. The final PR adds the single explicit token-order exception for multiline return types.
