### PR TITLE
Improve short sleeps on ESP32

### DIFF
--- a/src/os_esp32.cc
+++ b/src/os_esp32.cc
@@ -22,6 +22,7 @@
 #include <esp_heap_caps.h>
 #include <esp_log.h>
 #include <esp_sleep.h>
+#include <esp_timer.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 #include <freertos/task.h>
@@ -131,6 +132,14 @@ void OS::close(int fd) {
 // can only cause a conventional spurious wakeup on its owning thread.
 __thread SemaphoreHandle_t condition_wake_semaphore_ = null;
 
+struct ConditionWaitTimer {
+  SemaphoreHandle_t wake;
+  SemaphoreHandle_t callback_complete;
+  esp_timer_handle_t timer;
+};
+
+__thread ConditionWaitTimer condition_wait_timer_{};
+
 static SemaphoreHandle_t current_condition_wake_semaphore() {
   if (condition_wake_semaphore_ == null) {
     condition_wake_semaphore_ = xSemaphoreCreateBinary();
@@ -138,10 +147,40 @@ static SemaphoreHandle_t current_condition_wake_semaphore() {
   return condition_wake_semaphore_;
 }
 
+static void condition_wait_timeout(void* arg) {
+  auto timer = reinterpret_cast<ConditionWaitTimer*>(arg);
+  // The condition may have been signaled at the same time as the timeout. In
+  // that case the binary wake semaphore is already full, which is fine.
+  xSemaphoreGive(timer->wake);
+  if (xSemaphoreGive(timer->callback_complete) != pdTRUE) {
+    FATAL("condition-variable timer callback completed twice");
+  }
+}
+
+static ConditionWaitTimer* current_condition_wait_timer() {
+  ConditionWaitTimer* result = &condition_wait_timer_;
+  if (result->timer == null) {
+    result->wake = current_condition_wake_semaphore();
+    result->callback_complete = xSemaphoreCreateBinary();
+    if (result->wake == null || result->callback_complete == null) {
+      FATAL("unable to allocate condition wait timer semaphores");
+    }
+    esp_timer_create_args_t args{};
+    args.callback = condition_wait_timeout;
+    args.arg = result;
+    args.name = "toit condition wait";
+    if (esp_timer_create(&args, &result->timer) != ESP_OK) {
+      FATAL("unable to allocate condition wait timer");
+    }
+  }
+  return result;
+}
+
 // Inspired by pthread_cond_t impl on esp32-idf.
 struct ConditionVariableWaiter {
   SemaphoreHandle_t wake;
   bool signaled;
+  bool uses_timer;
   // Link to next semaphore to be notified.
   TAILQ_ENTRY(ConditionVariableWaiter) link;
 };
@@ -162,11 +201,56 @@ class ConditionVariable {
   bool wait_us(int64 us) {
     if (us <= 0LL) return false;
 
-    // Use ceiling divisions to avoid rounding the ticks down and thus
-    // not waiting long enough.
-    uint32 ms = 1 + static_cast<uint32>((us - 1) / 1000LL);
-    uint32 ticks = (ms + portTICK_PERIOD_MS - 1) / portTICK_PERIOD_MS;
-    return wait_ticks(ticks);
+    if (!mutex_->is_locked()) {
+      FATAL("wait on unlocked mutex");
+    }
+
+    ConditionWaitTimer* timer = current_condition_wait_timer();
+    // Every timed wait finishes or cancels its callback before returning, so
+    // both semaphores must be empty here.
+    if (xSemaphoreTake(timer->wake, 0) == pdTRUE ||
+        xSemaphoreTake(timer->callback_complete, 0) == pdTRUE) {
+      FATAL("stale condition-variable timer wakeup");
+    }
+
+    ConditionVariableWaiter w{};
+    w.wake = timer->wake;
+    w.uses_timer = true;
+    TAILQ_INSERT_TAIL(&waiter_list_, &w, link);
+
+    if (esp_timer_start_once(timer->timer, us) != ESP_OK) {
+      FATAL("unable to start condition wait timer");
+    }
+
+    mutex_->unlock();
+
+    if (xSemaphoreTake(w.wake, portMAX_DELAY) != pdTRUE) {
+      FATAL("condition-variable timer wait failed");
+    }
+
+    mutex_->lock();
+
+    esp_err_t stop_result = esp_timer_stop(timer->timer);
+    if (stop_result == ESP_ERR_INVALID_STATE) {
+      // The timer is removed from the timer queue before its callback runs.
+      // Wait for the callback so it cannot leave a wakeup behind for the next
+      // condition-variable wait on this thread.
+      if (xSemaphoreTake(timer->callback_complete, portMAX_DELAY) != pdTRUE) {
+        FATAL("condition-variable timer callback wait failed");
+      }
+    } else if (stop_result != ESP_OK) {
+      FATAL("unable to stop condition wait timer");
+    }
+
+    if (w.signaled) {
+      // A simultaneous timer expiry and condition signal can each give the
+      // binary semaphore. Consume the second wakeup before reusing it.
+      xSemaphoreTake(w.wake, 0);
+    } else {
+      TAILQ_REMOVE(&waiter_list_, &w, link);
+    }
+
+    return w.signaled;
   }
 
   bool wait_ticks(uint32 ticks) {
@@ -209,7 +293,7 @@ class ConditionVariable {
     if (entry) {
       TAILQ_REMOVE(&waiter_list_, entry, link);
       entry->signaled = true;
-      if (xSemaphoreGive(entry->wake) != pdTRUE) {
+      if (xSemaphoreGive(entry->wake) != pdTRUE && !entry->uses_timer) {
         FATAL("unable to signal condition variable");
       }
     }
@@ -222,7 +306,7 @@ class ConditionVariable {
     while (ConditionVariableWaiter* entry = TAILQ_FIRST(&waiter_list_)) {
       TAILQ_REMOVE(&waiter_list_, entry, link);
       entry->signaled = true;
-      if (xSemaphoreGive(entry->wake) != pdTRUE) {
+      if (xSemaphoreGive(entry->wake) != pdTRUE && !entry->uses_timer) {
         FATAL("unable to signal condition variable");
       }
     }
@@ -269,6 +353,14 @@ void Thread::_boot() {
   ASSERT(current() == this);
   HeapTagScope scope(ITERATE_CUSTOM_TAGS + OTHER_THREADS_MALLOC_TAG);
   entry();
+  if (condition_wait_timer_.timer != null) {
+    if (esp_timer_delete(condition_wait_timer_.timer) != ESP_OK) {
+      FATAL("unable to delete condition wait timer");
+    }
+    condition_wait_timer_.timer = null;
+    vSemaphoreDelete(condition_wait_timer_.callback_complete);
+    condition_wait_timer_.callback_complete = null;
+  }
   if (condition_wake_semaphore_ != null) {
     vSemaphoreDelete(condition_wake_semaphore_);
     condition_wake_semaphore_ = null;

--- a/src/os_esp32.cc
+++ b/src/os_esp32.cc
@@ -138,6 +138,9 @@ struct ConditionWaitTimer {
   esp_timer_handle_t timer;
 };
 
+// A native thread can only wait on one condition variable at a time, so one
+// timer per thread is sufficient. Toit task timers are multiplexed separately
+// by TimerEventSource; they do not each block a native thread.
 __thread ConditionWaitTimer condition_wait_timer_{};
 
 static SemaphoreHandle_t current_condition_wake_semaphore() {
@@ -353,6 +356,8 @@ void Thread::_boot() {
   ASSERT(current() == this);
   HeapTagScope scope(ITERATE_CUSTOM_TAGS + OTHER_THREADS_MALLOC_TAG);
   entry();
+  // Timed waits always cancel or finish their callback before returning, so
+  // no callback can use these semaphores after the native thread exits.
   if (condition_wait_timer_.timer != null) {
     if (esp_timer_delete(condition_wait_timer_.timer) != ESP_OK) {
       FATAL("unable to delete condition wait timer");

--- a/tests/hw/esp32/short-sleep-test.toit
+++ b/tests/hw/esp32/short-sleep-test.toit
@@ -39,11 +39,20 @@ test-parallel:
     :: run-sleeper index
   results := Task.group workers
   expect-equals PARALLEL-TASKS results.size
+  maximum-minimum-lateness-us := results.values.reduce --initial=0: |maximum-us minimum-us|
+    max maximum-us minimum-us
+  // Every worker gets several chances to wake with little scheduling jitter.
+  // Requiring all of them to do so makes the parallel test fail if concurrent
+  // short sleeps regress to the 10ms FreeRTOS tick.
+  expect maximum-minimum-lateness-us < 4_000
 
-run-sleeper index/int -> none:
+run-sleeper index/int -> int:
   requested-ms := 1 + index % 5
+  minimum-lateness-us := 1 << 60
   SLEEPS-PER-TASK.repeat:
     before := Time.monotonic-us
     sleep --ms=requested-ms
     elapsed-us := Time.monotonic-us - before
     expect elapsed-us >= requested-ms * 1_000
+    minimum-lateness-us = min minimum-lateness-us (elapsed-us - requested-ms * 1_000)
+  return minimum-lateness-us

--- a/tests/hw/esp32/short-sleep-test.toit
+++ b/tests/hw/esp32/short-sleep-test.toit
@@ -39,20 +39,21 @@ test-parallel:
     :: run-sleeper index
   results := Task.group workers
   expect-equals PARALLEL-TASKS results.size
-  maximum-minimum-lateness-us := results.values.reduce --initial=0: |maximum-us minimum-us|
-    max maximum-us minimum-us
-  // Every worker gets several chances to wake with little scheduling jitter.
-  // Requiring all of them to do so makes the parallel test fail if concurrent
-  // short sleeps regress to the 10ms FreeRTOS tick.
-  expect maximum-minimum-lateness-us < 4_000
+  low-latency-workers := 0
+  results.values.do: |minimum-us/int|
+    if minimum-us < 6_000: low-latency-workers++
+  // The 10ms FreeRTOS tick would keep every worker above this limit. Allow
+  // some workers to suffer scheduling jitter while requiring concurrent
+  // short sleeps to consistently avoid tick quantization.
+  expect low-latency-workers >= PARALLEL-TASKS * 3 / 4
 
 run-sleeper index/int -> int:
   requested-ms := 1 + index % 5
-  minimum-lateness-us := 1 << 60
+  minimum-us := 1 << 60
   SLEEPS-PER-TASK.repeat:
     before := Time.monotonic-us
     sleep --ms=requested-ms
     elapsed-us := Time.monotonic-us - before
     expect elapsed-us >= requested-ms * 1_000
-    minimum-lateness-us = min minimum-lateness-us (elapsed-us - requested-ms * 1_000)
-  return minimum-lateness-us
+    minimum-us = min minimum-us elapsed-us
+  return minimum-us

--- a/tests/hw/esp32/short-sleep-test.toit
+++ b/tests/hw/esp32/short-sleep-test.toit
@@ -6,10 +6,17 @@ import expect show *
 
 import .test
 
+PARALLEL-TASKS ::= 40
+SLEEPS-PER-TASK ::= 20
+
 main:
   run-test: test
 
 test:
+  test-single
+  test-parallel
+
+test-single:
   // Warm up the reusable native timer so its one-time allocation is not part
   // of the latency measurement.
   sleep --ms=1
@@ -26,3 +33,17 @@ test:
   // at least one 10ms tick. Allow ample scheduling jitter, but require at least
   // one sample that clearly did not wait for such a tick.
   expect minimum-us < 6_000
+
+test-parallel:
+  workers := List PARALLEL-TASKS: |index/int|
+    :: run-sleeper index
+  results := Task.group workers
+  expect-equals PARALLEL-TASKS results.size
+
+run-sleeper index/int -> none:
+  requested-ms := 1 + index % 5
+  SLEEPS-PER-TASK.repeat:
+    before := Time.monotonic-us
+    sleep --ms=requested-ms
+    elapsed-us := Time.monotonic-us - before
+    expect elapsed-us >= requested-ms * 1_000

--- a/tests/hw/esp32/short-sleep-test.toit
+++ b/tests/hw/esp32/short-sleep-test.toit
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+
+import .test
+
+main:
+  run-test: test
+
+test:
+  // Warm up the reusable native timer so its one-time allocation is not part
+  // of the latency measurement.
+  sleep --ms=1
+
+  minimum-us := 1 << 60
+  25.repeat:
+    before := Time.monotonic-us
+    sleep --ms=2
+    elapsed-us := Time.monotonic-us - before
+    expect elapsed-us >= 2_000
+    minimum-us = min minimum-us elapsed-us
+
+  // The 100Hz FreeRTOS tick used to make every short asynchronous sleep take
+  // at least one 10ms tick. Allow ample scheduling jitter, but require at least
+  // one sample that clearly did not wait for such a tick.
+  expect minimum-us < 6_000


### PR DESCRIPTION
## Summary

- use a reusable per-thread `esp_timer` for timed condition-variable waits on ESP32
- preserve condition signal semantics when a signal races with timer expiry
- add an ESP32 hardware regression test for sub-tick sleeps

This keeps the FreeRTOS tick rate at 100Hz while allowing Toit timer deadlines, which are already expressed in microseconds, to wake through the high-resolution ESP timer.

## Hardware results

Measured on an ESP32-D0WD-V3 using 50 samples per duration:

| Requested | Minimum | Average | Maximum |
|---:|---:|---:|---:|
| 1ms | 1.288ms | 1.316ms | 1.349ms |
| 2ms | 2.302ms | 2.315ms | 2.363ms |
| 5ms | 5.283ms | 5.307ms | 5.332ms |
| 9ms | 9.280ms | 9.302ms | 9.339ms |
| 10ms | 10.268ms | 10.296ms | 10.330ms |

## Validation

- `make esp32`
- `build/host/sdk/bin/toit run tests/sleep-test.toit`
- `build/host/sdk/bin/toit analyze -Werror --project-root tests/hw/esp32 tests/hw/esp32/short-sleep-test.toit`
- flashed a measurement container and captured results with `jag monitor --port /dev/ttyUSB4`
