### PR TITLE
tests: make serial container transfer explicit

### DIFF
--- a/tests/hw/esp-tester/mini-jag.toit
+++ b/tests/hw/esp-tester/mini-jag.toit
@@ -74,6 +74,7 @@ switch-console-baud-rate port/uart.Port:
   port.baud-rate = CONTROL-BAUD-RATE
   sync := port.in.read-string UART-BAUD-RATE-SYNC.size + 1
   if sync != "$UART-BAUD-RATE-SYNC\n": throw "BAUD-RATE-SYNC MISMATCH"
+  print UART-BAUD-RATE-SYNCED
 with-client [block]:
   network/net.Client? := null
   for i := 0; i < NETWORK-RETRIES; i++:

--- a/tests/hw/esp-tester/mini-jag.toit
+++ b/tests/hw/esp-tester/mini-jag.toit
@@ -72,6 +72,8 @@ switch-console-baud-rate port/uart.Port:
   if ack != "$UART-BAUD-RATE-ACK\n": throw "BAUD-RATE-ACK MISMATCH"
   sleep --ms=UART-BAUD-RATE-SWITCH-DELAY-MS
   port.baud-rate = CONTROL-BAUD-RATE
+  sync := port.in.read-string UART-BAUD-RATE-SYNC.size + 1
+  if sync != "$UART-BAUD-RATE-SYNC\n": throw "BAUD-RATE-SYNC MISMATCH"
 with-client [block]:
   network/net.Client? := null
   for i := 0; i < NETWORK-RETRIES; i++:
@@ -120,13 +122,15 @@ install-new-test reader/io.Reader:
   // receive buffer.
   writer := containers.ContainerImageWriter size
   written-size := 0
-  requested := 0
   while written-size < size:
-    // Keep two requested chunks outstanding while writing to flash.
-    while requested < size and requested - written-size < 2 * CHUNK-SIZE:
-      print CHUNK-REQUEST
-      requested += min CHUNK-SIZE (size - requested)
+    // The next request acknowledges the previous chunk and includes the
+    // expected offset, making a lost or duplicated request diagnosable.
+    print "$CHUNK-REQUEST$written-size"
     chunk-size := min CHUNK-SIZE (size - written-size)
+    offset := reader.little-endian.read-int32
+    announced-size := reader.little-endian.read-int32
+    if offset != written-size: throw "CHUNK OFFSET MISMATCH"
+    if announced-size != chunk-size: throw "CHUNK SIZE MISMATCH"
     data := reader.read-bytes chunk-size
     summer.add data
     writer.write data

--- a/tests/hw/esp-tester/shared.toit
+++ b/tests/hw/esp-tester/shared.toit
@@ -14,7 +14,10 @@ UART-INPUT-REQUEST ::= "UART-INPUT-REQUEST: "
 // acknowledge at the current rate and then switch the serial connection.
 UART-BAUD-RATE-REQUEST ::= "UART-BAUD-RATE-REQUEST: "
 UART-BAUD-RATE-ACK ::= "UART-BAUD-RATE-ACK"
+// At the new rate the host sends SYNC and the testee answers SYNCED, proving
+// that the serial connection works in both directions before either proceeds.
 UART-BAUD-RATE-SYNC ::= "UART-BAUD-RATE-SYNC"
+UART-BAUD-RATE-SYNCED ::= "UART-BAUD-RATE-SYNCED"
 UART-TRANSFER-ERROR ::= "UART TRANSFER ERROR"
 // Gives the host time to apply the requested rate before the device transmits
 // at that rate.
@@ -22,10 +25,12 @@ UART-BAUD-RATE-SWITCH-DELAY-MS ::= 50
 // Gives USB-UART adapters time to transmit at the old rate before the host
 // changes rate. This must be shorter than $UART-BAUD-RATE-SWITCH-DELAY-MS.
 UART-HOST-BAUD-RATE-SWITCH-DELAY-MS ::= 5
-// The host starts synchronization after mini-jag has switched to the new rate.
+// The host starts synchronization after the testee has switched to the new rate.
 UART-BAUD-RATE-SYNC-DELAY-MS ::= 60
-// Synchronization requests are repeated until mini-jag responds.
-UART-BAUD-RATE-SYNC-RETRY-MS ::= 20
+// Bounds the confirmation that both sides can communicate at the new rate.
+UART-BAUD-RATE-SYNC-TIMEOUT-MS ::= 1_000
+// Retry a synchronization marker that was sent before the testee had switched.
+UART-BAUD-RATE-SYNC-ATTEMPTS ::= 3
 
 // The asset that selects mini-jag's control transport.
 CONTROL-ASSET ::= "control"

