### PR TITLE
feat(formatter): lower trivia into semantic layouts

### DIFF
--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -17,8 +17,11 @@
 
 #include "../top.h"
 #include "ast.h"
+#include "format_trivia.h"
 #include "sources.h"
 #include "token.h"
+
+#include <algorithm>
 
 namespace toit {
 namespace compiler {
@@ -47,18 +50,48 @@ bool is_logical(Token::Kind kind) {
 
 class ExpressionLowering {
  public:
-  ExpressionLowering(Source* source, LayoutBuilder* layouts,
+  ExpressionLowering(Source* source,
+                     LayoutBuilder* layouts,
                      LogicalOperatorBindings* bindings,
                      SyntaxProtection* syntax,
-                     const FormatStyle& style)
+                     const FormatStyle& style,
+                     TriviaLowering* trivia)
       : source_(source)
       , layouts_(layouts)
       , bindings_(bindings)
       , syntax_(syntax)
-      , style_(style) {}
+      , style_(style)
+      , trivia_(trivia) {}
 
   LoweredExpression lower(Expression* expression, int outer_precedence) {
     ASSERT(expression != null);
+
+    // A real line comment makes its source line an immutable formatting
+    // island. The current expression slice conservatively preserves the
+    // complete expression when that line is inside it; this keeps every byte
+    // on the frozen line unchanged and, importantly, prevents a repair or
+    // parenthesis rule from moving syntax across it.
+    Expression* source_expression = expression;
+    if (trivia_ != null) {
+      Source::Range source_range = source_expression->full_range();
+      int source_from = source_->offset_in_source(source_range.from());
+      int source_to = source_->offset_in_source(source_range.to());
+      int line_comment =
+          trivia_->first_line_comment(source_from, source_to, true);
+      if (line_comment >= 0) {
+        source_to = std::max(source_to, trivia_->comment(line_comment).to);
+        LayoutMarker start = layouts_->marker();
+        LayoutMarker end = layouts_->marker();
+        return {
+            layouts_->concat({
+                layouts_->mark(start),
+                trivia_->verbatim_region(source_from, source_to),
+                layouts_->mark(end),
+            }),
+            {start, end},
+        };
+      }
+    }
 
     // Parenthesis nodes describe how the input happened to spell the tree.
     // Precedence and line topology below describe how the output must spell
@@ -69,9 +102,20 @@ class ExpressionLowering {
     LayoutMarker start = layouts_->marker();
     LayoutMarker end = layouts_->marker();
     Layout* contents = lower_contents(expression, outer_precedence);
+    Layout* semantic = layouts_->concat(
+        {layouts_->mark(start), contents, layouts_->mark(end)});
+    if (trivia_ != null) {
+      int source_to =
+          source_->offset_in_source(source_expression->full_range().to());
+      int line_end = source_to;
+      while (line_end < source_->size() && source_->text()[line_end] != '\n' &&
+             source_->text()[line_end] != '\r') {
+        line_end++;
+      }
+      semantic = trivia_->take_inline_suffix(semantic, source_to, line_end);
+    }
     LoweredExpression result = {
-        layouts_->concat(
-            {layouts_->mark(start), contents, layouts_->mark(end)}),
+        semantic,
         {start, end},
     };
     if (requires_parentheses_in(expression, outer_precedence)) {
@@ -86,6 +130,7 @@ class ExpressionLowering {
   LogicalOperatorBindings* bindings_;
   SyntaxProtection* syntax_;
   const FormatStyle& style_;
+  TriviaLowering* trivia_;
 
   bool requires_parentheses_in(Expression* expression,
                                int outer_precedence) const {
@@ -261,16 +306,18 @@ class ExpressionLowering {
 
 } // namespace
 
-LoweredExpression lower_expression(Expression* expression, Source* source,
+LoweredExpression lower_expression(Expression* expression,
+                                   Source* source,
                                    LayoutBuilder* layouts,
                                    LogicalOperatorBindings* bindings,
                                    SyntaxProtection* syntax,
-                                   const FormatStyle& style) {
+                                   const FormatStyle& style,
+                                   TriviaLowering* trivia) {
   ASSERT(source != null);
   ASSERT(layouts != null);
   ASSERT(bindings != null);
   ASSERT(syntax != null);
-  return ExpressionLowering(source, layouts, bindings, syntax, style)
+  return ExpressionLowering(source, layouts, bindings, syntax, style, trivia)
       .lower(expression, PRECEDENCE_NONE);
 }
 

--- a/src/compiler/format_expression.h
+++ b/src/compiler/format_expression.h
@@ -23,6 +23,7 @@ namespace toit {
 namespace compiler {
 
 class Source;
+class TriviaLowering;
 
 namespace ast {
 class Expression;
@@ -40,12 +41,14 @@ struct LoweredExpression {
 //
 // This first slice supports atoms, unary/binary expressions, and ordinary
 // calls. Keeping the entry point narrow makes the architectural invariant
-// reviewable before suites, collections, and trivia add more layout shapes.
-LoweredExpression lower_expression(ast::Expression* expression, Source* source,
+// reviewable before suites and collections add more layout shapes.
+LoweredExpression lower_expression(ast::Expression* expression,
+                                   Source* source,
                                    LayoutBuilder* layouts,
                                    LogicalOperatorBindings* bindings,
                                    SyntaxProtection* syntax,
-                                   const FormatStyle& style = FormatStyle());
+                                   const FormatStyle& style = FormatStyle(),
+                                   TriviaLowering* trivia = nullptr);
 
 } // namespace compiler
 } // namespace toit

--- a/src/compiler/format_method.cc
+++ b/src/compiler/format_method.cc
@@ -17,8 +17,10 @@
 
 #include "../top.h"
 #include "ast.h"
+#include "format_trivia.h"
 #include "sources.h"
 
+#include <algorithm>
 #include <cstring>
 
 namespace toit {
@@ -30,15 +32,51 @@ class MethodHeaderLowering {
                        LayoutBuilder* layouts,
                        LogicalOperatorBindings* bindings,
                        SyntaxProtection* syntax,
-                       const FormatStyle& style)
+                       const FormatStyle& style,
+                       TriviaLowering* trivia)
       : source_(source)
       , layouts_(layouts)
       , bindings_(bindings)
       , syntax_(syntax)
-      , style_(style) {}
+      , style_(style)
+      , trivia_(trivia) {}
 
   LoweredMethodHeader lower(ast::Method* method) {
     ASSERT(method != null);
+
+    int header_from = start(method);
+    int signature_end = end(method->name_or_dot());
+    for (ast::Parameter* parameter : method->parameters()) {
+      signature_end = std::max(signature_end, end(parameter));
+    }
+    if (method->return_type() != null) {
+      signature_end = std::max(signature_end, end(method->return_type()));
+    }
+    int header_limit = end(method);
+    if (method->body() != null && !method->body()->expressions().is_empty()) {
+      header_limit = start(method->body()->expressions().first());
+    }
+    int colon_offset = method->body() == null
+                           ? -1
+                           : find_syntax(signature_end, header_limit, ":");
+
+    if (trivia_ != null) {
+      int frozen_limit = colon_offset < 0 ? signature_end : colon_offset + 1;
+      int line_comment =
+          trivia_->first_line_comment(header_from, frozen_limit, true);
+      if (line_comment >= 0) {
+        // Token movement across a verbatim line would contradict the rule that
+        // only its indentation may change. Preserve this complete header as
+        // the current conservative replacement unit and expose no semantic
+        // return piece to the exceptional placement pass.
+        frozen_limit =
+            std::max(frozen_limit, trivia_->comment(line_comment).to);
+        Layout* frozen = trivia_->verbatim_region(header_from, frozen_limit);
+        return LoweredMethodHeader(layouts_, frozen, frozen, {}, null, null,
+                                   LayoutMarker(), LayoutMarker(),
+                                   style_.continuation_step);
+      }
+    }
 
     std::vector<Layout*> name_parts;
     if (method->is_abstract()) name_parts.push_back(layouts_->text("abstract "));
@@ -49,18 +87,65 @@ class MethodHeaderLowering {
       name = layouts_->concat({name, layouts_->text("=")});
     }
 
+    int name_limit =
+        next_component_after(end(method->name_or_dot()), method, colon_offset);
+    if (trivia_ != null && name_limit >= 0) {
+      name = trivia_->take_inline_suffix(name, end(method->name_or_dot()),
+                                         name_limit);
+    }
+
     std::vector<Layout*> parameters;
-    for (ast::Parameter* parameter : method->parameters()) {
-      parameters.push_back(lower_parameter(parameter));
+    for (int i = 0; i < method->parameters().length(); i++) {
+      ast::Parameter* parameter = method->parameters()[i];
+      int limit = next_component_after(end(parameter), method, colon_offset);
+      parameters.push_back(lower_parameter(parameter, limit));
     }
 
     Layout* return_type = method->return_type() == null
         ? null
         : lower_type(method->return_type());
+    if (return_type != null && trivia_ != null) {
+      int type_start = start(method->return_type());
+      // A default value may itself contain the bytes `->` (for example in a
+      // string). The grammar's return arrow is the last such spelling before
+      // the return type; comments are skipped by find_syntax.
+      int arrow = -1;
+      int search_from = header_from;
+      while (true) {
+        int candidate = trivia_->find_syntax(search_from, type_start, "->");
+        if (candidate < 0) break;
+        arrow = candidate;
+        search_from = candidate + 2;
+      }
+      if (arrow >= 0) {
+        return_type =
+            trivia_->take_inline_prefix(return_type, arrow + 2, type_start);
+      }
+      int return_limit = next_component_after(end(method->return_type()),
+                                              method, colon_offset);
+      if (return_limit >= 0) {
+        return_type = trivia_->take_inline_suffix(
+            return_type, end(method->return_type()), return_limit);
+      }
+    }
+
+    Layout* colon = null;
+    if (colon_offset >= 0) {
+      colon = layouts_->text(":");
+      if (trivia_ != null) {
+        int line_end = colon_offset + 1;
+        while (line_end < source_->size() &&
+               source_->text()[line_end] != '\n' &&
+               source_->text()[line_end] != '\r') {
+          line_end++;
+        }
+        colon = trivia_->take_inline_suffix(colon, colon_offset + 1, line_end);
+      }
+    }
     LayoutMarker parameters_start = layouts_->marker();
     LayoutMarker parameters_end = layouts_->marker();
-    Layout* regular_parameters = regular_parameter_list(
-        parameters, parameters_start, parameters_end);
+    Layout* regular_parameters =
+        regular_parameter_list(parameters, parameters_start, parameters_end);
 
     std::vector<Layout*> source_order = {name, regular_parameters};
     if (return_type != null) {
@@ -70,15 +155,13 @@ class MethodHeaderLowering {
       source_order.push_back(layouts_->text(" -> "));
       source_order.push_back(return_type);
     }
-    bool has_colon = method->body() != null;
-    if (has_colon) source_order.push_back(layouts_->text(":"));
+    if (colon != null) source_order.push_back(colon);
 
     Layout* source_order_layout =
         layouts_->group(layouts_->concat(std::move(source_order)));
-    return LoweredMethodHeader(layouts_, source_order_layout, name,
-                               std::move(parameters), return_type, has_colon,
-                               parameters_start, parameters_end,
-                               style_.continuation_step);
+    return LoweredMethodHeader(
+        layouts_, source_order_layout, name, std::move(parameters), return_type,
+        colon, parameters_start, parameters_end, style_.continuation_step);
   }
 
  private:
@@ -87,6 +170,44 @@ class MethodHeaderLowering {
   LogicalOperatorBindings* bindings_;
   SyntaxProtection* syntax_;
   const FormatStyle& style_;
+  TriviaLowering* trivia_;
+
+  int start(ast::Node* node) const {
+    return source_->offset_in_source(node->full_range().from());
+  }
+
+  int end(ast::Node* node) const {
+    return source_->offset_in_source(node->full_range().to());
+  }
+
+  int find_syntax(int from, int to, const char* syntax) const {
+    if (trivia_ != null) return trivia_->find_syntax(from, to, syntax);
+    int length = std::strlen(syntax);
+    const uint8* text = source_->text();
+    for (int offset = from; offset + length <= to; offset++) {
+      if (std::memcmp(text + offset, syntax, length) == 0) return offset;
+    }
+    return -1;
+  }
+
+  int next_component_after(int offset,
+                           ast::Method* method,
+                           int colon_offset) const {
+    int result = colon_offset > offset ? colon_offset : -1;
+    for (ast::Parameter* parameter : method->parameters()) {
+      int candidate = start(parameter);
+      if (candidate > offset && (result < 0 || candidate < result)) {
+        result = candidate;
+      }
+    }
+    if (method->return_type() != null) {
+      int candidate = start(method->return_type());
+      if (candidate > offset && (result < 0 || candidate < result)) {
+        result = candidate;
+      }
+    }
+    return result;
+  }
 
   std::string source_text(ast::Node* node) const {
     Source::Range range = node->full_range();
@@ -155,7 +276,7 @@ class MethodHeaderLowering {
     return ".";
   }
 
-  Layout* lower_parameter(ast::Parameter* parameter) {
+  Layout* lower_parameter(ast::Parameter* parameter, int suffix_limit) {
     std::vector<Layout*> parts;
     if (parameter->is_block()) parts.push_back(layouts_->text("["));
     if (parameter->is_named()) parts.push_back(layouts_->text("--"));
@@ -170,11 +291,17 @@ class MethodHeaderLowering {
     if (parameter->default_value() != null) {
       parts.push_back(layouts_->text("="));
       parts.push_back(lower_expression(parameter->default_value(), source_,
-                                        layouts_, bindings_, syntax_, style_)
+                                       layouts_, bindings_, syntax_, style_,
+                                       trivia_)
                           .layout);
     }
     if (parameter->is_block()) parts.push_back(layouts_->text("]"));
-    return layouts_->concat(std::move(parts));
+    Layout* result = layouts_->concat(std::move(parts));
+    if (trivia_ != null && suffix_limit >= 0) {
+      result = trivia_->take_inline_suffix(
+          result, end(parameter), suffix_limit);
+    }
+    return result;
   }
 
   Layout* regular_parameter_list(const std::vector<Layout*>& parameters,
@@ -191,18 +318,18 @@ class MethodHeaderLowering {
   }
 };
 
-LoweredMethodHeader lower_method_header(
-    ast::Method* method,
-    Source* source,
-    LayoutBuilder* layouts,
-    LogicalOperatorBindings* bindings,
-    SyntaxProtection* syntax,
-    const FormatStyle& style) {
+LoweredMethodHeader lower_method_header(ast::Method* method,
+                                        Source* source,
+                                        LayoutBuilder* layouts,
+                                        LogicalOperatorBindings* bindings,
+                                        SyntaxProtection* syntax,
+                                        const FormatStyle& style,
+                                        TriviaLowering* trivia) {
   ASSERT(source != null);
   ASSERT(layouts != null);
   ASSERT(bindings != null);
   ASSERT(syntax != null);
-  return MethodHeaderLowering(source, layouts, bindings, syntax, style)
+  return MethodHeaderLowering(source, layouts, bindings, syntax, style, trivia)
       .lower(method);
 }
 

--- a/src/compiler/format_method.h
+++ b/src/compiler/format_method.h
@@ -40,7 +40,7 @@ class LoweredMethodHeader {
                       Layout* name,
                       std::vector<Layout*> parameters,
                       Layout* return_type,
-                      bool has_colon,
+                      Layout* colon,
                       LayoutMarker parameters_start,
                       LayoutMarker parameters_end,
                       int continuation_step)
@@ -49,7 +49,7 @@ class LoweredMethodHeader {
       , name_(name)
       , parameters_(std::move(parameters))
       , return_type_(return_type)
-      , has_colon_(has_colon)
+      , colon_(colon)
       , parameters_start_(parameters_start)
       , parameters_end_(parameters_end)
       , continuation_step_(continuation_step) {}
@@ -59,7 +59,7 @@ class LoweredMethodHeader {
   Layout* name_;
   std::vector<Layout*> parameters_;
   Layout* return_type_;
-  bool has_colon_;
+  Layout* colon_;
   LayoutMarker parameters_start_;
   LayoutMarker parameters_end_;
   int continuation_step_;
@@ -76,16 +76,18 @@ class LoweredMethodHeader {
 //         first
 //         second -> ReturnType:
 //
-// Trivia is not part of this prototype slice yet. When it is added, trivia
-// around `->` must belong to semantic header pieces rather than source gaps so
-// the dedicated placement pass can carry comments without changing them.
+// Trivia is consumed while these semantic pieces are built. Attached block
+// comments are part of the piece they decorate, so the dedicated placement
+// pass carries them without any comment-specific behavior. A header touched by
+// a frozen `//` line exposes no reorderable return-type piece.
 LoweredMethodHeader lower_method_header(
     ast::Method* method,
     Source* source,
     LayoutBuilder* layouts,
     LogicalOperatorBindings* bindings,
     SyntaxProtection* syntax,
-    const FormatStyle& style = FormatStyle());
+    const FormatStyle& style = FormatStyle(),
+    TriviaLowering* trivia = nullptr);
 
 // Selects the complete method header, including the specialized return-type
 // placement policy when parameters break. Low-level Layout selection remains

--- a/src/compiler/format_return_type.cc
+++ b/src/compiler/format_return_type.cc
@@ -55,9 +55,9 @@ SelectedPlan select_method_header(const LoweredMethodHeader& header,
       header.return_type_,
       parameter_lines,
   };
-  if (header.has_colon_) {
+  if (header.colon_ != null) {
     reordered.push_back(header.layouts_->hardline());
-    reordered.push_back(header.layouts_->text(":"));
+    reordered.push_back(header.colon_);
   }
   return select_layout(header.layouts_->concat(std::move(reordered)),
                        preferred_width);

--- a/src/compiler/format_trivia.cc
+++ b/src/compiler/format_trivia.cc
@@ -1,0 +1,288 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#include "format_trivia.h"
+
+#include "../top.h"
+#include "sources.h"
+
+#include <algorithm>
+#include <cstring>
+
+namespace toit {
+namespace compiler {
+
+namespace {
+
+int offset(Source* source, Source::Position position) {
+  return source->offset_in_source(position);
+}
+
+int line_start(const uint8* text, int from) {
+  while (from > 0 && text[from - 1] != '\n') from--;
+  return from;
+}
+
+int line_end(const uint8* text, int size, int from) {
+  while (from < size && text[from] != '\n' && text[from] != '\r') from++;
+  return from;
+}
+
+bool has_code_before(const uint8* text, int line_start, int comment_start) {
+  for (int i = line_start; i < comment_start; i++) {
+    if (text[i] != ' ' && text[i] != '\t') return true;
+  }
+  return false;
+}
+
+} // namespace
+
+FormatTrivia::FormatTrivia(Source* source, List<Scanner::Comment> comments)
+    : source_(source) {
+  ASSERT(source != null);
+  const uint8* text = source->text();
+  for (Scanner::Comment scanner_comment : comments) {
+    if (!scanner_comment.is_valid()) continue;
+    int from = offset(source, scanner_comment.range().from());
+    int to = offset(source, scanner_comment.range().to());
+    ASSERT(0 <= from && from <= to && to <= source->size());
+    int start = line_start(text, from);
+    int end = line_end(text, source->size(), to);
+    std::string raw(reinterpret_cast<const char*>(text) + from, to - from);
+    comments_.push_back({
+        from,
+        to,
+        start,
+        end,
+        from - start,
+        !scanner_comment.is_multiline(),
+        raw.find('\n') != std::string::npos ||
+            raw.find('\r') != std::string::npos,
+        has_code_before(text, start, from),
+        std::move(raw),
+    });
+  }
+  std::sort(comments_.begin(), comments_.end(),
+            [](const Comment& left, const Comment& right) {
+              return left.from < right.from;
+            });
+}
+
+TriviaLowering::TriviaLowering(const FormatTrivia* trivia,
+                               LayoutBuilder* layouts)
+    : trivia_(trivia)
+    , layouts_(layouts)
+    , consumed_(trivia == null ? 0 : trivia->comments().size(), false) {
+  ASSERT(layouts != null);
+}
+
+bool TriviaLowering::only_horizontal_space(int from, int to) const {
+  ASSERT(trivia_ != null);
+  const uint8* text = trivia_->source()->text();
+  for (int i = from; i < to; i++) {
+    if (text[i] != ' ' && text[i] != '\t') return false;
+  }
+  return true;
+}
+
+int TriviaLowering::first_line_comment(int from,
+                                       int to,
+                                       bool include_trailing_line) const {
+  if (trivia_ == null) return -1;
+  const uint8* text = trivia_->source()->text();
+  int trailing_end = to;
+  if (include_trailing_line) {
+    trailing_end = line_end(text, trivia_->source()->size(), to);
+  }
+  const std::vector<FormatTrivia::Comment>& comments = trivia_->comments();
+  for (int id = 0; id < static_cast<int>(comments.size()); id++) {
+    const FormatTrivia::Comment& comment = comments[id];
+    if (!comment.is_line_comment) continue;
+    if (from <= comment.from && comment.from < trailing_end) return id;
+  }
+  return -1;
+}
+
+const FormatTrivia::Comment& TriviaLowering::comment(int id) const {
+  ASSERT(trivia_ != null);
+  ASSERT(0 <= id && id < static_cast<int>(trivia_->comments().size()));
+  return trivia_->comments()[id];
+}
+
+int TriviaLowering::find_syntax(int from, int to, const char* syntax) const {
+  ASSERT(trivia_ != null);
+  int length = std::strlen(syntax);
+  const uint8* text = trivia_->source()->text();
+  for (int offset = from; offset + length <= to; offset++) {
+    bool inside_comment = false;
+    for (const FormatTrivia::Comment& comment : trivia_->comments()) {
+      if (comment.from <= offset && offset < comment.to) {
+        offset = comment.to - 1;
+        inside_comment = true;
+        break;
+      }
+    }
+    if (inside_comment) continue;
+    if (std::memcmp(text + offset, syntax, length) == 0) return offset;
+  }
+  return -1;
+}
+
+Layout* TriviaLowering::exact_multiline_text(
+    const FormatTrivia::Comment& comment, int base_column) {
+  std::vector<Layout*> parts;
+  const std::string& text = comment.text;
+  size_t start = 0;
+  bool first = true;
+  while (start <= text.size()) {
+    size_t end = text.find('\n', start);
+    bool has_newline = end != std::string::npos;
+    if (!has_newline) end = text.size();
+    size_t content_start = start;
+    if (!first) {
+      int removed = 0;
+      while (content_start < end && removed < base_column &&
+             (text[content_start] == ' ' || text[content_start] == '\t')) {
+        content_start++;
+        removed++;
+      }
+    }
+    parts.push_back(
+        layouts_->text(text.substr(content_start, end - content_start)));
+    if (!has_newline) break;
+    parts.push_back(layouts_->hardline());
+    start = end + 1;
+    first = false;
+  }
+  return layouts_->concat(std::move(parts));
+}
+
+Layout* TriviaLowering::verbatim_region(int from, int to) {
+  ASSERT(trivia_ != null);
+  ASSERT(0 <= from && from <= to && to <= trivia_->source()->size());
+  const uint8* source_text = trivia_->source()->text();
+  int base_start = line_start(source_text, from);
+  int base_column = from - base_start;
+  std::string raw(reinterpret_cast<const char*>(source_text) + from, to - from);
+  FormatTrivia::Comment region = {
+      from,
+      to,
+      base_start,
+      to,
+      base_column,
+      false,
+      raw.find('\n') != std::string::npos,
+      false,
+      std::move(raw),
+  };
+  for (int id = 0; id < static_cast<int>(trivia_->comments().size()); id++) {
+    const FormatTrivia::Comment& comment = trivia_->comments()[id];
+    if (from <= comment.from && comment.to <= to) consumed_[id] = true;
+  }
+  return exact_multiline_text(region, base_column);
+}
+
+Layout* TriviaLowering::inline_comment(int id) {
+  ASSERT(trivia_ != null);
+  ASSERT(0 <= id && id < static_cast<int>(trivia_->comments().size()));
+  const FormatTrivia::Comment& comment = trivia_->comments()[id];
+  ASSERT(!comment.is_line_comment);
+  ASSERT(!comment.spans_lines);
+  ASSERT(!consumed_[id]);
+  consumed_[id] = true;
+  return layouts_->text(comment.text);
+}
+
+Layout* TriviaLowering::take_inline_prefix(Layout* core, int from, int to) {
+  if (trivia_ == null || from >= to) return core;
+  std::vector<int> ids;
+  int cursor = from;
+  for (int id = 0; id < static_cast<int>(trivia_->comments().size()); id++) {
+    const FormatTrivia::Comment& comment = trivia_->comments()[id];
+    if (consumed_[id] || comment.from < from || comment.to > to) continue;
+    if (comment.is_line_comment || comment.spans_lines ||
+        !only_horizontal_space(cursor, comment.from)) {
+      return core;
+    }
+    ids.push_back(id);
+    cursor = comment.to;
+  }
+  if (ids.empty() || !only_horizontal_space(cursor, to)) return core;
+
+  std::vector<Layout*> prefix;
+  cursor = from;
+  for (int id : ids) {
+    const FormatTrivia::Comment& comment = trivia_->comments()[id];
+    // The containing syntax owns the gap before a prefix. This fragment owns
+    // only gaps between attached comments and the one before the core.
+    if (!prefix.empty() && comment.from != cursor) {
+      prefix.push_back(layouts_->text(" "));
+    }
+    prefix.push_back(inline_comment(id));
+    cursor = comment.to;
+  }
+  if (cursor != to) prefix.push_back(layouts_->text(" "));
+  prefix.push_back(core);
+  return layouts_->concat(std::move(prefix));
+}
+
+Layout* TriviaLowering::take_inline_suffix(Layout* core, int from, int to) {
+  if (trivia_ == null || from >= to) return core;
+  std::vector<int> ids;
+  int cursor = from;
+  for (int id = 0; id < static_cast<int>(trivia_->comments().size()); id++) {
+    const FormatTrivia::Comment& comment = trivia_->comments()[id];
+    if (consumed_[id] || comment.from < from || comment.to > to) continue;
+    if (comment.is_line_comment || comment.spans_lines ||
+        !only_horizontal_space(cursor, comment.from)) {
+      if (ids.empty()) return core;
+      break;
+    }
+    ids.push_back(id);
+    cursor = comment.to;
+  }
+  if (ids.empty()) return core;
+
+  std::vector<Layout*> suffix = {core};
+  cursor = from;
+  for (int id : ids) {
+    const FormatTrivia::Comment& comment = trivia_->comments()[id];
+    if (comment.from != cursor) suffix.push_back(layouts_->text(" "));
+    suffix.push_back(inline_comment(id));
+    cursor = comment.to;
+  }
+  return layouts_->concat(std::move(suffix));
+}
+
+Layout* TriviaLowering::take_own_line_block(int id) {
+  ASSERT(trivia_ != null);
+  ASSERT(0 <= id && id < static_cast<int>(trivia_->comments().size()));
+  const FormatTrivia::Comment& comment = trivia_->comments()[id];
+  ASSERT(!comment.is_line_comment);
+  ASSERT(!comment.has_code_before);
+  ASSERT(!consumed_[id]);
+  consumed_[id] = true;
+  return exact_multiline_text(comment, comment.original_column);
+}
+
+bool TriviaLowering::all_comments_consumed() const {
+  for (bool consumed : consumed_) {
+    if (!consumed) return false;
+  }
+  return true;
+}
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_trivia.h
+++ b/src/compiler/format_trivia.h
@@ -1,0 +1,97 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "format_layout.h"
+#include "scanner.h"
+
+namespace toit {
+namespace compiler {
+
+class Source;
+
+// Immutable source facts collected before layout lowering. Trivia does not
+// survive as a parallel rendering model: each formatting run consumes these
+// entries into ordinary text and hard-line layouts.
+class FormatTrivia {
+ public:
+  struct Comment {
+    int from;
+    int to;
+    int line_start;
+    int line_end;
+    int original_column;
+    bool is_line_comment;
+    bool spans_lines;
+    bool has_code_before;
+    std::string text;
+  };
+
+  FormatTrivia(Source* source, List<Scanner::Comment> comments);
+
+  Source* source() const { return source_; }
+  const std::vector<Comment>& comments() const { return comments_; }
+
+ private:
+  Source* source_;
+  std::vector<Comment> comments_;
+};
+
+// Per-rendering consumer for FormatTrivia. A comment is converted to a Layout
+// exactly once, after which selection and rendering need no trivia-specific
+// behavior.
+class TriviaLowering {
+ public:
+  TriviaLowering(const FormatTrivia* trivia, LayoutBuilder* layouts);
+
+  // A real `//` comment freezes the source line. For the current expression
+  // and header slices the smallest safely replaceable unit may span several
+  // source lines; `verbatim_region` preserves all non-indentation bytes in
+  // that unit and shifts its lines by the unit's original base indentation.
+  int first_line_comment(int from, int to, bool include_trailing_line) const;
+  const FormatTrivia::Comment& comment(int id) const;
+  int find_syntax(int from, int to, const char* syntax) const;
+  Layout* verbatim_region(int from, int to);
+
+  // Blindly concatenates consecutive, same-line block comments immediately
+  // before or after a semantic component. Whitespace is canonicalized to no
+  // gap when the comment is glued and one space otherwise.
+  Layout* take_inline_prefix(Layout* core, int from, int to);
+  Layout* take_inline_suffix(Layout* core, int from, int to);
+
+  // Converts an own-line block comment to an exact, reindentable layout. The
+  // caller supplies its structural hard-line boundaries because indentation
+  // belongs to the containing statement/argument/element list.
+  Layout* take_own_line_block(int id);
+
+  bool all_comments_consumed() const;
+
+ private:
+  const FormatTrivia* trivia_;
+  LayoutBuilder* layouts_;
+  std::vector<bool> consumed_;
+
+  bool only_horizontal_space(int from, int to) const;
+  Layout* inline_comment(int id);
+  Layout* exact_multiline_text(const FormatTrivia::Comment& comment,
+                               int base_column);
+};
+
+} // namespace compiler
+} // namespace toit

--- a/tests/ctest/format-expression-input.toit
+++ b/tests/ctest/format-expression-input.toit
@@ -13,5 +13,10 @@ sample a b c foo bar gee alpha beta:
   alpha or
       beta
 
+trivia-sample foo bar:
+  foo  +   bar  // Keep   every byte.
+  foo/*attached*/
+  (foo + bar)/*attached-to-group*/ * 2
+
 main:
   sample 1 2 3 true false true false true

--- a/tests/ctest/format-expression-test.cc
+++ b/tests/ctest/format-expression-test.cc
@@ -12,6 +12,7 @@
 #include "../../src/compiler/diagnostic.h"
 #include "../../src/compiler/filesystem_local.h"
 #include "../../src/compiler/format_expression.h"
+#include "../../src/compiler/format_trivia.h"
 #include "../../src/compiler/parser.h"
 #include "../../src/compiler/scanner.h"
 #include "../../src/compiler/symbol_canonicalizer.h"
@@ -24,6 +25,7 @@ namespace compiler {
 struct ParsedExpression {
   std::unique_ptr<FormatTestSource> source;
   std::unique_ptr<SymbolCanonicalizer> symbols;
+  std::unique_ptr<FormatTrivia> trivia;
   ast::Expression* expression;
 };
 
@@ -47,6 +49,8 @@ static ParsedExpression parse_expression(const std::string& expression,
       || unit->declarations().length() != 1) exit(1);
   ast::Method* method = unit->declarations()[0]->as_Method();
   if (method == null || method->body()->expressions().length() != 1) exit(1);
+  result.trivia.reset(
+      new FormatTrivia(result.source.get(), scanner.comments()));
   result.expression = method->body()->expressions()[0];
   return result;
 }
@@ -143,13 +147,17 @@ static void expect(const char* expected, const std::string& actual) {
 }
 
 static std::string render_expression(ast::Expression* expression,
-                                     Source* source, int preferred_width,
-                                     bool apply_repairs = true) {
+                                     Source* source,
+                                     int preferred_width,
+                                     bool apply_repairs = true,
+                                     const FormatTrivia* trivia = null) {
   LayoutBuilder layouts;
   LogicalOperatorBindings bindings;
   SyntaxProtection syntax;
+  TriviaLowering trivia_lowering(trivia, &layouts);
   LoweredExpression lowered =
-      lower_expression(expression, source, &layouts, &bindings, &syntax);
+      lower_expression(expression, source, &layouts, &bindings, &syntax,
+                       FormatStyle(), trivia == null ? null : &trivia_lowering);
   SelectedPlan selected = select_layout(lowered.layout, preferred_width);
   if (apply_repairs) {
     WhitespaceEdits edits = FormatRepairs::propose(bindings, selected);
@@ -186,12 +194,18 @@ static void test_conflicting_repairs_are_rejected_atomically() {
 
 static void test_parsed_expressions(Source* source,
                                     ast::Unit* unit,
-                                    SourceManager* sources) {
-  ASSERT(unit->declarations().length() == 4);
+                                    SourceManager* sources,
+                                    const FormatTrivia* trivia) {
+  ASSERT(unit->declarations().length() == 5);
   ast::Method* sample = unit->declarations()[2]->as_Method();
   ASSERT(sample != null);
   List<ast::Expression*> expressions = sample->body()->expressions();
   ASSERT(expressions.length() == 5);
+  ast::Method* trivia_sample = unit->declarations()[3]->as_Method();
+  ASSERT(trivia_sample != null);
+  List<ast::Expression*> trivia_expressions =
+      trivia_sample->body()->expressions();
+  ASSERT(trivia_expressions.length() == 3);
 
   // Source parentheses disappear from the logical layout. They return only
   // when the selected topology needs them to keep the nested call together.
@@ -224,6 +238,23 @@ static void test_parsed_expressions(Source* source,
   // the canonical flat form, selection joins it again.
   expect("alpha or beta", render_expression(expressions[4], source, 100));
 
+  // A line containing `//` is an indentation-adjustable verbatim island. The
+  // generic binary formatter and the mixed-logical repair never see its
+  // interior gaps, so even deliberately noncanonical spacing is retained.
+  expect("foo  +   bar  // Keep   every byte.",
+         render_expression(trivia_expressions[0], source, 5, true, trivia));
+
+  // A same-line block comment is blindly concatenated to the atom it touches.
+  // It remains ordinary logical text and needs no rendering-time trivia pass.
+  expect("foo/*attached*/",
+         render_expression(trivia_expressions[1], source, 5, true, trivia));
+
+  // The attachment belongs to the parenthesized semantic operand, not to its
+  // final token. Syntax protection may reconstruct parentheses around that
+  // operand, but it must leave the attached comment outside them.
+  expect("(foo + bar)/*attached-to-group*/ * 2",
+         render_expression(trivia_expressions[2], source, 100, true, trivia));
+
   // Reparse representative flat and broken results, compare their trees, and
   // format the reparsed trees again. This catches both semantic changes and
   // non-idempotent layout decisions without counting source parens as nodes.
@@ -235,9 +266,18 @@ static void test_parsed_expressions(Source* source,
     ParsedExpression reparsed = parse_expression(rendered, sources);
     if (!equivalent_expression(original, reparsed.expression)) exit(1);
     expect(rendered.c_str(),
-           render_expression(reparsed.expression,
-                             reparsed.source.get(),
+           render_expression(reparsed.expression, reparsed.source.get(),
                              widths[i]));
+  }
+
+  for (int i = 0; i < trivia_expressions.length(); i++) {
+    ast::Expression* original = trivia_expressions[i];
+    std::string rendered = render_expression(original, source, 5, true, trivia);
+    ParsedExpression reparsed = parse_expression(rendered, sources);
+    if (!equivalent_expression(original, reparsed.expression)) exit(1);
+    expect(rendered.c_str(),
+           render_expression(reparsed.expression, reparsed.source.get(), 5,
+                             true, reparsed.trivia.get()));
   }
 }
 
@@ -260,8 +300,10 @@ int main(int argc, char** argv) {
   toit::compiler::Parser parser(loaded.source, &scanner, &diagnostics);
   toit::compiler::ast::Unit* unit = parser.parse_unit();
   ASSERT(!diagnostics.encountered_error());
+  toit::compiler::FormatTrivia trivia(loaded.source, scanner.comments());
 
   toit::compiler::test_conflicting_repairs_are_rejected_atomically();
-  toit::compiler::test_parsed_expressions(loaded.source, unit, &sources);
+  toit::compiler::test_parsed_expressions(loaded.source, unit, &sources,
+                                          &trivia);
   return 0;
 }

--- a/tests/ctest/format-method-input.toit
+++ b/tests/ctest/format-method-input.toit
@@ -35,5 +35,16 @@ class Fields:
 operator-name -> int:
   return 0
 
+attached value/List/*<int>*/ --marker="->" -> /* Describes result. */ bool:
+  return false
+
+colon-comment value -> int: /* Describes body. */
+  return value
+
+frozen  first  second  // Keep   every byte.
+    -> int
+:
+  return 0
+
 main:
   null

--- a/tests/ctest/format-method-test.cc
+++ b/tests/ctest/format-method-test.cc
@@ -12,6 +12,7 @@
 #include "../../src/compiler/diagnostic.h"
 #include "../../src/compiler/filesystem_local.h"
 #include "../../src/compiler/format_method.h"
+#include "../../src/compiler/format_trivia.h"
 #include "../../src/compiler/parser.h"
 #include "../../src/compiler/scanner.h"
 #include "../../src/compiler/symbol_canonicalizer.h"
@@ -24,12 +25,13 @@ namespace compiler {
 struct ParsedMethod {
   std::unique_ptr<FormatTestSource> source;
   std::unique_ptr<SymbolCanonicalizer> symbols;
+  std::unique_ptr<FormatTrivia> trivia;
   ast::Method* method;
 };
 
 static ParsedMethod parse_header(const std::string& header,
                                  SourceManager* sources) {
-  if (header.empty() || header.back() != ':') exit(1);
+  if (header.empty()) exit(1);
   ParsedMethod result;
   result.source.reset(new FormatTestSource(header + "\n  null\n"));
   result.symbols.reset(new SymbolCanonicalizer());
@@ -42,6 +44,8 @@ static ParsedMethod parse_header(const std::string& header,
   }
   result.method = unit->declarations()[0]->as_Method();
   if (result.method == null) exit(1);
+  result.trivia.reset(
+      new FormatTrivia(result.source.get(), scanner.comments()));
   return result;
 }
 
@@ -69,6 +73,10 @@ static bool equivalent_header_expression(ast::Expression* left,
   if (left->is_LiteralInteger() && right->is_LiteralInteger()) {
     return same_symbol(left->as_LiteralInteger()->data(),
                        right->as_LiteralInteger()->data());
+  }
+  if (left->is_LiteralString() && right->is_LiteralString()) {
+    return same_symbol(left->as_LiteralString()->data(),
+                       right->as_LiteralString()->data());
   }
   return false;
 }
@@ -110,13 +118,17 @@ static void expect(const char* expected, const std::string& actual) {
   exit(1);
 }
 
-static std::string render_header(ast::Method* method, Source* source,
-                                 int preferred_width) {
+static std::string render_header(ast::Method* method,
+                                 Source* source,
+                                 int preferred_width,
+                                 const FormatTrivia* trivia = null) {
   LayoutBuilder layouts;
   LogicalOperatorBindings bindings;
   SyntaxProtection syntax;
-  LoweredMethodHeader lowered =
-      lower_method_header(method, source, &layouts, &bindings, &syntax);
+  TriviaLowering trivia_lowering(trivia, &layouts);
+  LoweredMethodHeader lowered = lower_method_header(
+      method, source, &layouts, &bindings, &syntax, FormatStyle(),
+      trivia == null ? null : &trivia_lowering);
 
   // Return-type placement is deliberately the only selection entry point that
   // may choose a different token order. Everything after it is whitespace-only
@@ -130,8 +142,9 @@ static std::string render_header(ast::Method* method, Source* source,
 
 static void test_parsed_method_headers(Source* source,
                                        ast::Unit* unit,
-                                       SourceManager* sources) {
-  ASSERT(unit->declarations().length() == 8);
+                                       SourceManager* sources,
+                                       const FormatTrivia* trivia) {
+  ASSERT(unit->declarations().length() == 11);
   ast::Method* flat = unit->declarations()[0]->as_Method();
   ast::Method* source_split = unit->declarations()[1]->as_Method();
   ast::Method* plain = unit->declarations()[2]->as_Method();
@@ -144,6 +157,9 @@ static void test_parsed_method_headers(Source* source,
   ASSERT(fields != null && fields->members().length() == 3);
   ast::Method* constructor = fields->members()[2]->as_Method();
   ast::Method* operator_name = unit->declarations()[6]->as_Method();
+  ast::Method* attached = unit->declarations()[7]->as_Method();
+  ast::Method* colon_comment = unit->declarations()[8]->as_Method();
+  ast::Method* frozen = unit->declarations()[9]->as_Method();
 
   expect("flat first second -> int:", render_header(flat, source, 100));
   expect("flat -> int\n    first\n    second\n:",
@@ -183,21 +199,57 @@ static void test_parsed_method_headers(Source* source,
   expect("operator-name -> int:",
          render_header(operator_name, source, 100));
 
+  // Blind concatenation makes comments ordinary parts of the semantic header
+  // pieces. The exceptional pass moves those complete pieces and has no
+  // comment-specific branch.
+  expect("attached value/List/*<int>*/ --marker=\"->\" -> "
+         "/* Describes result. */ bool:",
+         render_header(attached, source, 100, trivia));
+  expect("attached -> /* Describes result. */ bool\n"
+         "    value/List/*<int>*/\n"
+         "    --marker=\"->\"\n"
+         ":",
+         render_header(attached, source, 24, trivia));
+
+  // Punctuation is itself a semantic header piece. A blindly concatenated
+  // block comment after `:` therefore remains after `:` in either token order.
+  expect("colon-comment value -> int: /* Describes body. */",
+         render_header(colon_comment, source, 100, trivia));
+  expect("colon-comment -> int\n"
+         "    value\n"
+         ": /* Describes body. */",
+         render_header(colon_comment, source, 24, trivia));
+
+  // The line comment is a source-order barrier. The current header slice uses
+  // the complete header as its conservative replacement unit, so no token can
+  // cross the frozen line while only its outer indentation remains variable.
+  expect("frozen  first  second  // Keep   every byte.\n"
+         "    -> int\n"
+         ":",
+         render_header(frozen, source, 10, trivia));
+
   // Return placement is the one formatter phase allowed to change token
   // order, so exact strings are not enough. Reparse both ordinary and
   // reordered headers, compare their semantic header trees, and format them a
   // second time to verify idempotence.
   ast::Method* methods[] = {
-      flat, flat, source_split, source_split, plain,
-      shapes, declaration, index, constructor, operator_name,
+      flat,     flat,        source_split,  source_split,  plain,
+      shapes,   declaration, index,         constructor,   operator_name,
+      attached, attached,    colon_comment, colon_comment, frozen,
   };
-  int widths[] = {100, 20, 100, 24, 12, 30, 24, 100, 100, 100};
-  for (int i = 0; i < 10; i++) {
-    std::string rendered = render_header(methods[i], source, widths[i]);
+  int widths[] = {
+      100, 20, 100, 24, 12, 30, 24, 100, 100, 100, 100, 24, 100, 24, 10,
+  };
+  for (int i = 0; i < 15; i++) {
+    bool has_trivia = methods[i] == attached || methods[i] == colon_comment ||
+                      methods[i] == frozen;
+    std::string rendered = render_header(methods[i], source, widths[i],
+                                         has_trivia ? trivia : null);
     ParsedMethod reparsed = parse_header(rendered, sources);
     if (!equivalent_header(methods[i], reparsed.method)) exit(1);
     expect(rendered.c_str(),
-           render_header(reparsed.method, reparsed.source.get(), widths[i]));
+           render_header(reparsed.method, reparsed.source.get(), widths[i],
+                         reparsed.trivia.get()));
   }
 }
 
@@ -220,7 +272,9 @@ int main(int argc, char** argv) {
   toit::compiler::Parser parser(loaded.source, &scanner, &diagnostics);
   toit::compiler::ast::Unit* unit = parser.parse_unit();
   ASSERT(!diagnostics.encountered_error());
+  toit::compiler::FormatTrivia trivia(loaded.source, scanner.comments());
 
-  toit::compiler::test_parsed_method_headers(loaded.source, unit, &sources);
+  toit::compiler::test_parsed_method_headers(loaded.source, unit, &sources,
+                                             &trivia);
   return 0;
 }

--- a/tests/ctest/format-trivia-input.toit
+++ b/tests/ctest/format-trivia-input.toit
@@ -1,0 +1,8 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+sample foo:  // Keep   every byte.
+  foo/*<int>*/
+  /* Standalone
+     block. */

--- a/tests/ctest/format-trivia-test.cc
+++ b/tests/ctest/format-trivia-test.cc
@@ -1,0 +1,112 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <string>
+
+#include "../../src/compiler/diagnostic.h"
+#include "../../src/compiler/filesystem_local.h"
+#include "../../src/compiler/format_trivia.h"
+#include "../../src/compiler/scanner.h"
+#include "../../src/compiler/symbol_canonicalizer.h"
+#include "../../src/top.h"
+
+namespace toit {
+namespace compiler {
+
+static void expect(const char* expected, const std::string& actual) {
+  if (actual == expected) return;
+  fprintf(stderr, "Expected:\n---\n%s\n---\nActual:\n---\n%s\n---\n", expected,
+          actual.c_str());
+  exit(1);
+}
+
+static std::string rendered(Layout* layout, int width = 100) {
+  return render_plan(std::move(select_layout(layout, width)).freeze());
+}
+
+static int find(const std::string& text, const char* needle) {
+  size_t result = text.find(needle);
+  if (result == std::string::npos) exit(1);
+  return static_cast<int>(result);
+}
+
+static int comment_at(const FormatTrivia& trivia, int offset) {
+  for (int id = 0; id < static_cast<int>(trivia.comments().size()); id++) {
+    if (trivia.comments()[id].from == offset) return id;
+  }
+  exit(1);
+}
+
+static void test_early_trivia(Source* source, const FormatTrivia& trivia) {
+  std::string source_text(reinterpret_cast<const char*>(source->text()),
+                          source->size());
+  ASSERT(trivia.comments().size() == 6);
+
+  LayoutBuilder layouts;
+  TriviaLowering lowering(&trivia, &layouts);
+
+  int header = find(source_text, "sample foo:");
+  int line_comment = find(source_text, "// Keep");
+  int line_id = comment_at(trivia, line_comment);
+  int line_comment_end = trivia.comments()[line_id].to;
+  int frozen = lowering.first_line_comment(header, header + 11, true);
+  ASSERT(frozen == line_id);
+  expect("sample foo:  // Keep   every byte.",
+         rendered(lowering.verbatim_region(header, line_comment_end)));
+
+  int type = find(source_text, "\n  foo") + 3;
+  int attached_id = comment_at(trivia, type + 3);
+  int attached_end = trivia.comments()[attached_id].to;
+  Layout* attached =
+      lowering.take_inline_suffix(layouts.text("foo"), type + 3, attached_end);
+  expect("foo/*<int>*/", rendered(attached));
+
+  int standalone_id = comment_at(trivia, find(source_text, "/* Standalone"));
+  Layout* own_line = lowering.take_own_line_block(standalone_id);
+  Layout* body = layouts.concat({
+      layouts.text("if true:"),
+      layouts.indent(2, layouts.concat({
+                            layouts.hardline(),
+                            own_line,
+                            layouts.hardline(),
+                            layouts.text("return"),
+                        })),
+  });
+  expect(
+      "if true:\n"
+      "  /* Standalone\n"
+      "     block. */\n"
+      "  return",
+      rendered(body));
+
+  // The copyright preamble lies outside every formatted unit in this focused
+  // test. The three comments exercised above were each consumed once.
+  ASSERT(line_id != attached_id && attached_id != standalone_id);
+}
+
+} // namespace compiler
+} // namespace toit
+
+int main(int argc, char** argv) {
+  toit::throwing_new_allowed = true;
+  ASSERT(argc == 2);
+
+  toit::compiler::FilesystemLocal filesystem;
+  toit::compiler::SourceManager sources(&filesystem);
+  toit::compiler::NullDiagnostics diagnostics(&sources);
+  toit::compiler::SourceManager::LoadResult loaded =
+      sources.load_file(argv[1], toit::compiler::Package::invalid());
+  ASSERT(loaded.status == toit::compiler::SourceManager::LoadResult::OK);
+
+  toit::compiler::SymbolCanonicalizer symbols;
+  toit::compiler::Scanner scanner(loaded.source, &symbols, &diagnostics);
+  while (scanner.next().token() != toit::compiler::Token::EOS) {
+  }
+  toit::compiler::FormatTrivia trivia(loaded.source, scanner.comments());
+  toit::compiler::test_early_trivia(loaded.source, trivia);
+  return 0;
+}


### PR DESCRIPTION
This follow-up experiments with consuming trivia during lowering instead of carrying a parallel comment model through selection and rendering.

- copies scanner comments into immutable source facts and consumes each comment into ordinary Layout nodes
- treats a line containing // as a verbatim barrier whose indentation may still change
- blindly concatenates same-line block comments to semantic expression/header pieces
- treats own-line block comments as exact, reindentable statement-like layouts
- keeps attached comments with return types, parameters, and punctuation when the return-placement pass changes token order
- reparses and reformats representative outputs to check semantics and idempotence

Current deliberate limitation: expression and method-header lowering cannot yet replace an arbitrary source-line fragment. If a // line occurs inside one of those composites, this slice freezes the complete composite conservatively. The line rule is represented correctly, but exact line-only formatting will need a smaller line-fragment boundary.

Tests: ctest --test-dir build/host --output-on-failure -R tests/ctest/format-(expression|layout|method|syntax|trivia)-test.cc
Also analyzed the three Toit fixtures with toit.compile --analyze.