### PR TITLE
tests: diagnose stalled hardware operations

### DIFF
--- a/tests/hw/esp32/i2s-shared.toit
+++ b/tests/hw/esp32/i2s-shared.toit
@@ -121,6 +121,8 @@ test args/List
     // The mclk has a multiplier of MCLK-MULTIPLIER which is based on the sample-rate.
     mclk-frequency = sample-rate * MCLK-MULTIPLIER
 
+  details := "arg=$arg board=$(board1 ? 1 : 2) master=$master writer=$is-writer"
+
   // Writers never fail. It's the reader that has to confirm that the test succeeded.
   // The only exception is the fast test, where we look at the error count.
   run-test --background=(is-writer and not is-fast-test):
@@ -155,12 +157,13 @@ test args/List
           preloaded := generator.do: channel.preload it
           if preloaded == 0: break
 
-      channel.start
+      with-i2s-progress-timeout "output start" details: channel.start
 
       printed-done := false
       while true:
         expect-equals 0 channel.errors
-        generator.do: channel.write it
+        with-i2s-progress-timeout "output write" details:
+          generator.do: channel.write it
 
         if is-fast-test:
           // We need to stop the test ourselves, since we are not background.
@@ -187,7 +190,7 @@ test args/List
           --mclk-external-frequency=use-mclk ? mclk-frequency : null
           --slots=stereo-in
 
-      channel.start
+      with-i2s-progress-timeout "input start" details: channel.start
 
       required-size := is-fast-test
           ? FAST-DATA-SIZE
@@ -197,19 +200,21 @@ test args/List
       all-read := 0
       last-channel-errors := 0
       while true:
-        chunk/ByteArray := ?
-        if is-fast-test:
-          chunk-size := channel.read in-buffer
-          chunk = in-buffer[..chunk-size]
-        else:
-          chunk = channel.read
+        chunk/ByteArray? := null
+        with-i2s-progress-timeout "input read" details:
+          if is-fast-test:
+            chunk-size := channel.read in-buffer
+            chunk = in-buffer[..chunk-size]
+          else:
+            chunk = channel.read
         current-errors := channel.errors
         if current-errors != last-channel-errors:
           print "Errors: $current-errors"
           last-channel-errors = current-errors
           generator.increment-error
-        all-read += chunk.size
-        generator.verify chunk
+        read-chunk := chunk as ByteArray
+        all-read += read-chunk.size
+        generator.verify read-chunk
         if generator.verified > required-size:
           // Don't stop consuming.
           if not printed-done:

--- a/tests/hw/esp32/i2s-test.toit
+++ b/tests/hw/esp32/i2s-test.toit
@@ -54,28 +54,32 @@ test
   out-started := monitor.Latch
 
   done := false
+  details := "bits=$bits-per-sample start-in-first=$start-in-first preload=$preload"
   task::
     if not start-in-first: out-started.get
-    in.start
+    with-i2s-progress-timeout "input start" details: in.start
     in-started.set true
     while true:
-      chunk := in.read
+      chunk/ByteArray? := null
+      with-i2s-progress-timeout "input read" details: chunk = in.read
       if in.errors != 0: print "Errors: $in.errors"
-      generator.verify chunk
+      generator.verify chunk as ByteArray
       if generator.verified > 10 * 1024:
         done = true
         break
     expect-equals 0 in.errors
 
   if start-in-first: in-started.get
-  if in != out: out.start
+  if in != out:
+    with-i2s-progress-timeout "output start" details: out.start
   out-started.set true
 
   while not done:
     if out.errors != 0:
       print "Out errors: $out.errors"
       break
-    written := generator.do: out.write it
+    with-i2s-progress-timeout "output write" details:
+      generator.do: out.write it
   print "Wrote $generator.written in total"
   expect-equals 0 out.errors
 

--- a/tests/hw/esp32/i2s-utils.toit
+++ b/tests/hw/esp32/i2s-utils.toit
@@ -11,12 +11,11 @@ I2S-PROGRESS-TIMEOUT-MS ::= 10_000
 I2S-PROGRESS-TIMEOUT ::= "I2S_PROGRESS_TIMEOUT"
 
 with-i2s-progress-timeout operation/string details/string [block]:
-  error := catch:
+  error := catch --unwind=(: it != DEADLINE-EXCEEDED-ERROR):
     with-timeout --ms=I2S-PROGRESS-TIMEOUT-MS: block.call
-  if error == DEADLINE-EXCEEDED-ERROR:
+  if error:
     print "I2S $operation made no progress for $(I2S-PROGRESS-TIMEOUT-MS)ms: $details"
     throw I2S-PROGRESS-TIMEOUT
-  if error: throw error
 
 interface DataGenerator:
   do [block] -> int

--- a/tests/hw/esp32/i2s-utils.toit
+++ b/tests/hw/esp32/i2s-utils.toit
@@ -7,6 +7,17 @@ import expect show *
 import i2s
 import system
 
+I2S-PROGRESS-TIMEOUT-MS ::= 10_000
+I2S-PROGRESS-TIMEOUT ::= "I2S_PROGRESS_TIMEOUT"
+
+with-i2s-progress-timeout operation/string details/string [block]:
+  error := catch:
+    with-timeout --ms=I2S-PROGRESS-TIMEOUT-MS: block.call
+  if error == DEADLINE-EXCEEDED-ERROR:
+    print "I2S $operation made no progress for $(I2S-PROGRESS-TIMEOUT-MS)ms: $details"
+    throw I2S-PROGRESS-TIMEOUT
+  if error: throw error
+
 interface DataGenerator:
   do [block] -> int
   verify chunk/ByteArray

--- a/tests/hw/esp32/ultrasound-board2.toit
+++ b/tests/hw/esp32/ultrasound-board2.toit
@@ -19,10 +19,12 @@ test:
   // Give the sensor time to settle.
   sleep --ms=200
 
-  5.repeat:
+  5.repeat: | measurement |
     distance := driver.read-distance
-    print distance
+    print "Ultrasound measurement $measurement: $distance mm"
     // Requires the board to be pointing towards a wall with at most 1m distance.
-    expect-not-null distance
+    if not distance:
+      print "No echo on pin $(Variant.CURRENT.board2-hc-sr04-echo-pin) after triggering pin $(Variant.CURRENT.board2-hc-sr04-trigger-pin)"
+      throw "ULTRASOUND_NO_ECHO"
     expect 0 < distance < 1000
     sleep --ms=200

--- a/tests/hw/esp32/wait-for1-board1.toit
+++ b/tests/hw/esp32/wait-for1-board1.toit
@@ -23,15 +23,16 @@ test:
   pin-in := gpio.Pin PIN-IN1 --input --pull-down
   pin-out := gpio.Pin PIN-OUT1 --output
 
-  ITERATIONS.repeat: | counter |
-    if counter % 1000 == 0: print "Iteration: $counter"
-    for i := 0; i < (counter % 200); i++:
-      null
-    // In this mode the pin stays high as long as we don't get any response.
-    pin-out.set 1
-    while pin-in.get != 1: null
-    pin-out.set 0
-    while pin-in.get != 0: null
+  with-peer-progress-timeout "initial $(ITERATIONS)-iteration handshake" 60_000:
+    ITERATIONS.repeat: | counter |
+      if counter % 1000 == 0: print "Iteration: $counter"
+      for i := 0; i < (counter % 200); i++:
+        null
+      // In this mode the pin stays high as long as we don't get any response.
+      pin-out.set 1
+      while pin-in.get != 1: null
+      pin-out.set 0
+      while pin-in.get != 0: null
 
   sleep --ms=500
 
@@ -42,9 +43,11 @@ test:
     sleep --ms=MEDIUM-PULSE-DURATION-MS
     pin-out.set 0
   print "medium pulses done"
-  pin-in.wait-for 1
+  with-peer-progress-timeout "medium-pulse acknowledgement high" 10_000:
+    pin-in.wait-for 1
 
-  pin-in.wait-for 0
+  with-peer-progress-timeout "medium-pulse acknowledgement low" 10_000:
+    pin-in.wait-for 0
   print "sending short pulses"
   sleep --ms=300
   SHORT-PULSE-ITERATIONS.repeat:
@@ -53,7 +56,8 @@ test:
     pin-out.set 0
 
   print "short pulses done"
-  pin-in.wait-for 1
+  with-peer-progress-timeout "short-pulse acknowledgement" 10_000:
+    pin-in.wait-for 1
 
   print "sending ultra short pulses"
 

--- a/tests/hw/esp32/wait-for1-board2.toit
+++ b/tests/hw/esp32/wait-for1-board2.toit
@@ -23,7 +23,7 @@ test:
   ITERATIONS.repeat: | iteration |
     if iteration % 1000 == 0: print "Iteration: $iteration"
     before := pin-in.get
-    exception := catch: with-timeout --ms=2_000:
+    exception := catch: with-peer-progress-timeout "initial handshake iteration $iteration" 2_000:
       pin-in.wait-for 1
     if exception:
       print "Iteration: $iteration"
@@ -35,7 +35,7 @@ test:
     pin-out.set 0
 
   print "Looking for medium pulses"
-  with-timeout --ms=(500 + 300 * MEDIUM-PULSE-ITERATIONS):
+  with-peer-progress-timeout "receiving medium pulses" (500 + 300 * MEDIUM-PULSE-ITERATIONS):
     MEDIUM-PULSE-ITERATIONS.repeat: | iteration |
       pin-in.wait-for 1
       pin-in.wait-for 0
@@ -45,7 +45,7 @@ test:
 
   print "Looking for short pulses"
   pin-out.set 0
-  with-timeout --ms=(500 + 300 * SHORT-PULSE-ITERATIONS):
+  with-peer-progress-timeout "receiving short pulses" (500 + 300 * SHORT-PULSE-ITERATIONS):
     SHORT-PULSE-ITERATIONS.repeat:
       pin-in.wait-for 1
       pin-in.wait-for 0
@@ -58,7 +58,7 @@ test:
   count := 0
   pin-out.set 0
   exception := catch:
-    with-timeout --ms=(500 + 30 * ULTRA-SHORT-PULSE-ITERATIONS):
+    with-peer-progress-timeout "receiving ultra-short pulses" (500 + 30 * ULTRA-SHORT-PULSE-ITERATIONS):
       ULTRA-SHORT-PULSE-ITERATIONS.repeat:
         pin-in.wait-for 1
         pin-in.wait-for 0

--- a/tests/hw/esp32/wait-for1-shared.toit
+++ b/tests/hw/esp32/wait-for1-shared.toit
@@ -10,6 +10,7 @@ Once that one is running, run `wait-for-board2.toit` on board2.
 */
 
 import gpio
+import system
 
 import .variants
 
@@ -22,3 +23,13 @@ ITERATIONS ::= 10_000
 MEDIUM-PULSE-ITERATIONS ::= 50
 SHORT-PULSE-ITERATIONS ::= 50
 ULTRA-SHORT-PULSE-ITERATIONS ::= 50
+
+WAIT-FOR-PROGRESS-TIMEOUT ::= "WAIT_FOR_PROGRESS_TIMEOUT"
+
+with-peer-progress-timeout phase/string timeout-ms/int [block]:
+  error := catch:
+    with-timeout --ms=timeout-ms: block.call
+  if error == DEADLINE-EXCEEDED-ERROR:
+    print "Peer GPIO made no progress during '$phase' for $(timeout-ms)ms; pins board1-in=$PIN-IN1 board1-out=$PIN-OUT1 board2-in=$PIN-IN2 board2-out=$PIN-OUT2"
+    throw WAIT-FOR-PROGRESS-TIMEOUT
+  if error: throw error

--- a/tests/hw/esp32/wait-for1-shared.toit
+++ b/tests/hw/esp32/wait-for1-shared.toit
@@ -27,9 +27,8 @@ ULTRA-SHORT-PULSE-ITERATIONS ::= 50
 WAIT-FOR-PROGRESS-TIMEOUT ::= "WAIT_FOR_PROGRESS_TIMEOUT"
 
 with-peer-progress-timeout phase/string timeout-ms/int [block]:
-  error := catch:
+  error := catch --unwind=(: it != DEADLINE-EXCEEDED-ERROR):
     with-timeout --ms=timeout-ms: block.call
-  if error == DEADLINE-EXCEEDED-ERROR:
+  if error:
     print "Peer GPIO made no progress during '$phase' for $(timeout-ms)ms; pins board1-in=$PIN-IN1 board1-out=$PIN-OUT1 board2-in=$PIN-IN2 board2-out=$PIN-OUT2"
     throw WAIT-FOR-PROGRESS-TIMEOUT
-  if error: throw error

--- a/tests/hw/esp32/wifi1-shared.toit
+++ b/tests/hw/esp32/wifi1-shared.toit
@@ -29,7 +29,8 @@ SSID ::= "test-wifi-scan"
 PORT ::= 7017
 
 MAX-RETRIES ::= 4
-RETRY-WAIT ::= 300
+RETRY-WAIT ::= 500
+AP-SETTLE-TIME-MS ::= 500
 
 // TODO(florian): don't use hardcoded IP.
 SOFTAP-ADDRESS ::= "200.200.200.1"
@@ -63,6 +64,14 @@ main-board1:
 contains-ssid access-points/List ssid/string:
   return access-points.any: | ap/wifi.AccessPoint | ap.ssid == ssid
 
+describe-test-access-points access-points/List -> string:
+  test-access-points := access-points.filter: | ap/wifi.AccessPoint |
+    ap.ssid.starts-with SSID
+  if test-access-points.is-empty: return "none"
+  return (test-access-points.map: | ap/wifi.AccessPoint |
+    "$(ap.ssid) channel=$(ap.channel) rssi=$(ap.rssi)"
+  ).join ", "
+
 test-board1:
   port := uart.Port --tx=TX1 --rx=RX1 --baud-rate=BAUD-RATE
   CONFIGS-TO-TEST.do: | config/Config |
@@ -71,6 +80,7 @@ test-board1:
 
     for i := 0; i < MAX-RETRIES; i++:
       scanned := wifi.scan #[config.channel]
+      print "Scan $(i + 1)/$MAX-RETRIES for $(config.ssid) on channel $(config.channel): $(describe-test-access-points scanned)"
       if i < MAX-RETRIES - 1 and not contains-ssid scanned config.ssid:
         print "Waiting for WiFi access point $config.ssid"
         sleep --ms=RETRY-WAIT
@@ -78,6 +88,7 @@ test-board1:
       expect (contains-ssid scanned config.ssid)
       other-channel := config.channel == 1 ? 5 : 1
       scanned = wifi.scan #[other-channel]
+      print "Opposite-channel scan on $other-channel: $(describe-test-access-points scanned)"
       expect-not (contains-ssid scanned config.ssid)
 
     // Connect to the other board.
@@ -109,6 +120,8 @@ test-board2:
         --channel=config.channel
     print "established"
     server-socket := network-ap.tcp-listen PORT
+    // Give the AP time to emit beacons before asking the other board to scan.
+    sleep --ms=AP-SETTLE-TIME-MS
     port.out.write "x" --flush  // Ready to receive.
     socket := server-socket.accept
     received := socket.in.read
@@ -117,4 +130,3 @@ test-board2:
     socket.close
     server-socket.close
     network-ap.close
-


### PR DESCRIPTION
## Summary

- add phase-specific I2S start/read/write progress deadlines
- add peer GPIO progress deadlines to the two-board wait-for stress test
- report ultrasound measurement number and trigger/echo pins when no echo arrives
- log only rig-local Wi-Fi test AP observations, and allow a short beacon-settle period

These changes keep real hardware failures visible while replacing generic CTest timeouts with the expected signal and phase.

## Validation

- Toit analysis passed for all changed files
- representative ESP32-S3 I2S test passed in 23 s
- ESP32-S3 `wait-for1` passed in 14 s
- formerly intermittent ESP32-S3 Wi-Fi test passed in 43 s
- ultrasound passed all five measurements and logged 119 mm readings

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