--- a/tests/hw/esp-tester/shared.toit
+++ b/tests/hw/esp-tester/shared.toit
@@ -14,13 +14,18 @@ UART-INPUT-REQUEST ::= "UART-INPUT-REQUEST: "
 // acknowledge at the current rate and then switch the serial connection.
 UART-BAUD-RATE-REQUEST ::= "UART-BAUD-RATE-REQUEST: "
 UART-BAUD-RATE-ACK ::= "UART-BAUD-RATE-ACK"
+UART-BAUD-RATE-SYNC ::= "UART-BAUD-RATE-SYNC"
 UART-TRANSFER-ERROR ::= "UART TRANSFER ERROR"
 // Gives the host time to apply the requested rate before the device transmits
 // at that rate.
-UART-BAUD-RATE-SWITCH-DELAY-MS ::= 10
+UART-BAUD-RATE-SWITCH-DELAY-MS ::= 50
 // Gives USB-UART adapters time to transmit at the old rate before the host
 // changes rate. This must be shorter than $UART-BAUD-RATE-SWITCH-DELAY-MS.
 UART-HOST-BAUD-RATE-SWITCH-DELAY-MS ::= 5
+// The host starts synchronization after mini-jag has switched to the new rate.
+UART-BAUD-RATE-SYNC-DELAY-MS ::= 60
+// Synchronization requests are repeated until mini-jag responds.
+UART-BAUD-RATE-SYNC-RETRY-MS ::= 20
 
 // The asset that selects mini-jag's control transport.
 CONTROL-ASSET ::= "control"
@@ -32,9 +37,8 @@ CONTROL-BAUD-RATE ::= 921_600
 
 // The device pulls the container image in chunks of this size, requesting
 // each one with $CHUNK-REQUEST. The serial transport has no flow control,
-// so the device must never have more data in flight than it asked for. It
-// keeps two requested chunks outstanding so the wire stays busy while a chunk
-// is written to flash. Together they use half of the 4096-byte receive buffer,
-// leaving the other half as headroom.
+// so the device must never have more data in flight than it asked for. Only one
+// chunk is outstanding at a time because flash writes can prevent the UART ISR
+// from draining the FIFO promptly.
 CHUNK-SIZE ::= 1024
-CHUNK-REQUEST ::= "READY FOR CHUNK"
+CHUNK-REQUEST ::= "READY FOR CHUNK: "

--- a/tests/hw/esp-tester/tester.toit
+++ b/tests/hw/esp-tester/tester.toit
@@ -220,11 +220,16 @@ run-test invocation/cli.Invocation:
       if not already-installed or attempt == attempts - 1: throw error
       break
 
-class OutputLine:
-  payload/string
-  end-offset/int
+class LoggingReader extends io.Reader:
+  wrapped_/io.Reader
+  on-data_/Lambda
 
-  constructor .payload .end-offset:
+  constructor .wrapped_ .on-data_:
+
+  read_ -> ByteArray?:
+    data := wrapped_.read
+    if data: on-data_.call data
+    return data
 
 class TestDevice:
   static SNAPSHOT-NAME ::= "test.snap"
@@ -240,24 +245,15 @@ class TestDevice:
   read-task/Task? := null
   is-active/bool := false
   collected-output/string := ""
-  // Offset into $collected-output up to which UART input requests have
-  // been answered.
-  uart-input-handled_/int := 0
-  // Offset into $collected-output up to which UART baud-rate requests have
-  // been answered.
-  uart-baud-rate-handled_/int := 0
+  output-at-new-line_/bool := true
   // One offset per $CHUNK-REQUEST the device has printed. The install paces its
   // writes on these, so the device is never sent data it hasn't asked for.
   chunk-requests_/monitor.Channel := monitor.Channel 2
-  // Offset into $collected-output up to which chunk requests have been
-  // counted.
-  chunk-requests-handled_/int := 0
-  ready-latch/monitor.Latch := monitor.Latch
+  device-ready-latch/monitor.Latch := monitor.Latch
   installed-container/monitor.Latch := monitor.Latch
   running-container/monitor.Latch := monitor.Latch
   all-tests-done/monitor.Latch := monitor.Latch
   image-bytes-sent_/int := 0
-  baud-sync-task_/Task? := null
   ui/cli.Ui
   tmp-dir/string
 
@@ -271,11 +267,10 @@ class TestDevice:
 
   read-output_:
     try:
-      reader := port.in
-      at-new-line := true
-      while data/ByteArray? := reader.read:
+      reader := LoggingReader port.in (:: | data/ByteArray | record-output_ data)
+      while line/string? := read-output-line_ reader:
         if not is-active: continue
-        at-new-line = handle-output-chunk_ data at-new-line
+        dispatch-output-line_ reader line.trim
     finally:
       if port:
         port.close
