### PR TITLE
Avoid flash-size probe on ESP32-S2

### DIFF
--- a/tools/firmware.toit
+++ b/tools/firmware.toit
@@ -1199,12 +1199,17 @@ flash invocation/cli.Invocation -> none:
           // Verify that the device's flash is big enough for the partition
           // table. 'build-esp32-image' derived the required flash size from the
           // partition table and stored it in the flashing settings.
-          required-flash-size := parse-flash-size_ flashing["flash_settings"]["flash_size"] --ui=ui
-          detected-flash-size := detect-flash-size_ esptool --port=port --chip=chip
-          if detected-flash-size and detected-flash-size < required-flash-size:
-            ui.abort "The partition table needs $(required-flash-size / 0x100000)MB of flash, but the device only has $(detected-flash-size / 0x100000)MB."
-          if not detected-flash-size:
-            ui.emit --warning "Could not determine the device's flash size; skipping the flash-size check."
+          // Any serial interaction with an ESP32-S2 using its integrated USB
+          // peripheral takes it out of manually entered download mode. Running
+          // 'flash-id' here would therefore make the port disappear before the
+          // actual 'write-flash' command gets a chance to open it.
+          if chip != "esp32s2":
+            required-flash-size := parse-flash-size_ flashing["flash_settings"]["flash_size"] --ui=ui
+            detected-flash-size := detect-flash-size_ esptool --port=port --chip=chip
+            if detected-flash-size and detected-flash-size < required-flash-size:
+              ui.abort "The partition table needs $(required-flash-size / 0x100000)MB of flash, but the device only has $(detected-flash-size / 0x100000)MB."
+            if not detected-flash-size:
+              ui.emit --warning "Could not determine the device's flash size; skipping the flash-size check."
 
           // The new esptool has deprecated underscores in some arguments.
           // TODO(floitsch): remove these replacements when the esp-idf has been updated


### PR DESCRIPTION
## Problem

The firmware flash command runs a separate `esptool flash-id` process before `write-flash` to validate the physical flash size.

On ESP32-S2 boards using the integrated USB peripheral, the first serial session takes the board out of manually entered download mode. The USB serial port disappears, so the subsequent `write-flash` process fails with `No such file or directory`.

This recreates the two-session failure that toitlang/jaguar#698 previously addressed in Jaguar itself.

## Fix

Skip the flash-size preflight probe for ESP32-S2. Other chip types retain the physical-flash-size check.

The tradeoff is that ESP32-S2 no longer gets an early error when a custom partition table requires more flash than the device provides. Image construction, partition validation, bootloader header adjustment, writing, and verification remain unchanged.

## Testing

- Reproduced through `jag flash --chip=esp32s2 --port /dev/ttyACM2` with SDK v2.0.0-alpha.196.
- Reproduced directly through `toit tool firmware ... flash --port=/dev/ttyACM2`.
- Verified the patched firmware tool directly on an ESP32-S2FNR2 using USB-OTG: all partitions written and verified, exit 0.
- Rebuilt the local SDK and verified the full Jaguar command: all partitions written and verified, exit 0.
- `toit analyze tools/firmware.toit` passes.