### PR TITLE
io: add standard streams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -652,6 +652,27 @@ jobs:
           make ESP32_CHIP=esp32s3 esp32
           ccache -s
 
+      - name: Build ESP32-S3 USB Serial/JTAG console firmware
+        run: tests/qemu/build-s3-usb-envelope.sh
+
+      - name: Install latest Toit QEMU release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          QEMU_VERSION="$(gh release view --repo toitlang/qemu --json tagName --jq .tagName)"
+          QEMU_ARCHIVE="qemu-toit-${QEMU_VERSION}-linux-x86_64.tar.gz"
+          QEMU_DIR="${RUNNER_TEMP}/toit-qemu"
+          mkdir -p "${QEMU_DIR}"
+          gh release download "${QEMU_VERSION}" --repo toitlang/qemu \
+            --pattern "${QEMU_ARCHIVE}" --pattern SHA256SUMS --dir "${QEMU_DIR}"
+          cd "${QEMU_DIR}"
+          grep " ${QEMU_ARCHIVE}$" SHA256SUMS | sha256sum --check
+          tar -xf "${QEMU_ARCHIVE}"
+          echo "QEMU_SYSTEM_XTENSA=${QEMU_DIR}/qemu-toit-${QEMU_VERSION}-linux-x86_64/bin/qemu-system-xtensa" >> "${GITHUB_ENV}"
+
+      - name: Test ESP32 standard streams in QEMU
+        run: tests/qemu/run-tests.sh
+
       - name: Pack firmware artifacts
         shell: bash
         run: |

--- a/lib/io/io.toit
+++ b/lib/io/io.toit
@@ -6,6 +6,7 @@ import .buffer
 import .byte-order
 import .data
 import .reader
+import .stdio
 import .writer
 
 export *

--- a/lib/io/stdio.toit
+++ b/lib/io/stdio.toit
@@ -8,6 +8,15 @@ import .data
 import .reader
 import .writer
 
+/**
+Provides direct access to the platform's standard input, output, and error
+  streams.
+
+On host platforms, the `host` package provides closeable, terminal-aware
+  versions of the same streams. Both packages access the same underlying
+  platform streams.
+*/
+
 STDIN-READ-STATE_ ::= 1 << 0
 
 stdin-group_ ::= stdin-init_
@@ -24,6 +33,9 @@ On ESP32, input is supported when ESP-IDF's primary console is a UART or USB
 The stream cannot be closed. It shares the platform input with other standard
   input APIs. If multiple readers or containers read concurrently, the first
   reader to consume available data receives it.
+
+On host platforms, use `host.stdin` when closing the stream or querying whether
+  it is a terminal is required.
 */
 stdin -> Reader:
   return stdin-instance_
@@ -32,7 +44,11 @@ stdin -> Reader:
 Returns the standard output stream.
 
 Writes go directly to the platform's standard output and do not pass through
-  the print service. The stream cannot be closed.
+  the print service. A write is synchronous and may block in the underlying
+  platform operation. The stream cannot be closed.
+
+On host platforms, use `host.stdout` when closing the stream or querying
+  whether it is a terminal is required.
 */
 stdout -> Writer:
   return stdout-instance_
@@ -41,7 +57,11 @@ stdout -> Writer:
 Returns the standard error stream.
 
 Writes go directly to the platform's standard error and do not pass through
-  the print service. The stream cannot be closed.
+  the print service. A write is synchronous and may block in the underlying
+  platform operation. The stream cannot be closed.
+
+On host platforms, use `host.stderr` when closing the stream or querying
+  whether it is a terminal is required.
 */
 stderr -> Writer:
   return stderr-instance_
@@ -69,6 +89,8 @@ class StandardWriter_ extends Writer:
   try-write_ data/Data from/int to/int -> int:
     if from == to: return 0
     bytes := ByteArray.from data from to
+    // Deliberately use the synchronous primitives also used by 'print_'. This
+    // gives direct standard-stream writes the same printf-like semantics.
     if is-stdout_:
       write-on-stdout_ bytes false
     else:

--- a/lib/io/stdio.toit
+++ b/lib/io/stdio.toit
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the lib/LICENSE file.
+
+import monitor
+
+import .data
+import .reader
+import .writer
+
+STDIN-READ-STATE_ ::= 1 << 0
+
+stdin-group_ ::= stdin-init_
+stdin-instance_ ::= Stdin_
+stdout-instance_ ::= StandardWriter_ true
+stderr-instance_ ::= StandardWriter_ false
+
+/**
+Returns the standard input stream.
+
+On ESP32, input is supported when ESP-IDF's primary console is a UART or USB
+  Serial/JTAG. Other console backends are unsupported.
+
+The stream cannot be closed. It shares the platform input with other standard
+  input APIs. If multiple readers or containers read concurrently, the first
+  reader to consume available data receives it.
+*/
+stdin -> Reader:
+  return stdin-instance_
+
+/**
+Returns the standard output stream.
+
+Writes go directly to the platform's standard output and do not pass through
+  the print service. The stream cannot be closed.
+*/
+stdout -> Writer:
+  return stdout-instance_
+
+/**
+Returns the standard error stream.
+
+Writes go directly to the platform's standard error and do not pass through
+  the print service. The stream cannot be closed.
+*/
+stderr -> Writer:
+  return stderr-instance_
+
+class Stdin_ extends Reader:
+  resource_ := ?
+  state_/monitor.ResourceState_
+
+  constructor:
+    resource_ = stdin-open_ stdin-group_
+    state_ = monitor.ResourceState_ stdin-group_ resource_
+
+  read_ -> ByteArray?:
+    while true:
+      state_.clear-state STDIN-READ-STATE_
+      result := stdin-read_ resource_
+      if result != -1: return result
+      state_.wait-for-state STDIN-READ-STATE_
+
+class StandardWriter_ extends Writer:
+  is-stdout_/bool
+
+  constructor .is-stdout_:
+
+  try-write_ data/Data from/int to/int -> int:
+    if from == to: return 0
+    bytes := ByteArray.from data from to
+    if is-stdout_:
+      write-on-stdout_ bytes false
+    else:
+      write-on-stderr_ bytes false
+    return to - from
+
+stdin-init_:
+  #primitive.stdio.stdin-init
+
+stdin-open_ group:
+  #primitive.stdio.stdin-open
+
+stdin-read_ resource:
+  #primitive.stdio.stdin-read
+
+write-on-stdout_ data add-newline/bool:
+  #primitive.core.write-on-stdout
+
+write-on-stderr_ data add-newline/bool:
+  #primitive.core.write-on-stderr

--- a/src/compiler/propagation/type_primitive_stdio.cc
+++ b/src/compiler/propagation/type_primitive_stdio.cc
@@ -1,0 +1,17 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the lib/LICENSE file.
+
+#include "type_primitive.h"
+
+namespace toit {
+namespace compiler {
+
+MODULE_TYPES(stdio, MODULE_STDIO)
+
+TYPE_PRIMITIVE_ANY(stdin_init)
+TYPE_PRIMITIVE_ANY(stdin_open)
+TYPE_PRIMITIVE_ANY(stdin_read)
+
+}  // namespace toit::compiler
+}  // namespace toit

--- a/src/event_sources/ev_queue_esp32.cc
+++ b/src/event_sources/ev_queue_esp32.cc
@@ -27,7 +27,7 @@
 
 // The max queue set size is the maximum number of events in the queue. This is used for the gpio queue,
 // up to two UART queues and the stop semaphore.