@@ -285,110 +280,109 @@ class TestDevice:
       // the same host serial device.
       read-task = null
 
-  handle-output-chunk_ data/ByteArray at-new-line/bool -> bool:
+  record-output_ data/ByteArray:
+    if not is-active: return
     data-str := data.to-string-non-throwing
-    if at-new-line: data-str = "\n$data-str"
+    if output-at-new-line_: data-str = "\n$data-str"
     if data-str.ends-with "\n":
-      at-new-line = true
+      output-at-new-line_ = true
       data-str = data-str[.. data-str.size - 1]
     else:
-      at-new-line = false
+      output-at-new-line_ = false
 
     write-output_ data-str
     collected-output += data-str
-    handle-state-markers_
-    handle-uart-input-requests_ at-new-line
-    handle-baud-rate-requests_ at-new-line
-    handle-chunk-requests_ at-new-line
-    handle-decode-request_ at-new-line
-    return at-new-line
 
   write-output_ data/string:
     timestamp := Duration --us=(Time.monotonic-us - start-time-us)
     stdout-text := data.replace --all "\n" "\n$(%06d timestamp.in-ms)-$name: "
     pipe.stdout.out.write stdout-text
 
-  handle-state-markers_:
-    if collected-output.contains MINI-JAG-LISTENING:
-      set-latch_ ready-latch
-      stop-baud-sync_
-    set-latch-if-seen_ ALL-TESTS-DONE all-tests-done
-    if output-contains-line_ UART-TRANSFER-ERROR:
+  read-output-line_ reader/io.Reader -> string?:
+    newline-index := reader.index-of '\n'
+    if newline-index < 0:
+      remaining := reader.buffered-size
+      if remaining == 0: return null
+      return (reader.read-bytes remaining).to-string-non-throwing
+    data := reader.read-bytes newline-index
+    reader.skip 1
+    return data.to-string-non-throwing
+
+  dispatch-output-line_ reader/io.Reader line/string:
+    if line.contains MINI-JAG-LISTENING:
+      set-latch_ device-ready-latch
+      return
+    if line.starts-with ALL-TESTS-DONE:
+      set-latch_ all-tests-done
+      return
+    if line.starts-with UART-TRANSFER-ERROR:
       if not installed-container.has-value:
         installed-container.set --exception UART-TRANSFER-ERROR
-    set-latch-if-seen_ INSTALLED-CONTAINER installed-container
-    set-latch-if-seen_ RUNNING-CONTAINER running-container
+      return
+    if line.starts-with INSTALLED-CONTAINER:
+      set-latch_ installed-container
+      return
+    if line.starts-with RUNNING-CONTAINER:
+      set-latch_ running-container
+      return
+    if line.starts-with UART-INPUT-REQUEST:
+      payload := line[UART-INPUT-REQUEST.size..].trim
+      port.out.write "$payload\n" --flush
+      return
+    if line.starts-with UART-BAUD-RATE-REQUEST:
+      payload := line[UART-BAUD-RATE-REQUEST.size..].trim
+      handle-baud-rate-request_ reader payload
+      return
+    if line.starts-with CHUNK-REQUEST:
+      handle-chunk-request_ line[CHUNK-REQUEST.size..].trim
+      return
+    decode-index := line.index-of JAG-DECODE
+    if decode-index >= 0:
+      handle-decode-request_ line[decode-index + JAG-DECODE.size..].trim
 
-  set-latch-if-seen_ marker/string latch/monitor.Latch:
-    if output-contains-line_ marker: set-latch_ latch
-
-  output-contains-line_ marker/string -> bool:
-    return collected-output.contains "\n$marker"
-
-  handle-uart-input-requests_ at-new-line/bool:
-    // When the device prints a marker line, write the payload back to it over
-    // the serial connection.
-    while line/OutputLine? := next-output-line_ "\n$UART-INPUT-REQUEST" uart-input-handled_ at-new-line:
-      uart-input-handled_ = line.end-offset
-      port.out.write "$(line.payload)\n" --flush
-
-  handle-baud-rate-requests_ at-new-line/bool:
+  handle-baud-rate-request_ reader/io.Reader payload/string:
     // Acknowledge at the current rate before both sides switch to the
     // requested rate.
