### PR TITLE
pkg: resolve local paths relative to project root

### DIFF
--- a/tests/pkg/install-local-project-root-test.toit
+++ b/tests/pkg/install-local-project-root-test.toit
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import encoding.yaml
+import expect show *
+import fs
+import host.directory
+import host.file
+import host.pipe
+
+main args/List:
+  expect-equals 1 args.size
+  toit-exe/string := args[0]
+  tmp-dir := directory.mkdtemp "/tmp/pkg-local-project-root-"
+  try:
+    package-dir := fs.join tmp-dir "widget"
+    tests-dir := fs.join package-dir "tests"
+    directory.mkdir --recursive (fs.join package-dir "src")
+    directory.mkdir tests-dir
+
+    file.write-contents --path=(fs.join package-dir "package.yaml") """
+        name: widget
+        description: Minimal local dependency target.
+        """
+    file.write-contents --path=(fs.join tests-dir "package.yaml") """
+        name: widget-tests
+        description: Minimal nested test project.
+        dependencies:
+          widget:
+            path: ..
+        """
+
+    original-cwd := directory.cwd
+    try:
+      directory.chdir package-dir
+      exit-code := pipe.run-program [
+        toit-exe,
+        "pkg",
+        "--project-root=tests",
+        "--no-auto-sync",
+        "install",
+        "--recompute",
+      ]
+      expect-equals 0 exit-code
+    finally:
+      directory.chdir original-cwd
+
+    lock/Map := yaml.decode (file.read-contents (fs.join tests-dir "package.lock"))
+    expect-equals ".." lock["packages"]["widget"]["path"]
+  finally:
+    directory.rmdir --recursive --force tmp-dir

--- a/tools/pkg/project/specification.toit
+++ b/tools/pkg/project/specification.toit
@@ -146,7 +146,7 @@ class ProjectSpecification extends Specification:
       if fs.is-relative human-path:
         // Clean the relative path, so we don't have unnecessary '../foo/bar' if we are
         // in a folder 'foo'. It should just be "bar".
-        human-path = fs.to-relative --base=entry-dir human-path
+        human-path = fs.to-relative --base=entry-dir absolute-path
 
       dep-specification-path/string := fs.join absolute-path Specification.FILE-NAME
       // Local packages are allowed not to have a package file.
@@ -443,5 +443,4 @@ class PackageDependency:
     return url == other.url and hash-code == other.hash-code and constraint == other.constraint
 
   stringify: return "$url:$constraint"
-
 


### PR DESCRIPTION
## Summary

- Resolve relative local dependency paths from the manifest-selected project root when generating the lockfile.
- Keep lockfile paths independent of the package command invocation directory.
- Add an end-to-end regression test for a nested project selected with `--project-root`.

## Testing

- `toit analyze -Werror tools/pkg/project/specification.toit tests/pkg/install-local-project-root-test.toit`
- `ctest --test-dir build/host -C slow --output-on-failure -R "^tests/pkg/" -j2` (52 tests passed)