-#define MAX_QUEUE_SET_SIZE (GPIO_QUEUE_SIZE + 2 * UART_QUEUE_SIZE + 1)
+#define MAX_QUEUE_SET_SIZE (GPIO_QUEUE_SIZE + 2 * UART_QUEUE_SIZE + STDIN_QUEUE_SIZE + 1)
 
 namespace toit {
 
@@ -100,13 +100,22 @@ void EventQueueEventSource::entry() {
         }
       }
     } else {
-      // Then loop through other queues.
-      for (auto r: resources()) {
+      // Then loop through other queues. Multiple resources may subscribe to
+      // the same queue. Receive the event once and dispatch it to all of them.
+      EventQueueResource* receiver = null;
+      for (auto r : resources()) {
         auto resource = static_cast<EventQueueResource*>(r);
         if (resource->queue() == handle) {
-          word data;
-          if (resource->receive_event(&data)) {
-            dispatch(locker, r, data);
+          receiver = resource;
+          break;
+        }
+      }
+      if (receiver != null) {
+        word data;
+        if (receiver->receive_event(&data)) {
+          for (auto r : resources()) {
+            auto resource = static_cast<EventQueueResource*>(r);
+            if (resource->queue() == handle) dispatch(locker, r, data);
           }
         }
       }
@@ -118,6 +127,11 @@ void EventQueueEventSource::on_register_resource(Locker& locker, Resource* r) {
   auto resource = static_cast<EventQueueResource*>(r);
   QueueHandle_t queue = resource->queue();
   if (queue == null) return;
+  for (auto existing : resources()) {
+    if (existing == r) continue;
+    auto existing_resource = static_cast<EventQueueResource*>(existing);
+    if (existing_resource->queue() == queue) return;
+  }
   // We can only add to the queue set when the queue is empty, so we
   // repeatedly try to drain the queue before adding it to the set.
   int attempts = 0;
@@ -134,6 +148,10 @@ void EventQueueEventSource::on_unregister_resource(Locker& locker, Resource* r) 
   auto resource = static_cast<EventQueueResource*>(r);
   QueueHandle_t queue = resource->queue();
   if (queue == null) return;
+  for (auto existing : resources()) {
+    auto existing_resource = static_cast<EventQueueResource*>(existing);
+    if (existing_resource->queue() == queue) return;
+  }
   // We can only remove from the queue set when the queue is empty, so we
   // repeatedly try to drain the queue before removing it from the set.
   int attempts = 0;

--- a/src/event_sources/ev_queue_esp32.h
+++ b/src/event_sources/ev_queue_esp32.h
@@ -25,6 +25,7 @@
 
 #define GPIO_QUEUE_SIZE 32
 #define UART_QUEUE_SIZE 32
+#define STDIN_QUEUE_SIZE 4
 
 namespace toit {
 

--- a/src/event_sources/stdio_host.cc
+++ b/src/event_sources/stdio_host.cc
@@ -1,0 +1,152 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the lib/LICENSE file.
+
+#include "../top.h"
+
+#if !defined(TOIT_FREERTOS)
+
+#ifdef TOIT_WINDOWS
+#include <windows.h>
+#else
+#include <errno.h>
+#include <poll.h>
+#include <unistd.h>
+#endif
+
+#include "stdio_host.h"
+
+namespace toit {
+
+static const word STDIN_READ_EVENT = 1 << 0;
+
+StdinEventSource* StdinEventSource::instance_ = null;
+
+StdinEventSource::StdinEventSource()
+    : LazyEventSource("Stdin", 1)
+    , Thread("Stdin")
+    , changed_(OS::allocate_condition_variable(mutex())) {
+  ASSERT(instance_ == null);
+  instance_ = this;
+}
+
+StdinEventSource::~StdinEventSource() {
+  OS::dispose(changed_);
+  instance_ = null;
+}
+
+bool StdinEventSource::start() {
+  stopping_ = false;
+  size_ = -1;
+  error_ = 0;
+  return spawn();
+}
+
+void StdinEventSource::stop() {
+  {
+    Locker locker(mutex());
+    stopping_ = true;
+    OS::signal_all(changed_);
+  }
+  cancel();
+  join();
+}
+
+void StdinEventSource::on_register_resource(Locker& locker, Resource* resource) {
+  if (size_ >= 0 || error_ != 0) {
+    dispatch(locker, resource, STDIN_READ_EVENT);
+  } else {
+    OS::signal(changed_);
+  }
+}
+
+void StdinEventSource::on_unregister_resource(Locker& locker, Resource* resource) {
+  OS::signal(changed_);
+}
+
+int StdinEventSource::data_size(int* error) {
+  Locker locker(mutex());
+  *error = error_;
+  return size_;
+}
+
+int StdinEventSource::read(uint8* destination, int size, int* error) {
+  Locker locker(mutex());
+  *error = error_;
+  if (error_ != 0 || size_ < 0) return -1;
+  if (size_ == 0) return 0;
+
+  int result = Utils::min(size, size_);
+  memcpy(destination, buffer_, result);
+  if (result < size_) {
+    memmove(buffer_, buffer_ + result, size_ - result);
+    size_ -= result;
+  } else {
+    size_ = -1;
+    OS::signal(changed_);
+  }
+  return result;
+}
+
+void StdinEventSource::entry() {
+  Locker locker(mutex());
+  while (!stopping_) {
+    while (!stopping_ && (resources().is_empty() || size_ >= 0 || error_ != 0)) {
+      OS::wait(changed_);
+    }
+    if (stopping_) return;
+
+    int read_count;
+    int error = 0;
+    {
+      Unlocker unlock(locker);
+#ifdef TOIT_WINDOWS
+      DWORD count = 0;
+      HANDLE input = GetStdHandle(STD_INPUT_HANDLE);
+      BOOL success = input != INVALID_HANDLE_VALUE &&
+          ReadFile(input, buffer_, BUFFER_SIZE, &count, NULL);
+      if (!success) error = GetLastError();
+      read_count = success ? static_cast<int>(count) : -1;
+#else
+      while (true) {
+        do {
+          read_count = ::read(STDIN_FILENO, buffer_, BUFFER_SIZE);
+        } while (read_count < 0 && errno == EINTR);
+        if (read_count >= 0) break;
+        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+          error = errno;
+          break;
+        }
+
+        // The host package marks stdin non-blocking when it opens its own
+        // standard stream. Wait here so both APIs can coexist; whichever one
+        // completes a read first consumes the data.
+        pollfd descriptor = { STDIN_FILENO, POLLIN, 0 };
+        int poll_result;
+        do {
+          poll_result = poll(&descriptor, 1, -1);
+        } while (poll_result < 0 && errno == EINTR);
+        if (poll_result < 0) {
+          error = errno;
+          read_count = -1;
+          break;
+        }
+      }
+#endif
+    }
+
+    if (stopping_) return;
+    if (read_count < 0) {
+      error_ = error;
+    } else {
+      size_ = read_count;
+    }
+    for (auto resource : resources()) {
+      dispatch(locker, resource, STDIN_READ_EVENT);
+    }
+  }
+}
+
+}  // namespace toit
+
+#endif  // !defined(TOIT_FREERTOS)

--- a/src/event_sources/stdio_host.h
+++ b/src/event_sources/stdio_host.h
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the lib/LICENSE file.
+
+#pragma once
+
+#include "../top.h"
+
+#if !defined(TOIT_FREERTOS)
+
+#include "../os.h"
+#include "../resource.h"
+
+namespace toit {
+
+class StdinEventSource : public LazyEventSource, public Thread {
+ public:
+  static const int BUFFER_SIZE = 4 * KB;
+
+  static StdinEventSource* instance() { return instance_; }
+
+  StdinEventSource();
+  ~StdinEventSource() override;
+
+  int data_size(int* error);
+  int read(uint8* destination, int size, int* error);
+
+ protected:
+  bool start() override;
+  void stop() override;
+
+ private:
+  void entry() override;
+  void on_register_resource(Locker& locker, Resource* resource) override;
+  void on_unregister_resource(Locker& locker, Resource* resource) override;
+
+  static StdinEventSource* instance_;
+
+  ConditionVariable* changed_;
+  uint8 buffer_[BUFFER_SIZE];
+  int size_ = -1;
+  int error_ = 0;
+  bool stopping_ = false;
+};
+
+}  // namespace toit
+
+#endif  // !defined(TOIT_FREERTOS)

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -67,6 +67,7 @@ namespace toit {
   M(spi_flash, MODULE_SPI_FLASH)             \
   M(file,    MODULE_FILE)                    \
   M(pipe,    MODULE_PIPE)                    \
+  M(stdio,   MODULE_STDIO)                   \
   M(zlib,    MODULE_ZLIB)                    \
   M(subprocess, MODULE_SUBPROCESS)           \
   M(math,    MODULE_MATH)                    \
@@ -736,6 +737,11 @@ namespace toit {
   PRIMITIVE(fd, 1)                           \
   PRIMITIVE(is_a_tty, 1)                     \
 
+#define MODULE_STDIO(PRIMITIVE)              \
+  PRIMITIVE(stdin_init, 0)                   \
+  PRIMITIVE(stdin_open, 1)                   \
+  PRIMITIVE(stdin_read, 1)                   \
+
 #define MODULE_ZLIB(PRIMITIVE)               \
   PRIMITIVE(adler32_start, 1)                \
   PRIMITIVE(adler32_add, 5)                  \
@@ -1095,6 +1101,7 @@ Object* get_absolute_path(Process* process, const wchar_t* pathname, wchar_t* ou
 #define _A_T_TimerResourceGroup(N, name)  MAKE_UNPACKING_MACRO(TimerResourceGroup, N, name)
 #define _A_T_UdpResourceGroup(N, name)    MAKE_UNPACKING_MACRO(UdpResourceGroup, N, name)
 #define _A_T_UartResourceGroup(N, name)   MAKE_UNPACKING_MACRO(UartResourceGroup, N, name)
+#define _A_T_StdinResourceGroup(N, name)  MAKE_UNPACKING_MACRO(StdinResourceGroup, N, name)
 #define _A_T_WifiResourceGroup(N, name)   MAKE_UNPACKING_MACRO(WifiResourceGroup, N, name)
 #define _A_T_EthernetResourceGroup(N, name) MAKE_UNPACKING_MACRO(EthernetResourceGroup, N, name)
 #define _A_T_BleResourceGroup(N, name)    MAKE_UNPACKING_MACRO(BleResourceGroup, N, name)
@@ -1139,6 +1146,7 @@ Object* get_absolute_path(Process* process, const wchar_t* pathname, wchar_t* ou
 #define _A_T_GpioPinResource(N, name)     MAKE_UNPACKING_MACRO(GpioPinResource, N, name)
 #define _A_T_GpioChipResource(N, name)    MAKE_UNPACKING_MACRO(GpioChipResource, N, name)
 #define _A_T_UartResource(N, name)        MAKE_UNPACKING_MACRO(UartResource, N, name)
+#define _A_T_StdinResource(N, name)       MAKE_UNPACKING_MACRO(StdinResource, N, name)
 #define _A_T_UdpSocketResource(N, name)   MAKE_UNPACKING_MACRO(UdpSocketResource, N, name)
 #define _A_T_TcpSocketResource(N, name)   MAKE_UNPACKING_MACRO(TcpSocketResource, N, name)
 #define _A_T_TcpServerSocketResource(N, name)   MAKE_UNPACKING_MACRO(TcpServerSocketResource, N, name)

--- a/src/primitive_core.cc
+++ b/src/primitive_core.cc
@@ -154,6 +154,8 @@ static Object* write_on_std(const uint8* bytes, size_t length, bool is_stdout, b
 
 #endif
 
+// These primitives are deliberately synchronous. They are shared by print_
+// and io.stdout/io.stderr and retain the platform's printf-like behavior.
 PRIMITIVE(write_on_stdout) {
   ARGS(Blob, message, bool, add_newline);
   bool is_stdout;

--- a/src/resources/stdio_esp32.cc
+++ b/src/resources/stdio_esp32.cc
@@ -1,0 +1,309 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the lib/LICENSE file.
+
+#include "../top.h"
+
+#ifdef TOIT_ESP32
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "sdkconfig.h"
+
+#ifdef CONFIG_ESP_CONSOLE_UART
+#include "driver/uart.h"
+#include "driver/uart_vfs.h"
+#include "uart_console_esp32.h"
+#endif
+
+#ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#include "driver/usb_serial_jtag.h"
+#include "driver/usb_serial_jtag_select.h"
+#include "driver/usb_serial_jtag_vfs.h"
+#endif
+
+#include "../event_sources/ev_queue_esp32.h"
+#include "../event_sources/system_esp32.h"
+#include "../objects_inline.h"
+#include "../primitive.h"
+#include "../process.h"
+#include "../resource.h"
+
+namespace toit {
+
+static const word STDIN_READ_EVENT = 1 << 0;
+static const int STDIN_BUFFER_SIZE = 1024;
+static const int UART_STDIN_RX_BUFFER_SIZE = 4096;
+
+enum StdinBackend {
+  STDIN_BACKEND_UART,
+  STDIN_BACKEND_USB_SERIAL_JTAG,
+};
+
+#ifdef CONFIG_ESP_CONSOLE_UART
+static int console_uart_stdin_users = 0;
+
+static esp_err_t acquire_uart_stdin(QueueHandle_t* queue) {
+  // Use the largest buffer supported by Port.console so opening that API
+  // later never silently weakens its --large-buffers contract.
+  esp_err_t err = console_uart_acquire(UART_STDIN_RX_BUFFER_SIZE, 1024, queue);
+  if (err != ESP_OK) return err;
+
+  bool failed = false;
+  {
+    Locker locker(OS::global_mutex());
+    if (console_uart_stdin_users++ == 0) {
+      uart_vfs_dev_use_driver(CONFIG_ESP_CONSOLE_UART_NUM);
+      int flags = fcntl(STDIN_FILENO, F_GETFL, 0);
+      if (flags < 0 || fcntl(STDIN_FILENO, F_SETFL, flags | O_NONBLOCK) < 0) {
+        console_uart_stdin_users--;
+        uart_vfs_dev_use_nonblocking(CONFIG_ESP_CONSOLE_UART_NUM);
+        failed = true;
+      }
+    }
+  }
+  if (failed) {
+    console_uart_release();
+    return ESP_FAIL;
+  }
+  return ESP_OK;
+}
+
+static void release_uart_stdin() {
+  {
+    Locker locker(OS::global_mutex());
+    ASSERT(console_uart_stdin_users > 0);
+    if (--console_uart_stdin_users == 0) {
+      uart_vfs_dev_use_nonblocking(CONFIG_ESP_CONSOLE_UART_NUM);
+    }
+  }
+  console_uart_release();
+}
+#endif
+
+#ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+static int usb_serial_jtag_stdin_users = 0;
+static QueueHandle_t usb_serial_jtag_stdin_queue = null;
+
+static void usb_serial_jtag_notify(usj_select_notif_t notification, BaseType_t* task_woken) {
+  if (notification != USJ_SELECT_READ_NOTIF || usb_serial_jtag_stdin_queue == null) return;
+  word event = STDIN_READ_EVENT;
+  xQueueSendFromISR(usb_serial_jtag_stdin_queue, &event, task_woken);
+}
+
+static esp_err_t acquire_usb_serial_jtag_stdin(QueueHandle_t* queue) {
+  Locker locker(OS::global_mutex());
+  if (usb_serial_jtag_stdin_users > 0) {
+    usb_serial_jtag_stdin_users++;
+    *queue = usb_serial_jtag_stdin_queue;
+    return ESP_OK;
+  }
+
+  usb_serial_jtag_stdin_queue = xQueueCreate(STDIN_QUEUE_SIZE, sizeof(word));
+  if (usb_serial_jtag_stdin_queue == null) return ESP_ERR_NO_MEM;
+
+  usb_serial_jtag_driver_config_t config = USB_SERIAL_JTAG_DRIVER_CONFIG_DEFAULT();
+  esp_err_t err = ESP_FAIL;
+  SystemEventSource::instance()->run([&]() -> void {
+    err = usb_serial_jtag_driver_install(&config);
+  });
+  if (err != ESP_OK) {
+    vQueueDelete(usb_serial_jtag_stdin_queue);
+    usb_serial_jtag_stdin_queue = null;
+    return err;
+  }
+
+  usb_serial_jtag_vfs_use_driver();
+  int flags = fcntl(STDIN_FILENO, F_GETFL, 0);
+  if (flags < 0 || fcntl(STDIN_FILENO, F_SETFL, flags | O_NONBLOCK) < 0) {
+    usb_serial_jtag_vfs_use_nonblocking();
+    SystemEventSource::instance()->run([&]() -> void {
+      err = usb_serial_jtag_driver_uninstall();
+    });
+    vQueueDelete(usb_serial_jtag_stdin_queue);
+    usb_serial_jtag_stdin_queue = null;
+    return ESP_FAIL;
+  }
+
+  usb_serial_jtag_set_select_notif_callback(usb_serial_jtag_notify);
+  if (usb_serial_jtag_read_ready()) {
+    word event = STDIN_READ_EVENT;
+    xQueueSend(usb_serial_jtag_stdin_queue, &event, 0);
+  }
+  usb_serial_jtag_stdin_users = 1;
+  *queue = usb_serial_jtag_stdin_queue;
+  return ESP_OK;
+}
+
+static void release_usb_serial_jtag_stdin() {
+  Locker locker(OS::global_mutex());
+  ASSERT(usb_serial_jtag_stdin_users > 0);
+  if (--usb_serial_jtag_stdin_users != 0) return;
+
+  usb_serial_jtag_set_select_notif_callback(null);
+  usb_serial_jtag_vfs_use_nonblocking();
+  esp_err_t err = ESP_FAIL;
+  SystemEventSource::instance()->run([&]() -> void {
+    err = usb_serial_jtag_driver_uninstall();
+  });
+  if (err != ESP_OK) {
+    esp_rom_printf("[stdio] error: failed to uninstall USB Serial/JTAG driver\n");
+    ESP_ERROR_CHECK(err);
+  }
+  vQueueDelete(usb_serial_jtag_stdin_queue);
+  usb_serial_jtag_stdin_queue = null;
+}
+#endif
+
+class StdinResource : public EventQueueResource {
+ public:
+  TAG(StdinResource);
+
+  StdinResource(ResourceGroup* group, QueueHandle_t queue, StdinBackend backend)
+      : EventQueueResource(group, queue)
+      , backend_(backend) {}
+
+  ~StdinResource() override {
+    switch (backend_) {
+#ifdef CONFIG_ESP_CONSOLE_UART
+      case STDIN_BACKEND_UART:
+        release_uart_stdin();
+        return;
+#endif
+#ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+      case STDIN_BACKEND_USB_SERIAL_JTAG:
+        release_usb_serial_jtag_stdin();
+        return;
+#endif
+      default:
+        UNREACHABLE();
+    }
+  }
+
+  bool receive_event(word* data) override {
+    switch (backend_) {
+#ifdef CONFIG_ESP_CONSOLE_UART
+      case STDIN_BACKEND_UART: {
+        uart_event_t event;
+        if (!xQueueReceive(queue(), &event, 0)) return false;
+        *data = event.type;
+        return true;
+      }
+#endif
+#ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+      case STDIN_BACKEND_USB_SERIAL_JTAG:
+        return xQueueReceive(queue(), data, 0);
+#endif
+      default:
+        UNREACHABLE();
+    }
+  }
+
+  StdinBackend backend() const { return backend_; }
+
+ private:
+  const StdinBackend backend_;
+};
+
+class StdinResourceGroup : public ResourceGroup {
+ public:
+  TAG(StdinResourceGroup);
+
+  StdinResourceGroup(Process* process, EventSource* event_source)
+      : ResourceGroup(process, event_source) {}
+
+  uint32_t on_event(Resource* resource, word data, uint32_t state) override {
+#ifdef CONFIG_ESP_CONSOLE_UART
+    auto stdin_resource = static_cast<StdinResource*>(resource);
+    if (stdin_resource->backend() == STDIN_BACKEND_UART) {
+      // Error events do not carry data, but must still wake a pending read so
+      // it can retry instead of waiting indefinitely.
+      return state | STDIN_READ_EVENT;
+    }
+#else
+    USE(resource);
+#endif
+    return state | static_cast<uint32_t>(data);
+  }
+};
+
+MODULE_IMPLEMENTATION(stdio, MODULE_STDIO)
+
+PRIMITIVE(stdin_init) {
+  ByteArray* proxy = process->object_heap()->allocate_proxy();
+  if (proxy == null) FAIL(ALLOCATION_FAILED);
+
+  auto group = _new StdinResourceGroup(process, EventQueueEventSource::instance());
+  if (group == null) FAIL(MALLOC_FAILED);
+
+  proxy->set_external_address(group);
+  return proxy;
+}
+
+PRIMITIVE(stdin_open) {
+  ARGS(StdinResourceGroup, group)
+
+#if !defined(CONFIG_ESP_CONSOLE_UART) && !defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
+  FAIL(UNSUPPORTED);
+#else
+  ByteArray* proxy = process->object_heap()->allocate_proxy();
+  if (proxy == null) FAIL(ALLOCATION_FAILED);
+
+  QueueHandle_t queue = null;
+  StdinBackend backend;
+  esp_err_t err;
+#ifdef CONFIG_ESP_CONSOLE_UART
+  backend = STDIN_BACKEND_UART;
+  err = acquire_uart_stdin(&queue);
+#else
+  backend = STDIN_BACKEND_USB_SERIAL_JTAG;
+  err = acquire_usb_serial_jtag_stdin(&queue);
+#endif
+  if (err != ESP_OK) return Primitive::os_error(err, process);
+
+  bool handed_to_resource = false;
+  Defer release_backend { [&] {
+    if (handed_to_resource) return;
+#ifdef CONFIG_ESP_CONSOLE_UART
+    release_uart_stdin();
+#else
+    release_usb_serial_jtag_stdin();
+#endif
+  } };
+
+  auto resource = _new StdinResource(group, queue, backend);
+  if (resource == null) FAIL(MALLOC_FAILED);
+  handed_to_resource = true;
+  group->register_resource(resource);
+  proxy->set_external_address(resource);
+  return proxy;
+#endif
+}
+
+PRIMITIVE(stdin_read) {
+  ARGS(StdinResource, resource)
+  USE(resource);
+
+#if !defined(CONFIG_ESP_CONSOLE_UART) && !defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
+  FAIL(UNSUPPORTED);
+#else
+  ByteArray* result = process->allocate_byte_array(STDIN_BUFFER_SIZE, true);
+  if (result == null) FAIL(ALLOCATION_FAILED);
+
+  ByteArray::Bytes bytes(result);
+  int read_count = ::read(STDIN_FILENO, bytes.address(), STDIN_BUFFER_SIZE);
+  if (read_count < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) return Smi::from(-1);
+    return Primitive::os_error(errno, process);
+  }
+  if (read_count == 0) return process->null_object();
+  if (read_count < STDIN_BUFFER_SIZE) result->resize_external(process, read_count);
+  return result;
+#endif
+}
+
+}  // namespace toit
+
+#endif  // TOIT_ESP32

--- a/src/resources/stdio_esp32.cc
+++ b/src/resources/stdio_esp32.cc
@@ -37,10 +37,9 @@ static const word STDIN_READ_EVENT = 1 << 0;
 static const int STDIN_BUFFER_SIZE = 1024;
 static const int UART_STDIN_RX_BUFFER_SIZE = 4096;
 
-enum StdinBackend {
-  STDIN_BACKEND_UART,
-  STDIN_BACKEND_USB_SERIAL_JTAG,
-};
+// ESP-IDF selects exactly one primary console. In particular,
+// CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG_ENABLED may additionally enable USB
+// Serial/JTAG output, but it does not select it as the standard streams.
 
 #ifdef CONFIG_ESP_CONSOLE_UART
 static int console_uart_stdin_users = 0;
@@ -161,50 +160,31 @@ class StdinResource : public EventQueueResource {
  public:
   TAG(StdinResource);
 
-  StdinResource(ResourceGroup* group, QueueHandle_t queue, StdinBackend backend)
-      : EventQueueResource(group, queue)
-      , backend_(backend) {}
+  StdinResource(ResourceGroup* group, QueueHandle_t queue)
+      : EventQueueResource(group, queue) {}
 
   ~StdinResource() override {
-    switch (backend_) {
 #ifdef CONFIG_ESP_CONSOLE_UART
-      case STDIN_BACKEND_UART:
-        release_uart_stdin();
-        return;
+    release_uart_stdin();
+#elif defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
+    release_usb_serial_jtag_stdin();
+#else
+    UNREACHABLE();
 #endif
-#ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
-      case STDIN_BACKEND_USB_SERIAL_JTAG:
-        release_usb_serial_jtag_stdin();
-        return;
-#endif
-      default:
-        UNREACHABLE();
-    }
   }
 
   bool receive_event(word* data) override {
-    switch (backend_) {
 #ifdef CONFIG_ESP_CONSOLE_UART
-      case STDIN_BACKEND_UART: {
-        uart_event_t event;
-        if (!xQueueReceive(queue(), &event, 0)) return false;
-        *data = event.type;
-        return true;
-      }
+    uart_event_t event;
+    if (!xQueueReceive(queue(), &event, 0)) return false;
+    *data = event.type;
+    return true;
+#elif defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
+    return xQueueReceive(queue(), data, 0);
+#else
+    UNREACHABLE();
 #endif
-#ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
-      case STDIN_BACKEND_USB_SERIAL_JTAG:
-        return xQueueReceive(queue(), data, 0);
-#endif
-      default:
-        UNREACHABLE();
-    }
   }
-
-  StdinBackend backend() const { return backend_; }
-
- private:
-  const StdinBackend backend_;
 };
 
 class StdinResourceGroup : public ResourceGroup {
@@ -215,15 +195,12 @@ class StdinResourceGroup : public ResourceGroup {
       : ResourceGroup(process, event_source) {}
 
   uint32_t on_event(Resource* resource, word data, uint32_t state) override {
-#ifdef CONFIG_ESP_CONSOLE_UART
-    auto stdin_resource = static_cast<StdinResource*>(resource);
-    if (stdin_resource->backend() == STDIN_BACKEND_UART) {
-      // Error events do not carry data, but must still wake a pending read so
-      // it can retry instead of waiting indefinitely.
-      return state | STDIN_READ_EVENT;
-    }
-#else
     USE(resource);
+#ifdef CONFIG_ESP_CONSOLE_UART
+    USE(data);
+    // Error events do not carry data, but must still wake a pending read so it
+    // can retry instead of waiting indefinitely.
+    return state | STDIN_READ_EVENT;
 #endif
     return state | static_cast<uint32_t>(data);
   }
@@ -252,13 +229,10 @@ PRIMITIVE(stdin_open) {
   if (proxy == null) FAIL(ALLOCATION_FAILED);
 
   QueueHandle_t queue = null;
-  StdinBackend backend;
   esp_err_t err;
 #ifdef CONFIG_ESP_CONSOLE_UART
-  backend = STDIN_BACKEND_UART;
   err = acquire_uart_stdin(&queue);
 #else
-  backend = STDIN_BACKEND_USB_SERIAL_JTAG;
   err = acquire_usb_serial_jtag_stdin(&queue);
 #endif
   if (err != ESP_OK) return Primitive::os_error(err, process);
@@ -273,7 +247,7 @@ PRIMITIVE(stdin_open) {
 #endif
   } };
 
-  auto resource = _new StdinResource(group, queue, backend);
+  auto resource = _new StdinResource(group, queue);
   if (resource == null) FAIL(MALLOC_FAILED);
   handed_to_resource = true;
   group->register_resource(resource);

--- a/src/resources/stdio_host.cc
+++ b/src/resources/stdio_host.cc
@@ -1,0 +1,109 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the lib/LICENSE file.
+
+#include "../top.h"
+
+#if !defined(TOIT_FREERTOS)
+
+#ifdef TOIT_WINDOWS
+#include "../error_win.h"
+#endif
+
+#include "../event_sources/stdio_host.h"
+#include "../objects_inline.h"
+#include "../primitive.h"
+#include "../process.h"
+#include "../resource.h"
+
+namespace toit {
+
+class StdinResource : public Resource {
+ public:
+  TAG(StdinResource);
+
+  explicit StdinResource(ResourceGroup* group) : Resource(group) {}
+};
+
+class StdinResourceGroup : public ResourceGroup {
+ public:
+  TAG(StdinResourceGroup);
+
+  StdinResourceGroup(Process* process, EventSource* event_source)
+      : ResourceGroup(process, event_source) {}
+
+  uint32_t on_event(Resource* resource, word data, uint32_t state) override {
+    return state | static_cast<uint32_t>(data);
+  }
+};
+
+MODULE_IMPLEMENTATION(stdio, MODULE_STDIO)
+
+PRIMITIVE(stdin_init) {
+  ByteArray* proxy = process->object_heap()->allocate_proxy();
+  if (proxy == null) FAIL(ALLOCATION_FAILED);
+
+  StdinEventSource* event_source = StdinEventSource::instance();
+  if (!event_source->use()) FAIL(ERROR);
+
+  auto group = _new StdinResourceGroup(process, event_source);
+  if (group == null) {
+    event_source->unuse();
+    FAIL(MALLOC_FAILED);
+  }
+
+  proxy->set_external_address(group);
+  return proxy;
+}
+
+PRIMITIVE(stdin_open) {
+  ARGS(StdinResourceGroup, group)
+
+  ByteArray* proxy = process->object_heap()->allocate_proxy();
+  if (proxy == null) FAIL(ALLOCATION_FAILED);
+
+  auto resource = _new StdinResource(group);
+  if (resource == null) FAIL(MALLOC_FAILED);
+  group->register_resource(resource);
+  proxy->set_external_address(resource);
+  return proxy;
+}
+
+PRIMITIVE(stdin_read) {
+  ARGS(StdinResource, resource)
+  USE(resource);
+
+  StdinEventSource* event_source = StdinEventSource::instance();
+  int error = 0;
+  int size = event_source->data_size(&error);
+  if (error != 0) {
+#ifdef TOIT_WINDOWS
+    return windows_error(process, error);
+#else
+    return Primitive::os_error(error, process);
+#endif
+  }
+  if (size < 0) return Smi::from(-1);
+  if (size == 0) return process->null_object();
+
+  ByteArray* result = process->allocate_byte_array(size, true);
+  if (result == null) FAIL(ALLOCATION_FAILED);
+
+  ByteArray::Bytes bytes(result);
+  int read = event_source->read(bytes.address(), size, &error);
+  if (error != 0) {
+#ifdef TOIT_WINDOWS
+    return windows_error(process, error);
+#else
+    return Primitive::os_error(error, process);
+#endif
+  }
+  if (read < 0) return Smi::from(-1);
+  if (read == 0) return process->null_object();
+  if (read < size) result->resize_external(process, read);
+  return result;
+}
+
+}  // namespace toit
+
+#endif  // !defined(TOIT_FREERTOS)

--- a/src/resources/uart_console_esp32.h
+++ b/src/resources/uart_console_esp32.h
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the lib/LICENSE file.
+
+#pragma once
+
+#include "../top.h"
+
+#if defined(TOIT_ESP32) && defined(CONFIG_ESP_CONSOLE_UART)
+
+#include "driver/uart.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+
+namespace toit {
+
+esp_err_t console_uart_acquire(int rx_buffer_size, int tx_buffer_size, QueueHandle_t* queue);
+void console_uart_release();
+
+}  // namespace toit
+
+#endif  // defined(TOIT_ESP32) && defined(CONFIG_ESP_CONSOLE_UART)

--- a/src/resources/uart_esp32.cc
+++ b/src/resources/uart_esp32.cc
@@ -34,6 +34,7 @@
 #include "../utils.h"
 
 #include "gpio_esp32.h"
+#include "uart_console_esp32.h"
 
 #ifndef FORCE_INLINE
 #error "FORCE_INLINE not defined"
@@ -111,6 +112,12 @@ public:
       , port_(port)
       , tx_buffer_size_(tx_buffer_size) {}
 
+  UartResource(ResourceGroup* group, uart_port_t port, int tx_buffer_size, QueueHandle_t queue, bool is_console)
+      : EventQueueResource(group, queue)
+      , port_(port)
+      , tx_buffer_size_(tx_buffer_size)
+      , is_console_(is_console) {}
+
   ~UartResource() override;
 
   uart_port_t port() const { return port_; }
@@ -118,6 +125,8 @@ public:
   int errors() const { return errors_; }
 
   int tx_buffer_size() const { return tx_buffer_size_; }
+
+  bool is_console() const { return is_console_; }
 
   // GPIO pins reserved by this port (tx/rx/rts/cts).
   GpioPins& owned_pins() { return owned_pins_; }
@@ -133,6 +142,7 @@ public:
  private:
   const uart_port_t port_;
   const int tx_buffer_size_;
+  const bool is_console_ = false;
   int64 errors_ = 0;
   GpioPins owned_pins_;
 
@@ -163,7 +173,7 @@ class UartResourceGroup : public ResourceGroup {
   void on_unregister_resource(Resource* r) override {
     auto uart_res = reinterpret_cast<UartResource*>(r);
 #ifdef CONFIG_ESP_CONSOLE_UART
-    if (uart_res->port() == CONFIG_ESP_CONSOLE_UART_NUM) {
+    if (uart_res->is_console()) {
       console_uart_port.put(uart_res->port());
       return;
     }
@@ -175,10 +185,17 @@ class UartResourceGroup : public ResourceGroup {
 };
 
 UartResource::~UartResource() {
-  esp_err_t err = uart_driver_delete(port_);
-  if (err != ESP_OK) {
-    esp_rom_printf("[uart] error: failed to delete UART driver\n");
-    ESP_ERROR_CHECK(err);
+#ifdef CONFIG_ESP_CONSOLE_UART
+  if (is_console_) {
+    console_uart_release();
+  } else
+#endif
+  {
+    esp_err_t err = uart_driver_delete(port_);
+    if (err != ESP_OK) {
+      esp_rom_printf("[uart] error: failed to delete UART driver\n");
+      ESP_ERROR_CHECK(err);
+    }
   }
   // Release any GPIO pins this port reserved.
   owned_pins_.release();
@@ -244,6 +261,71 @@ uint32 UartResourceGroup::on_event(Resource* r, word data, uint32 state) {
 }
 
 MODULE_IMPLEMENTATION(uart, MODULE_UART)
+
+#ifdef CONFIG_ESP_CONSOLE_UART
+static int console_uart_users = 0;
+static QueueHandle_t console_uart_queue = null;
+
+esp_err_t console_uart_acquire(int rx_buffer_size, int tx_buffer_size, QueueHandle_t* queue) {
+  Locker locker(OS::global_mutex());
+  if (console_uart_users > 0) {
+    console_uart_users++;
+    *queue = console_uart_queue;
+    return ESP_OK;
+  }
+
+  struct {
+    uart_port_t port;
+    int rx_buffer_size;
+    int tx_buffer_size;
+    esp_err_t result;
+  } args = {
+    .port = static_cast<uart_port_t>(CONFIG_ESP_CONSOLE_UART_NUM),
+    .rx_buffer_size = rx_buffer_size,
+    .tx_buffer_size = tx_buffer_size,
+    .result = ESP_FAIL,
+  };
+  SystemEventSource::instance()->run([&args]() -> void {
+    args.result = uart_driver_install(args.port,
+                                      args.rx_buffer_size,
+                                      args.tx_buffer_size,
+                                      UART_QUEUE_SIZE,
+                                      &console_uart_queue,
+                                      ESP_INTR_FLAG_SHARED | ESP_INTR_FLAG_LEVEL2 | ESP_INTR_FLAG_LEVEL1);
+  });
+  if (args.result != ESP_OK) return args.result;
+
+  esp_err_t err = uart_flush_input(args.port);
+  if (err != ESP_OK) {
+    SystemEventSource::instance()->run([&args]() -> void {
+      uart_driver_delete(args.port);
+    });
+    console_uart_queue = null;
+    return err;
+  }
+
+  console_uart_users = 1;
+  *queue = console_uart_queue;
+  return ESP_OK;
+}
+
+void console_uart_release() {
+  Locker locker(OS::global_mutex());
+  ASSERT(console_uart_users > 0);
+  if (--console_uart_users != 0) return;
+
+  uart_port_t port = static_cast<uart_port_t>(CONFIG_ESP_CONSOLE_UART_NUM);
+  esp_err_t err = ESP_FAIL;
+  SystemEventSource::instance()->run([&]() -> void {
+    err = uart_driver_delete(port);
+  });
+  console_uart_queue = null;
+  if (err != ESP_OK) {
+    esp_rom_printf("[uart] error: failed to delete console UART driver\n");
+    ESP_ERROR_CHECK(err);
+  }
+}
+#endif
 
 PRIMITIVE(init) {
   ByteArray* proxy = process->object_heap()->allocate_proxy();
@@ -546,38 +628,19 @@ PRIMITIVE(create_console) {
   // The console UART keeps the configuration (baud rate, pins, ...) it was
   // given during boot; only the driver is installed, which makes RX
   // interrupt driven. System output (logging, `print`) keeps going through
-  // the polling VFS path and thus doesn't need the driver.
+  // whichever UART VFS mode is active.
 
   esp_err_t err;
   QueueHandle_t queue;
-  DriverArgs args = {
-    .port = port,
-    .rx_buffer_size = static_cast<uint16_t>(rx_buffer_size),
-    .tx_buffer_size = static_cast<uint16_t>(tx_buffer_size),
-    // Level 3 interrupts are problematic on some chips (see `create`), so
-    // stick to the levels that are safe everywhere.
-    .interrupt_flags = ESP_INTR_FLAG_SHARED | ESP_INTR_FLAG_LEVEL2 | ESP_INTR_FLAG_LEVEL1,
-    .queue = &queue,
-    .queue_size = UART_QUEUE_SIZE,
-  };
-  // Install the ISR on the SystemEventSource's main thread that runs on core 0,
-  // to allocate the interrupts on core 0.
-  SystemEventSource::instance()->run([&]() -> void {
-    err = uart_driver_install(args.port,
-                              args.rx_buffer_size,
-                              args.tx_buffer_size,
-                              args.queue_size,
-                              args.queue,
-                              args.interrupt_flags);
-  });
+  err = console_uart_acquire(rx_buffer_size, tx_buffer_size, &queue);
   if (err != ESP_OK) return Primitive::os_error(err, process);
-  Defer uninstall_driver { [&] { if (!handed_to_resource) uart_driver_delete(port); } };
+  Defer uninstall_driver { [&] { if (!handed_to_resource) console_uart_release(); } };
 
   // Discard anything that was received before the port was opened.
   err = uart_flush_input(port);
   if (err != ESP_OK) return Primitive::os_error(err, process);
 
-  auto resource = _new UartResource(group, port, tx_buffer_size, queue);
+  auto resource = _new UartResource(group, port, tx_buffer_size, queue, true);
   if (!resource) FAIL(MALLOC_FAILED);
   handed_to_resource = true;
 

--- a/src/resources/uart_esp32.cc
+++ b/src/resources/uart_esp32.cc
@@ -269,6 +269,10 @@ static QueueHandle_t console_uart_queue = null;
 esp_err_t console_uart_acquire(int rx_buffer_size, int tx_buffer_size, QueueHandle_t* queue) {
   Locker locker(OS::global_mutex());
   if (console_uart_users > 0) {
+    // Buffer sizes only affect the first driver installation. Stdin requests
+    // the largest sizes exposed by Port.console. If Port.console installs its
+    // smaller default receive buffer first, stdin still works and makes no
+    // public buffer-size guarantee.
     console_uart_users++;
     *queue = console_uart_queue;
     return ESP_OK;

--- a/src/tags.h
+++ b/src/tags.h
@@ -42,6 +42,7 @@ namespace toit {
   fn(ZlibRle)                           \
   fn(Zlib)                              \
   fn(UartResource)                      \
+  fn(StdinResource)                     \
   fn(GpioResource)                      \
   fn(GpioPinResource)                   \
   fn(GpioChipResource)                  \
@@ -102,6 +103,7 @@ namespace toit {
   fn(MbedTlsResourceGroup)              \
   fn(UdpResourceGroup)                  \
   fn(UartResourceGroup)                 \
+  fn(StdinResourceGroup)                \
   fn(RmtResourceGroup)                  \
   fn(WifiResourceGroup)                 \
   fn(EthernetResourceGroup)             \

--- a/src/vm_bsd.cc
+++ b/src/vm_bsd.cc
@@ -21,6 +21,7 @@
 #include "vm.h"
 
 #include "event_sources/kqueue_bsd.h"
+#include "event_sources/stdio_host.h"
 #include "event_sources/lwip_esp32.h"
 #include "event_sources/subprocess.h"
 #include "event_sources/timer.h"
@@ -35,6 +36,7 @@ void VM::load_platform_event_sources() {
   event_manager()->add_event_source(_new SubprocessEventSource());
   event_manager()->add_event_source(_new TlsEventSource());
   event_manager()->add_event_source(_new HostBleEventSource());
+  event_manager()->add_event_source(_new StdinEventSource());
 }
 
 } // namespace toit

--- a/src/vm_linux.cc
+++ b/src/vm_linux.cc
@@ -24,6 +24,7 @@
 #include "event_sources/gpio_linux.h"
 #include "event_sources/lwip_esp32.h"
 #include "event_sources/spi_linux.h"
+#include "event_sources/stdio_host.h"
 #include "event_sources/subprocess.h"
 #include "event_sources/timer.h"
 #include "event_sources/tls.h"
@@ -41,6 +42,7 @@ void VM::load_platform_event_sources() {
   event_manager()->add_event_source(_new TlsEventSource());
   event_manager()->add_event_source(_new GpioEventSource());
   event_manager()->add_event_source(_new SpiEventSource());
+  event_manager()->add_event_source(_new StdinEventSource());
 }
 
 } // namespace toit

--- a/src/vm_win.cc
+++ b/src/vm_win.cc
@@ -23,6 +23,7 @@
 #include "event_sources/timer.h"
 #include "event_sources/tls.h"
 #include "event_sources/event_win.h"
+#include "event_sources/stdio_host.h"
 
 namespace toit {
 
@@ -34,6 +35,7 @@ void VM::load_platform_event_sources() {
   event_manager()->add_event_source(_new TimerEventSource());
   event_manager()->add_event_source(_new TlsEventSource());
   event_manager()->add_event_source(_new WindowsEventSource());
+  event_manager()->add_event_source(_new StdinEventSource());
 }
 
 } // namespace toit

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -176,6 +176,7 @@ add_subdirectory(pkg)
 add_subdirectory(envelope)
 add_subdirectory(toitdoc)
 add_subdirectory(dependencies)
+add_subdirectory(stdio)
 
 # Add the pi-tests so that its packages are downloaded.
 # This is only necessary for the health tests, since the tests themselves

--- a/tests/qemu/README.md
+++ b/tests/qemu/README.md
@@ -1,25 +1,40 @@
 # Running ESP32 stdio tests with QEMU
 
 These notes describe the workflow verified in August 2026 with the
-[`toitlang/qemu` v9.2.2-toitlang.1 release](https://github.com/toitlang/qemu/releases/tag/v9.2.2-toitlang.1).
+[`toitlang/qemu` v9.2.2-toitlang.2 release](https://github.com/toitlang/qemu/releases/tag/v9.2.2-toitlang.2).
 
 ## Install QEMU
 
 For an x86-64 Linux host:
 
 ```sh
-QEMU_VERSION=v9.2.2-toitlang.1
+QEMU_VERSION=v9.2.2-toitlang.2
+QEMU_ARCHIVE=qemu-toit-$QEMU_VERSION-linux-x86_64.tar.gz
+QEMU_SHA256=103a3a52ab0639afffc0a82c10cb92294d0f5c8a00ee631ce98cb190e7d5a17d
 curl -L --fail \
-  "https://github.com/toitlang/qemu/releases/download/$QEMU_VERSION/qemu-toit-$QEMU_VERSION-linux-x86_64.tar.gz" \
-  -o "/tmp/qemu-toit-$QEMU_VERSION-linux-x86_64.tar.gz"
-sha256sum "/tmp/qemu-toit-$QEMU_VERSION-linux-x86_64.tar.gz"
-tar -xf "/tmp/qemu-toit-$QEMU_VERSION-linux-x86_64.tar.gz" -C /tmp
+  "https://github.com/toitlang/qemu/releases/download/$QEMU_VERSION/$QEMU_ARCHIVE" \
+  -o "/tmp/$QEMU_ARCHIVE"
+printf '%s  %s\n' "$QEMU_SHA256" "/tmp/$QEMU_ARCHIVE" | sha256sum --check
+tar -xf "/tmp/$QEMU_ARCHIVE" -C /tmp
 QEMU=/tmp/qemu-toit-$QEMU_VERSION-linux-x86_64/bin/qemu-system-xtensa
 ```
 
-The expected SHA-256 for this archive is
-`7f064715d32629e34edc3c54c85d5c132c32e40e4d7d5564822258150f3c8fe0`.
 Release archives for other hosts are available on the same release page.
+
+## Run the automated tests
+
+After building the regular ESP32 firmware, build a separate S3 envelope whose
+primary console is USB Serial/JTAG and run all standard-stream fixtures:
+
+```sh
+tests/qemu/build-s3-usb-envelope.sh
+QEMU_SYSTEM_XTENSA=$QEMU tests/qemu/run-tests.sh
+```
+
+The runner tests stdin, stdout, and stderr through both an ESP32 UART and the
+ESP32-S3 USB Serial/JTAG device. It also verifies that `io.stdin` and
+`uart.Port.console` can share the console UART. Each input is sent only after
+the corresponding readiness marker appears, and every wait has a timeout.
 
 ## Build and create a flash image
 
@@ -85,47 +100,32 @@ Repeat the envelope commands with `build/esp32s3`, then run QEMU with
 `-M esp32s3`. The tested QEMU release prints a PSRAM-detection error during
 boot; this did not prevent the Toit runtime or UART stdio test from running.
 
-The USB Serial/JTAG backend can be compile-tested by building the S3 with
-`CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y` as the primary console and
-`CONFIG_ESP_CONSOLE_SECONDARY_NONE=y`. Use a temporary `SDKCONFIG` and a
-separate build directory so the checked-in configuration stays unchanged.
-
-The following is the non-interactive configuration used for this test:
+Build the S3 USB Serial/JTAG envelope with the provided helper. It uses a
+generated `SDKCONFIG` and a separate build directory, leaving the checked-in
+configuration unchanged:
 
 ```sh
-mkdir -p /tmp/toit-s3-usj
-cp toolchains/esp32s3/sdkconfig /tmp/toit-s3-usj/sdkconfig
-sed -i \
-  -e 's/^CONFIG_ESP_CONSOLE_UART_DEFAULT=y$/# CONFIG_ESP_CONSOLE_UART_DEFAULT is not set/' \
-  -e 's/^# CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG is not set$/CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y/' \
-  -e 's/^# CONFIG_ESP_CONSOLE_SECONDARY_NONE is not set$/CONFIG_ESP_CONSOLE_SECONDARY_NONE=y/' \
-  -e 's/^CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y$/# CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG is not set/' \
-  -e 's/^CONFIG_ESP_CONSOLE_UART=y$/# CONFIG_ESP_CONSOLE_UART is not set/' \
-  -e 's/^CONFIG_CONSOLE_UART_DEFAULT=y$/# CONFIG_CONSOLE_UART_DEFAULT is not set/' \
-  -e 's/^CONFIG_CONSOLE_UART=y$/# CONFIG_CONSOLE_UART is not set/' \
-  /tmp/toit-s3-usj/sdkconfig
-
-source third_party/esp-idf/export.sh
-IDF_TARGET=esp32s3 IDF_CCACHE_ENABLE=1 CCACHE_DIR=/tmp/toit-ccache \
-  python third_party/esp-idf/tools/idf.py \
-    -C toolchains/esp32s3 \
-    -B build/esp32s3-usj \
-    -D SDKCONFIG=/tmp/toit-s3-usj/sdkconfig \
-    build
+CCACHE_DIR=/tmp/toit-ccache tests/qemu/build-s3-usb-envelope.sh
 ```
 
-After configuration, verify that
-`build/esp32s3-usj/config/sdkconfig.h` defines
-`CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG` and does not define
-`CONFIG_ESP_CONSOLE_UART`.
+Connect QEMU's emulated device to a character backend using the structured
+`-global` form. The device type contains dots, so the shorthand form cannot
+address it:
 
-It cannot currently be tested end-to-end with this QEMU release. The emulated
-USB Serial/JTAG device in
-[`hw/misc/esp32c3_jtag.c`](https://github.com/toitlang/qemu/blob/v9.2.2-toitlang.1/hw/misc/esp32c3_jtag.c)
-returns zero for every register read, ignores every write, has no interrupt,
-and exposes no character-device connection. The S3 machine maps that stub,
-so an application using USB Serial/JTAG receives no input and its output is
-not visible. This is a QEMU limitation, not a usable USB test setup.
+```sh
+$QEMU \
+  -M esp32s3 \
+  -accel tcg,thread=single \
+  -display none \
+  -monitor none \
+  -serial null \
+  -chardev stdio,id=usb \
+  -global driver=misc.esp32c3.usb_serial_jtag,property=chardev,value=usb \
+  -drive file=build/esp32s3-usj/qemu-stdio.bin,format=raw,if=mtd \
+  -no-reboot
+```
+
+The automated runner creates the flash image and supplies these options.
 
 ESP32-S2 USB CDC is intentionally outside this test and the current stdio
 implementation.

--- a/tests/qemu/README.md
+++ b/tests/qemu/README.md
@@ -1,0 +1,131 @@
+# Running ESP32 stdio tests with QEMU
+
+These notes describe the workflow verified in August 2026 with the
+[`toitlang/qemu` v9.2.2-toitlang.1 release](https://github.com/toitlang/qemu/releases/tag/v9.2.2-toitlang.1).
+
+## Install QEMU
+
+For an x86-64 Linux host:
+
+```sh
+QEMU_VERSION=v9.2.2-toitlang.1
+curl -L --fail \
+  "https://github.com/toitlang/qemu/releases/download/$QEMU_VERSION/qemu-toit-$QEMU_VERSION-linux-x86_64.tar.gz" \
+  -o "/tmp/qemu-toit-$QEMU_VERSION-linux-x86_64.tar.gz"
+sha256sum "/tmp/qemu-toit-$QEMU_VERSION-linux-x86_64.tar.gz"
+tar -xf "/tmp/qemu-toit-$QEMU_VERSION-linux-x86_64.tar.gz" -C /tmp
+QEMU=/tmp/qemu-toit-$QEMU_VERSION-linux-x86_64/bin/qemu-system-xtensa
+```
+
+The expected SHA-256 for this archive is
+`7f064715d32629e34edc3c54c85d5c132c32e40e4d7d5564822258150f3c8fe0`.
+Release archives for other hosts are available on the same release page.
+
+## Build and create a flash image
+
+Build the SDK and ESP32 firmware from the repository root. In a restricted
+agent environment, point ccache at a writable directory:
+
+```sh
+CCACHE_DIR=/tmp/toit-ccache make -j4 esp32
+```
+
+Compile the test program, add it as a boot-triggered container, and ask the
+firmware tool to assemble a complete flash image:
+
+```sh
+TOIT=build/host/sdk/bin/toit
+$TOIT compile --snapshot --project-root tests/qemu \
+  -o build/esp32/qemu-stdio.snapshot tests/qemu/stdio.toit
+$TOIT tool firmware --envelope=build/esp32/firmware.envelope \
+  container install -o build/esp32/qemu-stdio.envelope \
+  stdio build/esp32/qemu-stdio.snapshot
+$TOIT tool firmware --envelope=build/esp32/qemu-stdio.envelope \
+  extract --format=image -o build/esp32/qemu-stdio.bin
+```
+
+Using `firmware extract --format=image` is easier and less error-prone than
+calling `esptool merge-bin` manually: it uses the offsets and binaries stored
+in the envelope.
+
+## Run the ESP32 UART test
+
+```sh
+$QEMU \
+  -M esp32 \
+  -display none \
+  -monitor none \
+  -serial stdio \
+  -drive file=build/esp32/qemu-stdio.bin,format=raw,if=mtd \
+  -no-reboot
+```
+
+Wait for `STDIO-READY` before entering input. Opening the interrupt-driven
+console UART deliberately flushes bytes received before it was opened. For
+example, entering `hello-qemu` followed by return should produce both
+`STDOUT:hello-qemu` and `STDERR:hello-qemu`.
+
+The separate `stdio-uart-console.toit` fixture checks that `io.stdin` and
+`uart.Port.console` can share the driver. It first reads through `io.stdin`,
+then through the UART port; send one line after each readiness marker.
+
+Using `-display none -monitor none -serial stdio` gives the UART exclusive use
+of the terminal. `-nographic` also works, but multiplexes the QEMU monitor and
+serial port and therefore makes scripted input less convenient.
+
+## ESP32-S3
+
+The UART configuration can be tested in the same way:
+
+```sh
+CCACHE_DIR=/tmp/toit-ccache make -j4 esp32s3
+```
+
+Repeat the envelope commands with `build/esp32s3`, then run QEMU with
+`-M esp32s3`. The tested QEMU release prints a PSRAM-detection error during
+boot; this did not prevent the Toit runtime or UART stdio test from running.
+
+The USB Serial/JTAG backend can be compile-tested by building the S3 with
+`CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y` as the primary console and
+`CONFIG_ESP_CONSOLE_SECONDARY_NONE=y`. Use a temporary `SDKCONFIG` and a
+separate build directory so the checked-in configuration stays unchanged.
+
+The following is the non-interactive configuration used for this test:
+
+```sh
+mkdir -p /tmp/toit-s3-usj
+cp toolchains/esp32s3/sdkconfig /tmp/toit-s3-usj/sdkconfig
+sed -i \
+  -e 's/^CONFIG_ESP_CONSOLE_UART_DEFAULT=y$/# CONFIG_ESP_CONSOLE_UART_DEFAULT is not set/' \
+  -e 's/^# CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG is not set$/CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y/' \
+  -e 's/^# CONFIG_ESP_CONSOLE_SECONDARY_NONE is not set$/CONFIG_ESP_CONSOLE_SECONDARY_NONE=y/' \
+  -e 's/^CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y$/# CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG is not set/' \
+  -e 's/^CONFIG_ESP_CONSOLE_UART=y$/# CONFIG_ESP_CONSOLE_UART is not set/' \
+  -e 's/^CONFIG_CONSOLE_UART_DEFAULT=y$/# CONFIG_CONSOLE_UART_DEFAULT is not set/' \
+  -e 's/^CONFIG_CONSOLE_UART=y$/# CONFIG_CONSOLE_UART is not set/' \
+  /tmp/toit-s3-usj/sdkconfig
+
+source third_party/esp-idf/export.sh
+IDF_TARGET=esp32s3 IDF_CCACHE_ENABLE=1 CCACHE_DIR=/tmp/toit-ccache \
+  python third_party/esp-idf/tools/idf.py \
+    -C toolchains/esp32s3 \
+    -B build/esp32s3-usj \
+    -D SDKCONFIG=/tmp/toit-s3-usj/sdkconfig \
+    build
+```
+
+After configuration, verify that
+`build/esp32s3-usj/config/sdkconfig.h` defines
+`CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG` and does not define
+`CONFIG_ESP_CONSOLE_UART`.
+
+It cannot currently be tested end-to-end with this QEMU release. The emulated
+USB Serial/JTAG device in
+[`hw/misc/esp32c3_jtag.c`](https://github.com/toitlang/qemu/blob/v9.2.2-toitlang.1/hw/misc/esp32c3_jtag.c)
+returns zero for every register read, ignores every write, has no interrupt,
+and exposes no character-device connection. The S3 machine maps that stub,
+so an application using USB Serial/JTAG receives no input and its output is
+not visible. This is a QEMU limitation, not a usable USB test setup.
+
+ESP32-S2 USB CDC is intentionally outside this test and the current stdio
+implementation.

--- a/tests/qemu/build-s3-usb-envelope.sh
+++ b/tests/qemu/build-s3-usb-envelope.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2026 Toit contributors.
+# Use of this source code is governed by a Zero-Clause BSD license that can
+# be found in the tests/LICENSE file.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUILD_DIR="${1:-${ROOT_DIR}/build/esp32s3-usj}"
+SDKCONFIG="${BUILD_DIR}/sdkconfig.usj"
+
+mkdir -p "${BUILD_DIR}"
+cp "${ROOT_DIR}/toolchains/esp32s3/sdkconfig" "${SDKCONFIG}"
+sed -i \
+  -e 's/^CONFIG_ESP_CONSOLE_UART_DEFAULT=y$/# CONFIG_ESP_CONSOLE_UART_DEFAULT is not set/' \
+  -e 's/^# CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG is not set$/CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y/' \
+  -e 's/^# CONFIG_ESP_CONSOLE_SECONDARY_NONE is not set$/CONFIG_ESP_CONSOLE_SECONDARY_NONE=y/' \
+  -e 's/^CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y$/# CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG is not set/' \
+  -e 's/^CONFIG_ESP_CONSOLE_UART=y$/# CONFIG_ESP_CONSOLE_UART is not set/' \
+  -e 's/^CONFIG_CONSOLE_UART_DEFAULT=y$/# CONFIG_CONSOLE_UART_DEFAULT is not set/' \
+  -e 's/^CONFIG_CONSOLE_UART=y$/# CONFIG_CONSOLE_UART is not set/' \
+  "${SDKCONFIG}"
+
+export IDF_PATH="${ROOT_DIR}/third_party/esp-idf"
+source "${IDF_PATH}/export.sh"
+IDF_TARGET=esp32s3 IDF_CCACHE_ENABLE=1 python \
+  "${IDF_PATH}/tools/idf.py" \
+  -C "${ROOT_DIR}/toolchains/esp32s3" \
+  -B "${BUILD_DIR}" \
+  -D "SDKCONFIG=${SDKCONFIG}" \
+  build
+
+CONFIG_HEADER="${BUILD_DIR}/config/sdkconfig.h"
+if ! grep -q '^#define CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG 1$' "${CONFIG_HEADER}" ||
+    grep -q '^#define CONFIG_ESP_CONSOLE_UART 1$' "${CONFIG_HEADER}"; then
+  echo "ESP32-S3 USB Serial/JTAG console configuration was not selected." >&2
+  exit 1
+fi

--- a/tests/qemu/run-tests.sh
+++ b/tests/qemu/run-tests.sh
@@ -51,10 +51,12 @@ make_image() {
   local fixture="$1"
   local envelope="$2"
   local name="$3"
+  local source="${TEMP_DIR}/${fixture}"
 
+  cp "${ROOT_DIR}/tests/qemu/${fixture}" "${source}"
   "${TOIT}" compile --snapshot --project-root "${TEMP_DIR}" \
     -o "${TEMP_DIR}/${name}.snapshot" \
-    "${ROOT_DIR}/tests/qemu/${fixture}"
+    "${source}"
   "${TOIT}" tool firmware --envelope="${envelope}" container install \
     -o "${TEMP_DIR}/${name}.envelope" \
     "${name}" "${TEMP_DIR}/${name}.snapshot"

--- a/tests/qemu/run-tests.sh
+++ b/tests/qemu/run-tests.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2026 Toit contributors.
+# Use of this source code is governed by a Zero-Clause BSD license that can
+# be found in the tests/LICENSE file.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+QEMU_SYSTEM_XTENSA="${QEMU_SYSTEM_XTENSA:-qemu-system-xtensa}"
+TOIT="${TOIT:-${ROOT_DIR}/build/host/sdk/bin/toit}"
+UART_ENVELOPE="${UART_ENVELOPE:-${ROOT_DIR}/build/esp32/firmware.envelope}"
+USB_ENVELOPE="${USB_ENVELOPE:-${ROOT_DIR}/build/esp32s3-usj/firmware.envelope}"
+QEMU_TIMEOUT_TICKS="${QEMU_TIMEOUT_TICKS:-300}"
+
+if ! command -v "${QEMU_SYSTEM_XTENSA}" >/dev/null 2>&1; then
+  echo "QEMU executable not found: ${QEMU_SYSTEM_XTENSA}" >&2
+  exit 2
+fi
+if [[ ! -x "${TOIT}" ]]; then
+  echo "Toit executable is not executable: ${TOIT}" >&2
+  exit 2
+fi
+for envelope in "${UART_ENVELOPE}" "${USB_ENVELOPE}"; do
+  if [[ ! -f "${envelope}" ]]; then
+    echo "Firmware envelope not found: ${envelope}" >&2
+    exit 2
+  fi
+done
+
+TEMP_DIR="$(mktemp -d)"
+QEMU_PID=""
+QEMU_LOG=""
+
+stop_qemu() {
+  exec 3>&- 2>/dev/null || true
+  if [[ -n "${QEMU_PID}" ]]; then
+    kill "${QEMU_PID}" 2>/dev/null || true
+    wait "${QEMU_PID}" 2>/dev/null || true
+    QEMU_PID=""
+  fi
+}
+
+cleanup() {
+  stop_qemu
+  rm -rf "${TEMP_DIR}"
+}
+trap cleanup EXIT
+
+make_image() {
+  local fixture="$1"
+  local envelope="$2"
+  local name="$3"
+
+  "${TOIT}" compile --snapshot --project-root "${ROOT_DIR}/tests/qemu" \
+    -o "${TEMP_DIR}/${name}.snapshot" \
+    "${ROOT_DIR}/tests/qemu/${fixture}"
+  "${TOIT}" tool firmware --envelope="${envelope}" container install \
+    -o "${TEMP_DIR}/${name}.envelope" \
+    "${name}" "${TEMP_DIR}/${name}.snapshot"
+  "${TOIT}" tool firmware --envelope="${TEMP_DIR}/${name}.envelope" extract \
+    --format=image -o "${TEMP_DIR}/${name}.bin"
+}
+
+start_qemu() {
+  local machine="$1"
+  local image="$2"
+  local console="$3"
+  local input="${TEMP_DIR}/${image}.in"
+  QEMU_LOG="${TEMP_DIR}/${image}.log"
+
+  mkfifo "${input}"
+  exec 3<>"${input}"
+
+  local -a console_options
+  if [[ "${console}" == uart ]]; then
+    console_options=(-serial stdio)
+  else
+    console_options=(
+      -serial null
+      -chardev stdio,id=usb
+      -global driver=misc.esp32c3.usb_serial_jtag,property=chardev,value=usb
+    )
+  fi
+
+  "${QEMU_SYSTEM_XTENSA}" \
+    -M "${machine}" \
+    -accel tcg,thread=single \
+    -display none \
+    -monitor none \
+    -no-reboot \
+    -drive "file=${TEMP_DIR}/${image}.bin,if=mtd,format=raw" \
+    "${console_options[@]}" \
+    <"${input}" >"${QEMU_LOG}" 2>&1 &
+  QEMU_PID="$!"
+}
+
+wait_for() {
+  local marker="$1"
+  for ((tick = 0; tick < QEMU_TIMEOUT_TICKS; tick++)); do
+    if grep -Fq "${marker}" "${QEMU_LOG}"; then
+      return 0
+    fi
+    if ! kill -0 "${QEMU_PID}" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  echo "Timed out waiting for '${marker}'." >&2
+  cat "${QEMU_LOG}" >&2
+  return 1
+}
+
+run_stdio_test() {
+  local machine="$1"
+  local image="$2"
+  local console="$3"
+
+  start_qemu "${machine}" "${image}" "${console}"
+  wait_for STDIO-READY
+  printf 'hello-qemu\n' >&3
+  wait_for STDOUT:hello-qemu
+  wait_for STDERR:hello-qemu
+  stop_qemu
+  echo "PASS: ${machine} ${console} stdin/stdout/stderr"
+}
+
+run_uart_sharing_test() {
+  start_qemu esp32 uart-share uart
+  wait_for IO-READY
+  printf 'io-line\n' >&3
+  wait_for IO:io-line
+  wait_for UART-READY
+  printf 'uart-line\n' >&3
+  wait_for UART:uart-line
+  stop_qemu
+  echo "PASS: ESP32 io.stdin and uart.Port.console sharing"
+}
+
+make_image stdio.toit "${UART_ENVELOPE}" stdio-uart
+make_image stdio-uart-console.toit "${UART_ENVELOPE}" uart-share
+make_image stdio.toit "${USB_ENVELOPE}" stdio-usb
+
+run_stdio_test esp32 stdio-uart uart
+run_uart_sharing_test
+run_stdio_test esp32s3 stdio-usb usb-serial-jtag

--- a/tests/qemu/run-tests.sh
+++ b/tests/qemu/run-tests.sh
@@ -52,7 +52,7 @@ make_image() {
   local envelope="$2"
   local name="$3"
 
-  "${TOIT}" compile --snapshot --project-root "${ROOT_DIR}/tests/qemu" \
+  "${TOIT}" compile --snapshot --project-root "${TEMP_DIR}" \
     -o "${TEMP_DIR}/${name}.snapshot" \
     "${ROOT_DIR}/tests/qemu/${fixture}"
   "${TOIT}" tool firmware --envelope="${envelope}" container install \

--- a/tests/qemu/stdio-uart-console.toit
+++ b/tests/qemu/stdio-uart-console.toit
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the lib/LICENSE file.
+
+import io
+import uart
+
+main:
+  port := uart.Port.console
+
+  io.stdout.write "IO-READY\n"
+  data := io.stdin.read
+  io.stdout.write "IO:"
+  if data: io.stdout.write data
+
+  io.stdout.write "UART-READY\n"
+  data = port.in.read
+  io.stdout.write "UART:"
+  if data: io.stdout.write data

--- a/tests/qemu/stdio-uart-console.toit
+++ b/tests/qemu/stdio-uart-console.toit
@@ -9,11 +9,11 @@ main:
   port := uart.Port.console
 
   io.stdout.write "IO-READY\n"
-  data := io.stdin.read
+  data := io.stdin.read-line --keep-newline
   io.stdout.write "IO:"
   if data: io.stdout.write data
 
   io.stdout.write "UART-READY\n"
-  data = port.in.read
+  data = port.in.read-line --keep-newline
   io.stdout.write "UART:"
   if data: io.stdout.write data

--- a/tests/qemu/stdio.toit
+++ b/tests/qemu/stdio.toit
@@ -1,0 +1,13 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the lib/LICENSE file.
+
+import io
+
+main:
+  io.stdout.write "STDIO-READY\n"
+  data := io.stdin.read
+  io.stdout.write "STDOUT:"
+  if data: io.stdout.write data
+  io.stderr.write "STDERR:"
+  if data: io.stderr.write data

--- a/tests/qemu/stdio.toit
+++ b/tests/qemu/stdio.toit
@@ -6,7 +6,7 @@ import io
 
 main:
   io.stdout.write "STDIO-READY\n"
-  data := io.stdin.read
+  data := io.stdin.read-line --keep-newline
   io.stdout.write "STDOUT:"
   if data: io.stdout.write data
   io.stderr.write "STDERR:"

--- a/tests/stdio/CMakeLists.txt
+++ b/tests/stdio/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (C) 2026 Toit contributors.
+# Use of this source code is governed by an MIT-style license that can be
+# found in the lib/LICENSE file.
+
+add_test(
+  NAME tests/stdio/stdio-test
+  COMMAND ${CMAKE_COMMAND}
+      -DTOIT_RUN=$<TARGET_FILE:toit.run>
+      -DTEST=${CMAKE_CURRENT_SOURCE_DIR}/stdio-test.toit
+      -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/stdin.txt
+      -DPROJECT_ROOT=${CMAKE_CURRENT_SOURCE_DIR}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/run.cmake
+  )
+
+add_test(
+  NAME tests/stdio/host-coexist-test
+  COMMAND ${CMAKE_COMMAND}
+      -DTOIT_RUN=$<TARGET_FILE:toit.run>
+      -DTEST=${CMAKE_CURRENT_SOURCE_DIR}/host-coexist-test.toit
+      -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/stdin.txt
+      -DPROJECT_ROOT=${TOIT_SDK_SOURCE_DIR}/tests
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/run.cmake
+  )

--- a/tests/stdio/host-coexist-test.toit
+++ b/tests/stdio/host-coexist-test.toit
@@ -1,0 +1,16 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the lib/LICENSE file.
+
+import host.pipe
+import io
+
+main:
+  // Opening host.stdin marks the descriptor non-blocking on Posix systems.
+  // io.stdin must still wait for and consume input correctly.
+  pipe.stdin
+  data := io.stdin.read-all
+  io.stdout.write "stdout:"
+  if data: io.stdout.write data
+  io.stderr.write "stderr:"
+  if data: io.stderr.write data

--- a/tests/stdio/run.cmake
+++ b/tests/stdio/run.cmake
@@ -8,9 +8,12 @@ execute_process(
   OUTPUT_VARIABLE ACTUAL_STDOUT
   ERROR_VARIABLE ACTUAL_STDERR
   RESULT_VARIABLE RESULT
+  TIMEOUT 30
   )
 
-if(NOT RESULT EQUAL 0)
+if(RESULT MATCHES "[Tt]imeout")
+  message(FATAL_ERROR "stdio test timed out:\n${ACTUAL_STDERR}")
+elseif(NOT RESULT EQUAL 0)
   message(FATAL_ERROR "stdio test failed with exit code ${RESULT}:\n${ACTUAL_STDERR}")
 endif()
 

--- a/tests/stdio/run.cmake
+++ b/tests/stdio/run.cmake
@@ -1,0 +1,24 @@
+# Copyright (C) 2026 Toit contributors.
+# Use of this source code is governed by an MIT-style license that can be
+# found in the lib/LICENSE file.
+
+execute_process(
+  COMMAND "${TOIT_RUN}" --project-root "${PROJECT_ROOT}" "${TEST}"
+  INPUT_FILE "${INPUT}"
+  OUTPUT_VARIABLE ACTUAL_STDOUT
+  ERROR_VARIABLE ACTUAL_STDERR
+  RESULT_VARIABLE RESULT
+  )
+
+if(NOT RESULT EQUAL 0)
+  message(FATAL_ERROR "stdio test failed with exit code ${RESULT}:\n${ACTUAL_STDERR}")
+endif()
+
+set(EXPECTED_STDOUT "stdout:hello from stdin\n")
+set(EXPECTED_STDERR "stderr:hello from stdin\n")
+if(NOT ACTUAL_STDOUT STREQUAL EXPECTED_STDOUT)
+  message(FATAL_ERROR "unexpected stdout: '${ACTUAL_STDOUT}'")
+endif()
+if(NOT ACTUAL_STDERR STREQUAL EXPECTED_STDERR)
+  message(FATAL_ERROR "unexpected stderr: '${ACTUAL_STDERR}'")
+endif()

--- a/tests/stdio/stdin.txt
+++ b/tests/stdio/stdin.txt
@@ -1,0 +1,1 @@
+hello from stdin

--- a/tests/stdio/stdio-test.toit
+++ b/tests/stdio/stdio-test.toit
@@ -1,0 +1,12 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the lib/LICENSE file.
+
+import io
+
+main:
+  data := io.stdin.read-all
+  io.stdout.write "stdout:"
+  if data: io.stdout.write data
+  io.stderr.write "stderr:"
+  if data: io.stderr.write data


### PR DESCRIPTION
## Summary

Add non-closeable `io.stdin`, `io.stdout`, and `io.stderr` streams.

- `io.stdin` is an `io.Reader`; concurrent readers and containers share the platform input, and whichever read consumes the available data first wins
- `io.stdout` and `io.stderr` are `io.Writer`s that write directly to the platform descriptors, like `printf`, without going through the print service
- host stdin is read by a dedicated blocking thread, including on Windows, while primitives remain non-blocking
- host-package stdin and `io.stdin` can coexist and compete for the same descriptor
- ESP32 stdin uses ESP-IDF's configured primary console: UART or USB Serial/JTAG
- `io.stdin` and `uart.Port.console` share the UART driver and event queue when both are used

ESP32-S2 USB CDC is intentionally not implemented in this change. Accessing `io.stdin` with an unsupported primary console backend reports `UNSUPPORTED`; stdout and stderr remain available.

The companion QEMU console implementation is [toitlang/qemu#13](https://github.com/toitlang/qemu/pull/13).

## Testing

- full host SDK rebuild
- `toit analyze -Werror` on the new host and QEMU fixtures
- `ctest --test-dir build/host -R '^tests/stdio/' --output-on-failure`
  - standard stdin/stdout/stderr test
  - coexistence with `host.stdin`
- fresh `make -j4 esp32 esp32s3` firmware builds
- ESP32 UART QEMU tests for stdin/stdout/stderr and coexistence with `uart.Port.console`
- ESP32-S3 USB Serial/JTAG end-to-end QEMU test:

```text
STDIO-READY
STDOUT:usb-test
STDERR:usb-test
```

The USB Serial/JTAG test exercises ESP-IDF's interrupt-driven driver through the companion QEMU implementation. S2 USB CDC still requires manual/future implementation and testing.