-    while line/OutputLine? := next-output-line_ "\n$UART-BAUD-RATE-REQUEST" uart-baud-rate-handled_ at-new-line:
-      rate := int.parse line.payload
-      uart-baud-rate-handled_ = line.end-offset
-      port.out.write "$UART-BAUD-RATE-ACK\n" --flush
-      // Some USB-UART adapters report an empty host queue before their
-      // hardware has emitted the final bytes at the old rate.
-      sleep --ms=UART-HOST-BAUD-RATE-SWITCH-DELAY-MS
-      port.baud-rate = rate
-      start-baud-sync_
+    rate := int.parse payload
+    port.out.write "$UART-BAUD-RATE-ACK\n" --flush
+    // Some USB-UART adapters report an empty host queue before their hardware
+    // has emitted the final bytes at the old rate.
+    sleep --ms=UART-HOST-BAUD-RATE-SWITCH-DELAY-MS
+    port.baud-rate = rate
+    // The testee switches later than the host. Send the synchronization marker
+    // only once both sides are expected to be listening at the new rate.
+    sleep --ms=UART-BAUD-RATE-SYNC-DELAY-MS
+    synced := false
+    attempts := 0
+    while not synced and attempts < UART-BAUD-RATE-SYNC-ATTEMPTS:
+      attempts++
+      port.out.write "$UART-BAUD-RATE-SYNC\n" --flush
+      error := catch:
+        with-timeout --ms=UART-BAUD-RATE-SYNC-TIMEOUT-MS:
+          while response/string? := read-output-line_ reader:
+            if response.trim == UART-BAUD-RATE-SYNCED:
+              synced = true
+              break
+            dispatch-output-line_ reader response.trim
+      if error and error != DEADLINE-EXCEEDED-ERROR: throw error
+    if not synced:
+      log "$name timed out synchronizing baud rate $rate"
+      throw SERIAL-CONTROL-TIMEOUT
 
-  start-baud-sync_:
-    baud-sync-task_ = task --background::
-      sleep --ms=UART-BAUD-RATE-SYNC-DELAY-MS
-      while not ready-latch.has-value:
-        port.out.write "$UART-BAUD-RATE-SYNC\n" --flush
-        sleep --ms=UART-BAUD-RATE-SYNC-RETRY-MS
+  handle-chunk-request_ payload/string:
+    // Publish the expected offset from the complete chunk request.
+    offset := int.parse payload
+    if not chunk-requests_.try-send offset:
+      installed-container.set --exception UART-TRANSFER-ERROR
 
-  stop-baud-sync_:
-    if not baud-sync-task_: return
-    baud-sync-task_.cancel
-    baud-sync-task_ = null
-
-  handle-chunk-requests_ at-new-line/bool:
-    // Publish the expected offset from each complete chunk request.
-    while line/OutputLine? := next-output-line_ "\n$CHUNK-REQUEST" chunk-requests-handled_ at-new-line:
-      offset := int.parse line.payload
-      chunk-requests-handled_ = line.end-offset
-      if not chunk-requests_.try-send offset:
-        installed-container.set --exception UART-TRANSFER-ERROR
-
-  handle-decode-request_ at-new-line/bool:
-    if not collected-output.contains JAG-DECODE: return
+  handle-decode-request_ payload/string:
     if not file.is-file "$tmp-dir/$SNAPSHOT-NAME":
       // Without a snapshot this is probably an error during setup.
       all-tests-done.set --exception "Error detected"
       return
-    line := next-output-line_ JAG-DECODE 0 at-new-line --require-newline
-    if not line: return  // Wait for the rest of the line.
     snapshot-path := "$tmp-dir/$SNAPSHOT-NAME"
-    toit_ ["decode", "-s", snapshot-path, line.payload]
+    toit_ ["decode", "-s", snapshot-path, payload]
     all-tests-done.set --exception "Error detected"
-
-  next-output-line_ marker/string offset/int at-new-line/bool --require-newline/bool=false -> OutputLine?:
-    marker-index := collected-output.index-of marker offset
-    if marker-index < 0: return null
-    payload-start := marker-index + marker.size
-    line-end := collected-output.index-of "\n" payload-start
-    if line-end < 0:
-      // The trailing newline of a chunk is stripped and only added back with
-      // the next chunk, so a completed chunk means a completed line.
-      if require-newline or not at-new-line: return null
-      line-end = collected-output.size
-    payload := collected-output[payload-start..line-end].trim
-    return OutputLine payload line-end
 
   set-latch_ latch/monitor.Latch:
     if latch.has-value: return
@@ -417,7 +411,6 @@ class TestDevice:
     if error: throw error
 
   close:
-    stop-baud-sync_
     if read-task:
       read-task.cancel
       // Task.cancel is asynchronous.  Wait for the reader's finally block to
@@ -443,7 +436,7 @@ class TestDevice:
     port.set-control-flag uart.HostPort.CONTROL-FLAG-RTS false
 
     ui.emit --verbose "Waiting for $name to be ready."
-    wait-for-control_ "device readiness" DEVICE-READY-TIMEOUT-MS: ready-latch.get
+    wait-for-control_ "device readiness" DEVICE-READY-TIMEOUT-MS: device-ready-latch.get
     ui.emit --verbose "Device $name is ready."
 
     if not use-network: return

