### PR TITLE
tests: gate hardware matrix on rig health

### DIFF
--- a/tests/hw/CMakeLists.txt
+++ b/tests/hw/CMakeLists.txt
@@ -23,11 +23,11 @@ add_custom_target(
   # wrong chip family. The later commands are only run when this succeeds.
   COMMAND ${CMAKE_CTEST_COMMAND} -j2 -C hw --output-on-failure
       -R "^rig-preflight-"
-  # Flash mini-jag, verify the board-to-board GPIO link, and exercise one
-  # representative S3 I2S clock/data transfer before starting the matrix.
+  # Flash mini-jag and verify the board-to-board GPIO link before starting the
+  # matrix.
   COMMAND ${CMAKE_CTEST_COMMAND} -j2 -C hw --output-on-failure
       -FA "^rig-preflight-"
-      -R "^(rig-health-board1\\.toit-(esp32|esp32s3)|i2s-board1\\.toit-esp32s3-philips16)$"
+      -R "^rig-health-board1\\.toit-(esp32|esp32s3)$"
   # The current Raspberry Pi can't run more than 2 tests in parallel.
   COMMAND ${CMAKE_CTEST_COMMAND} -j2 -T test -C hw --output-on-failure
       -FA "^(rig-preflight-|setup-boards-)"

--- a/tests/hw/CMakeLists.txt
+++ b/tests/hw/CMakeLists.txt
@@ -19,8 +19,20 @@ project(hw NONE)  # No need for compilers.
 
 add_custom_target(
   check_hw
+  # Fail quickly and clearly when serial paths are absent or point at the
+  # wrong chip family. The later commands are only run when this succeeds.
+  COMMAND ${CMAKE_CTEST_COMMAND} -j2 -C hw --output-on-failure
+      -R "^rig-preflight-"
+  # Flash mini-jag, verify the board-to-board GPIO link, and exercise one
+  # representative S3 I2S clock/data transfer before starting the matrix.
+  COMMAND ${CMAKE_CTEST_COMMAND} -j2 -C hw --output-on-failure
+      -FA "^rig-preflight-"
+      -R "^(rig-health-board1\\.toit-(esp32|esp32s3)|i2s-board1\\.toit-esp32s3-philips16)$"
   # The current Raspberry Pi can't run more than 2 tests in parallel.
   COMMAND ${CMAKE_CTEST_COMMAND} -j2 -T test -C hw --output-on-failure
+      -FA "^(rig-preflight-|setup-boards-)"
+      -E "^(rig-preflight-|rig-health-|setup-board)"
+  VERBATIM
   USES_TERMINAL
   )
 

--- a/tests/hw/README.md
+++ b/tests/hw/README.md
@@ -80,10 +80,9 @@ ctest --verbose --test-dir build/hw -C esp32 -R "uart-"
 
 For the complete matrix, prefer `make test-hw` (or the `check_hw` Ninja
 target). It first opens and identifies all configured serial devices, flashes
-the tester firmware, runs a board-to-board GPIO sentinel, and checks one
-representative ESP32-S3 I2S transfer. A failed preflight stops the matrix, so a
-disconnected or miswired rig produces a few focused failures instead of a long
-list of dependent tests that were never run.
+the tester firmware, and runs a board-to-board GPIO sentinel. A failed preflight
+stops the matrix, so a disconnected or miswired rig produces a few focused
+failures instead of a long list of dependent tests that were never run.
 
 Notes:
 - `-R <regex>` matches test names. Append `$` to avoid matching the `-esp32s3`

--- a/tests/hw/README.md
+++ b/tests/hw/README.md
@@ -78,6 +78,13 @@ Run a category:
 ctest --verbose --test-dir build/hw -C esp32 -R "uart-"
 ```
 
+For the complete matrix, prefer `make test-hw` (or the `check_hw` Ninja
+target). It first opens and identifies all configured serial devices, flashes
+the tester firmware, runs a board-to-board GPIO sentinel, and checks one
+representative ESP32-S3 I2S transfer. A failed preflight stops the matrix, so a
+disconnected or miswired rig produces a few focused failures instead of a long
+list of dependent tests that were never run.
+
 Notes:
 - `-R <regex>` matches test names. Append `$` to avoid matching the `-esp32s3`
   variant when you want only esp32.
@@ -96,6 +103,12 @@ Notes:
   Either build it (`make esp32s3`) or run with `-C esp32` to skip.
 - **Setup `Timeout` on board1/board2** → board not responding on its USB port.
   Re-plug, check `ls -l /dev/ttyEsp32*`, or look at `dmesg | tail`.
+- **`RIG_PREFLIGHT_FAILED`** → a configured serial path could not be opened or
+  did not emit the boot marker for its expected ESP32 family. The error includes
+  the path, open/read error, and recent serial output.
+- **`RIG_PEER_LINK_FAILED`** → the short cross-board GPIO handshake did not
+  observe an expected level. Check rig power, common ground, and the two board
+  connection wires before debugging the named test matrix.
 - **Test runs but throws on the board** (e.g. `INVALID_CHIP`, `wifi connect`,
   etc.) → that's the actual hardware test failing. The tester prints the
   on-board exception trace and a `jag decode …` line you can run to

--- a/tests/hw/esp-tester/tester.toit
+++ b/tests/hw/esp-tester/tester.toit
@@ -22,8 +22,10 @@ JAG-DECODE ::= "jag decode"
 
 SERIAL-CONTROL-TIMEOUT ::= "SERIAL_CONTROL_TIMEOUT"
 TEST-COMPLETION-TIMEOUT ::= "TEST_COMPLETION_TIMEOUT"
+RIG-PREFLIGHT-FAILED ::= "RIG_PREFLIGHT_FAILED"
 
 DEVICE-READY-TIMEOUT-MS ::= 15_000
+RIG-PREFLIGHT-TIMEOUT-MS ::= 5_000
 CONTAINER-HEADER-TIMEOUT-MS ::= 10_000
 CONTAINER-CHUNK-TIMEOUT-MS ::= 10_000
 CONTAINER-INSTALL-TIMEOUT-MS ::= 30_000
@@ -81,6 +83,26 @@ main args:
 
   root-cmd.add setup-cmd
 
+  preflight-cmd := cli.Command "preflight"
+      --help="Verify the rig's serial paths and chip identities"
+      --options=[
+        cli.Option "port-board1"
+            --help="The path to the UART port of board 1"
+            --type="path"
+            --required,
+        cli.Option "port-board2"
+            --help="The path to the UART port of board 2"
+            --type="path"
+            --required,
+        cli.OptionEnum "chip" ["esp32", "esp32s3"]
+            --help="The expected chip family"
+            --required,
+      ]
+      --run=:: | invocation/cli.Invocation |
+        preflight-rig invocation
+
+  root-cmd.add preflight-cmd
+
   run-cmd := cli.Command "run"
       --help="Run a test on the ESP"
       --options=[
@@ -116,6 +138,38 @@ main args:
   root-cmd.add run-cmd
 
   root-cmd.run args
+
+preflight-rig invocation/cli.Invocation:
+  chip/string := invocation["chip"]
+  expected-marker := chip == "esp32"
+      ? "ets Jun  8 2016"
+      : "ESP-ROM:esp32s3"
+  Task.group [
+    :: preflight-port "board1" invocation["port-board1"] chip expected-marker,
+    :: preflight-port "board2" invocation["port-board2"] chip expected-marker,
+  ]
+
+preflight-port name/string path/string chip/string expected-marker/string:
+  output := ""
+  error := catch:
+    port := uart.HostPort path --baud-rate=CONSOLE-BAUD-RATE
+    try:
+      port.set-control-flag uart.HostPort.CONTROL-FLAG-DTR false
+      port.set-control-flag uart.HostPort.CONTROL-FLAG-RTS true
+      sleep --ms=500
+      port.set-control-flag uart.HostPort.CONTROL-FLAG-RTS false
+      with-timeout --ms=RIG-PREFLIGHT-TIMEOUT-MS:
+        while not output.contains expected-marker:
+          data := port.in.read
+          if not data: throw "Serial port closed"
+          output += data.to-string-non-throwing
+    finally:
+      port.close
+  if error:
+    if output.size > 300: output = output[output.size - 300..]
+    print "Rig preflight failed for $name: expected $chip on $path; error: $error; last serial output: $(output.trim)"
+    throw RIG-PREFLIGHT-FAILED
+  print "Rig preflight $name: identified $chip on $path"
 
 with-tmp-dir [block]:
   dir := directory.mkdtemp "/tmp/esp-tester"

--- a/tests/hw/esp32/CMakeLists.txt
+++ b/tests/hw/esp32/CMakeLists.txt
@@ -20,13 +20,29 @@ set(TESTER ${CMAKE_CURRENT_SOURCE_DIR}/../esp-tester/tester.toit)
 
 add_custom_target(
   check_esp32
+  COMMAND ${CMAKE_CTEST_COMMAND} -j2 -C esp32 --output-on-failure
+      -R "^rig-preflight-esp32$"
+  COMMAND ${CMAKE_CTEST_COMMAND} -j2 -C esp32 --output-on-failure
+      -FA "^rig-preflight-"
+      -R "^rig-health-board1\\.toit-esp32$"
   COMMAND ${CMAKE_CTEST_COMMAND} -j2 -T test -C esp32 --output-on-failure
+      -FA "^(rig-preflight-|setup-boards-)"
+      -E "^(rig-preflight-|rig-health-|setup-board)"
+  VERBATIM
   USES_TERMINAL
   )
 
 add_custom_target(
   check_esp32s3
+  COMMAND ${CMAKE_CTEST_COMMAND} -j2 -C esp32s3 --output-on-failure
+      -R "^rig-preflight-esp32s3$"
+  COMMAND ${CMAKE_CTEST_COMMAND} -j2 -C esp32s3 --output-on-failure
+      -FA "^rig-preflight-"
+      -R "^(rig-health-board1\\.toit-esp32s3|i2s-board1\\.toit-esp32s3-philips16)$"
   COMMAND ${CMAKE_CTEST_COMMAND} -j2 -T test -C esp32s3 --output-on-failure
+      -FA "^(rig-preflight-|setup-boards-)"
+      -E "^(rig-preflight-|rig-health-|setup-board)"
+  VERBATIM
   USES_TERMINAL
 )
 
@@ -39,6 +55,23 @@ set(VARIANTS
 
 foreach(esp_variant ${VARIANTS})
   string(TOUPPER ${esp_variant} ESP_VARIANT)
+
+  set(preflight_name "rig-preflight-${esp_variant}")
+  add_test(
+    NAME ${preflight_name}
+    COMMAND "${TOIT_EXE_HW}" "${TESTER}"
+        --toit-exe "${TOIT_EXE_HW}"
+        preflight
+        --chip "${esp_variant}"
+        --port-board1 "$ENV{${ESP_VARIANT}_BOARD1_PORT}"
+        --port-board2 "$ENV{${ESP_VARIANT}_BOARD2_PORT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    CONFIGURATIONS ${esp_variant} hw
+    )
+  set_tests_properties(${preflight_name} PROPERTIES
+      TIMEOUT 10
+      FIXTURES_SETUP "rig-preflight-${esp_variant}"
+      RESOURCE_LOCK ${esp_variant})
 
   # The control channel rides on the serial connection: all boards on the
   # rig are connected through USB-UART bridges, so the console UART works
@@ -73,6 +106,7 @@ foreach(esp_variant ${VARIANTS})
     # give it a generous margin.
     set_tests_properties("${test_name}" PROPERTIES TIMEOUT 150)
     set_tests_properties("${test_name}" PROPERTIES FIXTURES_SETUP "setup-boards-${esp_variant}")
+    set_tests_properties("${test_name}" PROPERTIES FIXTURES_REQUIRED "rig-preflight-${esp_variant}")
   endforeach()
 endforeach()
 

--- a/tests/hw/esp32/CMakeLists.txt
+++ b/tests/hw/esp32/CMakeLists.txt
@@ -38,7 +38,7 @@ add_custom_target(
       -R "^rig-preflight-esp32s3$"
   COMMAND ${CMAKE_CTEST_COMMAND} -j2 -C esp32s3 --output-on-failure
       -FA "^rig-preflight-"
-      -R "^(rig-health-board1\\.toit-esp32s3|i2s-board1\\.toit-esp32s3-philips16)$"
+      -R "^rig-health-board1\\.toit-esp32s3$"
   COMMAND ${CMAKE_CTEST_COMMAND} -j2 -T test -C esp32s3 --output-on-failure
       -FA "^(rig-preflight-|setup-boards-)"
       -E "^(rig-preflight-|rig-health-|setup-board)"

--- a/tests/hw/esp32/rig-health-board1.toit
+++ b/tests/hw/esp32/rig-health-board1.toit
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import gpio
+
+import .rig-health-shared
+import .test
+
+main:
+  run-test:
+    input := gpio.Pin BOARD1-IN --input --pull-down
+    output := gpio.Pin BOARD1-OUT --output
+    output.set 0
+    wait-for-rig-level input BOARD1-IN 0 "board1" "initial peer low"
+
+    [1, 0, 1, 0].do: | level |
+      output.set level
+      wait-for-rig-level input BOARD1-IN level "board1" "peer echo"
+
+    print "Rig peer link healthy: board1 pins in=$BOARD1-IN out=$BOARD1-OUT"

--- a/tests/hw/esp32/rig-health-board2.toit
+++ b/tests/hw/esp32/rig-health-board2.toit
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import gpio
+
+import .rig-health-shared
+import .test
+
+main:
+  run-test:
+    input := gpio.Pin BOARD2-IN --input --pull-down
+    output := gpio.Pin BOARD2-OUT --output
+    output.set 0
+
+    [1, 0, 1, 0].do: | level |
+      wait-for-rig-level input BOARD2-IN level "board2" "peer request"
+      output.set level
+
+    print "Rig peer link healthy: board2 pins in=$BOARD2-IN out=$BOARD2-OUT"

--- a/tests/hw/esp32/rig-health-shared.toit
+++ b/tests/hw/esp32/rig-health-shared.toit
@@ -16,10 +16,9 @@ RIG-PEER-TIMEOUT-MS ::= 5_000
 RIG-PEER-LINK-FAILED ::= "RIG_PEER_LINK_FAILED"
 
 wait-for-rig-level pin/gpio.Pin pin-number/int level/int board/string phase/string:
-  error := catch:
+  error := catch --unwind=(: it != DEADLINE-EXCEEDED-ERROR):
     with-timeout --ms=RIG-PEER-TIMEOUT-MS:
       while pin.get != level: sleep --ms=1
-  if error == DEADLINE-EXCEEDED-ERROR:
+  if error:
     print "Rig health failed on $board during $phase: pin $pin-number did not reach level $level in $(RIG-PEER-TIMEOUT-MS)ms"
     throw RIG-PEER-LINK-FAILED
-  if error: throw error

--- a/tests/hw/esp32/rig-health-shared.toit
+++ b/tests/hw/esp32/rig-health-shared.toit
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import gpio
+import system
+
+import .variants
+
+BOARD1-IN ::= Variant.CURRENT.board-connection-pin1
+BOARD1-OUT ::= Variant.CURRENT.board-connection-pin2
+BOARD2-IN ::= Variant.CURRENT.board-connection-pin2
+BOARD2-OUT ::= Variant.CURRENT.board-connection-pin1
+
+RIG-PEER-TIMEOUT-MS ::= 5_000
+RIG-PEER-LINK-FAILED ::= "RIG_PEER_LINK_FAILED"
+
+wait-for-rig-level pin/gpio.Pin pin-number/int level/int board/string phase/string:
+  error := catch:
+    with-timeout --ms=RIG-PEER-TIMEOUT-MS:
+      while pin.get != level: sleep --ms=1
+  if error == DEADLINE-EXCEEDED-ERROR:
+    print "Rig health failed on $board during $phase: pin $pin-number did not reach level $level in $(RIG-PEER-TIMEOUT-MS)ms"
+    throw RIG-PEER-LINK-FAILED
+  if error: throw error


### PR DESCRIPTION
## Summary

- open and reset both configured ports per chip family before flashing
- verify each port emits the expected ESP32 or ESP32-S3 ROM identity marker
- gate the matrix on a short two-wire peer GPIO sentinel and a representative ESP32-S3 I2S transfer
- stop before the matrix when the rig is absent or unhealthy, instead of producing a wall of dependent `Not Run` results
- document the new workflow and failure markers

## Validation

- real ESP32 preflight identified both boards in 1.0 s
- real ESP32-S3 preflight identified both boards in 1.1 s
- synthetic missing-port preflight failed in 0.6 s with paths and underlying errors
- ESP32-S3 setup, peer sentinel, and I2S health prelude passed
- Toit analysis, CMake generation, Ninja command escaping, and `git diff --check` passed

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