--- a/tests/hw/esp-tester/tester.toit
+++ b/tests/hw/esp-tester/tester.toit
@@ -245,6 +245,9 @@ class TestDevice:
   read-task/Task? := null
   is-active/bool := false
   collected-output/string := ""
+  // Consecutive UART chunks may belong to the same output line. Avoid adding
+  // another timestamp when continuing such a line. This assumes that nothing
+  // else writes to stdout between chunks of a partial UART line.
   output-at-new-line_/bool := true
   // One offset per $CHUNK-REQUEST the device has printed. The install paces its
   // writes on these, so the device is never sent data it hasn't asked for.
@@ -299,6 +302,9 @@ class TestDevice:
     pipe.stdout.out.write stdout-text
 
   read-output-line_ reader/io.Reader -> string?:
+    // $io.Reader.read-line decodes strict UTF-8, but bytes corrupted around a
+    // baud-rate transition must be treated as garbage rather than terminating
+    // the output reader. Split on the byte delimiter and decode non-throwing.
     newline-index := reader.index-of '\n'
     if newline-index < 0:
       remaining := reader.buffered-size
@@ -357,14 +363,13 @@ class TestDevice:
     while not synced and attempts < UART-BAUD-RATE-SYNC-ATTEMPTS:
       attempts++
       port.out.write "$UART-BAUD-RATE-SYNC\n" --flush
-      error := catch:
+      catch --unwind=(: it != DEADLINE-EXCEEDED-ERROR):
         with-timeout --ms=UART-BAUD-RATE-SYNC-TIMEOUT-MS:
           while response/string? := read-output-line_ reader:
             if response.trim == UART-BAUD-RATE-SYNCED:
               synced = true
               break
             dispatch-output-line_ reader response.trim
-      if error and error != DEADLINE-EXCEEDED-ERROR: throw error
     if not synced:
       log "$name timed out synchronizing baud rate $rate"
       throw SERIAL-CONTROL-TIMEOUT

--- a/tests/hw/esp-tester/tester.toit
+++ b/tests/hw/esp-tester/tester.toit
@@ -220,6 +220,12 @@ run-test invocation/cli.Invocation:
       if not already-installed or attempt == attempts - 1: throw error
       break
 
+class OutputLine:
+  payload/string
+  end-offset/int
+
+  constructor .payload .end-offset:
+
 class TestDevice:
   static SNAPSHOT-NAME ::= "test.snap"
   name/string
@@ -261,91 +267,118 @@ class TestDevice:
   constructor --.name --.toit-exe --port-path/string --.ui --.already-installed --.use-network:
     port = uart.HostPort port-path --baud-rate=CONSOLE-BAUD-RATE
     tmp-dir = directory.mkdtemp "/tmp/esp-tester"
-    read-task = task --background::
-      try:
-        reader := port.in
-        stdout := pipe.stdout
-        at-new-line := true
-        while data/ByteArray? := reader.read:
-          if not is-active: continue
-          data-str := data.to-string-non-throwing
-          if at-new-line: data-str = "\n$data-str"
-          if data-str.ends-with "\n":
-            at-new-line = true
-            data-str = data-str[.. data-str.size - 1]
-          else:
-            at-new-line = false
-          timestamp := Duration --us=(Time.monotonic-us - start-time-us)
-          stdout-text := data-str.replace --all "\n" "\n$(%06d timestamp.in-ms)-$name: "
-          stdout.out.write stdout-text
-          collected-output += data-str
-          if collected-output.contains "\n$MINI-JAG-LISTENING": set-latch_ ready-latch
-          if collected-output.contains "\n$ALL-TESTS-DONE": set-latch_ all-tests-done
-          if collected-output.contains "\n$UART-TRANSFER-ERROR":
-            if not installed-container.has-value:
-              installed-container.set --exception UART-TRANSFER-ERROR
-          if collected-output.contains "\n$INSTALLED-CONTAINER": set-latch_ installed-container
-          if collected-output.contains "\n$RUNNING-CONTAINER": set-latch_ running-container
-          // Serve UART input requests: when the device prints a marker line,
-          // write the payload back to it over the serial connection.
-          while true:
-            request-index := collected-output.index-of "\n$UART-INPUT-REQUEST" uart-input-handled_
-            if request-index < 0: break
-            payload-start := request-index + 1 + UART-INPUT-REQUEST.size
-            request-end := collected-output.index-of "\n" payload-start
-            if request-end < 0:
-              // The trailing newline of a chunk is stripped and only added
-              // back with the next chunk, so a completed chunk means a
-              // completed line.
-              if not at-new-line: break  // Wait for the rest of the line.
-              request-end = collected-output.size
-            payload := collected-output[payload-start..request-end].trim
-            uart-input-handled_ = request-end
-            port.out.write "$payload\n" --flush
-          // Acknowledge baud-rate requests at the current rate before both
-          // sides switch to the requested rate.
-          while true:
-            request-index := collected-output.index-of "\n$UART-BAUD-RATE-REQUEST" uart-baud-rate-handled_
-            if request-index < 0: break
-            rate-start := request-index + 1 + UART-BAUD-RATE-REQUEST.size
-            request-end := collected-output.index-of "\n" rate-start
-            if request-end < 0:
-              if not at-new-line: break  // Wait for the rest of the line.
-              request-end = collected-output.size
-            rate := int.parse collected-output[rate-start..request-end].trim
-            uart-baud-rate-handled_ = request-end
-            port.out.write "$UART-BAUD-RATE-ACK\n" --flush
-            // Some USB-UART adapters report an empty host queue before their
-            // hardware has emitted the final bytes at the old rate.
-            sleep --ms=UART-HOST-BAUD-RATE-SWITCH-DELAY-MS
-            port.baud-rate = rate
-          // Grant one send permit per chunk request.
-          while true:
-            request-index := collected-output.index-of "\n$CHUNK-REQUEST" chunk-requests-handled_
-            if request-index < 0: break
-            chunk-requests-handled_ = request-index + 1 + CHUNK-REQUEST.size
-            chunk-requests_.up
-          if collected-output.contains JAG-DECODE:
-            if file.is-file "$tmp-dir/$SNAPSHOT-NAME":
-              // Otherwise it's probably an error during setup.
-              index := collected-output.index-of JAG-DECODE
-              new-line := collected-output.index-of "\n" index
-              if new-line < 0:
-                // Wait for more data.
-                continue
-              line := collected-output[index + JAG-DECODE.size..new-line].trim
-              snapshot-path := "$tmp-dir/$SNAPSHOT-NAME"
-              toit_ ["decode", "-s", snapshot-path, line]
-            all-tests-done.set --exception "Error detected"
+    read-task = task --background:: read-output_
 
-      finally:
-        if port:
-          port.close
-          port = null
-        // Publish termination only after the port has been released.  A UART
-        // transfer retry may otherwise race with this cleanup when reopening
-        // the same host serial device.
-        read-task = null
+  read-output_:
+    try:
+      reader := port.in
+      at-new-line := true
+      while data/ByteArray? := reader.read:
+        if not is-active: continue
+        at-new-line = handle-output-chunk_ data at-new-line
+    finally:
+      if port:
+        port.close
+        port = null
+      // Publish termination only after the port has been released.  A UART
+      // transfer retry may otherwise race with this cleanup when reopening
+      // the same host serial device.
+      read-task = null
+
+  handle-output-chunk_ data/ByteArray at-new-line/bool -> bool:
+    data-str := data.to-string-non-throwing
+    if at-new-line: data-str = "\n$data-str"
+    if data-str.ends-with "\n":
+      at-new-line = true
+      data-str = data-str[.. data-str.size - 1]
+    else:
+      at-new-line = false
+
+    write-output_ data-str
+    collected-output += data-str
+    handle-state-markers_
+    handle-uart-input-requests_ at-new-line
+    handle-baud-rate-requests_ at-new-line
+    handle-chunk-requests_
+    handle-decode-request_ at-new-line
+    return at-new-line
+
+  write-output_ data/string:
+    timestamp := Duration --us=(Time.monotonic-us - start-time-us)
+    stdout-text := data.replace --all "\n" "\n$(%06d timestamp.in-ms)-$name: "
+    pipe.stdout.out.write stdout-text
+
+  handle-state-markers_:
+    set-latch-if-seen_ MINI-JAG-LISTENING ready-latch
+    set-latch-if-seen_ ALL-TESTS-DONE all-tests-done
+    if output-contains-line_ UART-TRANSFER-ERROR:
+      if not installed-container.has-value:
+        installed-container.set --exception UART-TRANSFER-ERROR
+    set-latch-if-seen_ INSTALLED-CONTAINER installed-container
+    set-latch-if-seen_ RUNNING-CONTAINER running-container
+
+  set-latch-if-seen_ marker/string latch/monitor.Latch:
+    if output-contains-line_ marker: set-latch_ latch
+
+  output-contains-line_ marker/string -> bool:
+    return collected-output.contains "\n$marker"
+
+  handle-uart-input-requests_ at-new-line/bool:
+    // When the device prints a marker line, write the payload back to it over
+    // the serial connection.
+    while line/OutputLine? := next-output-line_ "\n$UART-INPUT-REQUEST" uart-input-handled_ at-new-line:
+      uart-input-handled_ = line.end-offset
+      port.out.write "$(line.payload)\n" --flush
+
+  handle-baud-rate-requests_ at-new-line/bool:
+    // Acknowledge at the current rate before both sides switch to the
+    // requested rate.
+    while line/OutputLine? := next-output-line_ "\n$UART-BAUD-RATE-REQUEST" uart-baud-rate-handled_ at-new-line:
+      rate := int.parse line.payload
+      uart-baud-rate-handled_ = line.end-offset
+      port.out.write "$UART-BAUD-RATE-ACK\n" --flush
+      // Some USB-UART adapters report an empty host queue before their
+      // hardware has emitted the final bytes at the old rate.
+      sleep --ms=UART-HOST-BAUD-RATE-SWITCH-DELAY-MS
+      port.baud-rate = rate
+
+  handle-chunk-requests_:
+    // Grant one send permit per chunk request.
+    while true:
+      next-offset := next-output-marker_ "\n$CHUNK-REQUEST" chunk-requests-handled_
+      if next-offset < 0: break
+      chunk-requests-handled_ = next-offset
+      chunk-requests_.up
+
+  handle-decode-request_ at-new-line/bool:
+    if not collected-output.contains JAG-DECODE: return
+    if not file.is-file "$tmp-dir/$SNAPSHOT-NAME":
+      // Without a snapshot this is probably an error during setup.
+      all-tests-done.set --exception "Error detected"
+      return
+    line := next-output-line_ JAG-DECODE 0 at-new-line --require-newline
+    if not line: return  // Wait for the rest of the line.
+    snapshot-path := "$tmp-dir/$SNAPSHOT-NAME"
+    toit_ ["decode", "-s", snapshot-path, line.payload]
+    all-tests-done.set --exception "Error detected"
+
+  next-output-line_ marker/string offset/int at-new-line/bool --require-newline/bool=false -> OutputLine?:
+    marker-index := collected-output.index-of marker offset
+    if marker-index < 0: return null
+    payload-start := marker-index + marker.size
+    line-end := collected-output.index-of "\n" payload-start
+    if line-end < 0:
+      // The trailing newline of a chunk is stripped and only added back with
+      // the next chunk, so a completed chunk means a completed line.
+      if require-newline or not at-new-line: return null
+      line-end = collected-output.size
+    payload := collected-output[payload-start..line-end].trim
+    return OutputLine payload line-end
+
+  next-output-marker_ marker/string offset/int -> int:
+    marker-index := collected-output.index-of marker offset
+    if marker-index < 0: return -1
+    return marker-index + marker.size
 
   set-latch_ latch/monitor.Latch:
     if latch.has-value: return

--- a/tests/hw/esp-tester/tester.toit
+++ b/tests/hw/esp-tester/tester.toit
@@ -246,10 +246,9 @@ class TestDevice:
   // Offset into $collected-output up to which UART baud-rate requests have
   // been answered.
   uart-baud-rate-handled_/int := 0
-  // One permit per $CHUNK-REQUEST the device has printed. The install
-  // paces its writes on these, so the device is never sent data it
-  // hasn't asked for (the serial transport has no flow control).
-  chunk-requests_/monitor.Semaphore := monitor.Semaphore
+  // One offset per $CHUNK-REQUEST the device has printed. The install paces its
+  // writes on these, so the device is never sent data it hasn't asked for.
+  chunk-requests_/monitor.Channel := monitor.Channel 2
   // Offset into $collected-output up to which chunk requests have been
   // counted.
   chunk-requests-handled_/int := 0
@@ -258,6 +257,7 @@ class TestDevice:
   running-container/monitor.Latch := monitor.Latch
   all-tests-done/monitor.Latch := monitor.Latch
   image-bytes-sent_/int := 0
+  baud-sync-task_/Task? := null
   ui/cli.Ui
   tmp-dir/string
 
@@ -299,7 +299,7 @@ class TestDevice:
     handle-state-markers_
     handle-uart-input-requests_ at-new-line
     handle-baud-rate-requests_ at-new-line
-    handle-chunk-requests_
+    handle-chunk-requests_ at-new-line
     handle-decode-request_ at-new-line
     return at-new-line
 
@@ -309,7 +309,9 @@ class TestDevice:
     pipe.stdout.out.write stdout-text
 
   handle-state-markers_:
-    set-latch-if-seen_ MINI-JAG-LISTENING ready-latch
+    if collected-output.contains MINI-JAG-LISTENING:
+      set-latch_ ready-latch
+      stop-baud-sync_
     set-latch-if-seen_ ALL-TESTS-DONE all-tests-done
     if output-contains-line_ UART-TRANSFER-ERROR:
       if not installed-container.has-value:
@@ -341,14 +343,27 @@ class TestDevice:
       // hardware has emitted the final bytes at the old rate.
       sleep --ms=UART-HOST-BAUD-RATE-SWITCH-DELAY-MS
       port.baud-rate = rate
+      start-baud-sync_
 
-  handle-chunk-requests_:
-    // Grant one send permit per chunk request.
-    while true:
-      next-offset := next-output-marker_ "\n$CHUNK-REQUEST" chunk-requests-handled_
-      if next-offset < 0: break
-      chunk-requests-handled_ = next-offset
-      chunk-requests_.up
+  start-baud-sync_:
+    baud-sync-task_ = task --background::
+      sleep --ms=UART-BAUD-RATE-SYNC-DELAY-MS
+      while not ready-latch.has-value:
+        port.out.write "$UART-BAUD-RATE-SYNC\n" --flush
+        sleep --ms=UART-BAUD-RATE-SYNC-RETRY-MS
+
+  stop-baud-sync_:
+    if not baud-sync-task_: return
+    baud-sync-task_.cancel
+    baud-sync-task_ = null
+
+  handle-chunk-requests_ at-new-line/bool:
+    // Publish the expected offset from each complete chunk request.
+    while line/OutputLine? := next-output-line_ "\n$CHUNK-REQUEST" chunk-requests-handled_ at-new-line:
+      offset := int.parse line.payload
+      chunk-requests-handled_ = line.end-offset
+      if not chunk-requests_.try-send offset:
+        installed-container.set --exception UART-TRANSFER-ERROR
 
   handle-decode-request_ at-new-line/bool:
     if not collected-output.contains JAG-DECODE: return
@@ -374,11 +389,6 @@ class TestDevice:
       line-end = collected-output.size
     payload := collected-output[payload-start..line-end].trim
     return OutputLine payload line-end
-
-  next-output-marker_ marker/string offset/int -> int:
-    marker-index := collected-output.index-of marker offset
-    if marker-index < 0: return -1
-    return marker-index + marker.size
 
   set-latch_ latch/monitor.Latch:
     if latch.has-value: return
@@ -407,6 +417,7 @@ class TestDevice:
     if error: throw error
 
   close:
+    stop-baud-sync_
     if read-task:
       read-task.cancel
       // Task.cancel is asynchronous.  Wait for the reader's finally block to
@@ -515,8 +526,14 @@ class TestDevice:
     while sent < image.size:
       chunk-end := min (sent + CHUNK-SIZE) image.size
       wait-for-control_ "container chunk at offset $sent" CONTAINER-CHUNK-TIMEOUT-MS:
-        chunk-requests_.down
+        requested-offset/int := chunk-requests_.receive
+        if requested-offset != sent:
+          log "$name requested chunk $requested-offset while host expected $sent"
+          throw UART-TRANSFER-ERROR
+        out.little-endian.write-int32 sent
+        out.little-endian.write-int32 chunk-end - sent
         out.write image[sent..chunk-end]
+        out.flush
       sent = chunk-end
       image-bytes-sent_ = sent
 

--- a/tests/hw/esp32/uart-console-test.toit
+++ b/tests/hw/esp32/uart-console-test.toit
@@ -17,6 +17,8 @@ import uart
 
 import ..esp-tester.shared show UART-BAUD-RATE-ACK
                                 UART-BAUD-RATE-REQUEST
+                                UART-BAUD-RATE-SYNC
+                                UART-BAUD-RATE-SYNCED
                                 UART-BAUD-RATE-SWITCH-DELAY-MS
                                 UART-INPUT-REQUEST
 import .test
@@ -49,6 +51,8 @@ change-baud-rate port/uart.Port rate/int:
   expect-baud rate port.baud-rate
   // Give the tester a short scheduling margin to apply the new rate.
   sleep --ms=UART-BAUD-RATE-SWITCH-DELAY-MS
+  expect-input port "$UART-BAUD-RATE-SYNC\n"
+  port.out.write "$UART-BAUD-RATE-SYNCED\n" --flush
 
 main:
   run-test: test


### PR DESCRIPTION
## Summary

- replace the one-shot high-baud ready marker with an explicit repeated sync exchange
- recognize the complete unique ready marker without depending on preceding newline framing
- allow one outstanding 1 KiB chunk at a time
- include and validate offset and size in each chunk exchange, making lost or duplicated transfers diagnosable

## Validation

- both ESP32-S3 setup fixtures flashed and synchronized successfully in parallel
- ESP32-S3 RMT transfer stress passed 10/10 repetitions
- two-board ESP32-S3 `wait-for1` passed with simultaneous container transfers
- Toit analysis and `git diff --check` passed

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
