### PR TITLE
Fix bundled esptool discovery and test flashing in QEMU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,6 +655,9 @@ jobs:
       - name: Build ESP32-S3 USB Serial/JTAG console firmware
         run: tests/qemu/build-s3-usb-envelope.sh
 
+      - name: Install bundled esptool
+        run: make install-esptool
+
       - name: Install latest Toit QEMU release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -670,7 +673,7 @@ jobs:
           tar -xf "${QEMU_ARCHIVE}"
           echo "QEMU_SYSTEM_XTENSA=${QEMU_DIR}/qemu-toit-${QEMU_VERSION}-linux-x86_64/bin/qemu-system-xtensa" >> "${GITHUB_ENV}"
 
-      - name: Test ESP32 standard streams in QEMU
+      - name: Test ESP32 flashing and standard streams in QEMU
         run: tests/qemu/run-tests.sh
 
       - name: Pack firmware artifacts

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ debug:
 .PHONY: sdk
 sdk: tools version-file
 
+.PHONY: install-esptool
+install-esptool: sdk
+	tools/install-esptool.sh $(BUILD)/$(HOST)/sdk
+
 # Rebuilds the SDK using only Ninja, without rebuilding the
 # Ninja files with Cmake.
 .PHONY: sdk-no-cmake

--- a/tests/package.lock
+++ b/tests/package.lock
@@ -7,6 +7,7 @@ prefixes:
   fs: pkg-fs
   host: pkg-host
   partition-table: toit-partition-table-esp32
+  semver: toit-semver
   tar: pkg-tar
 packages:
   pkg-ar:
@@ -73,3 +74,8 @@ packages:
     name: partition-table
     version: 1.4.0
     hash: 9ee4032b913a00d0c0f87446261d034842b707f1
+  toit-semver:
+    url: github.com/toitware/toit-semver
+    name: semver
+    version: 1.2.0
+    hash: 7b862ca7b40601ae2a63ec6ffbacebb48c929e02

--- a/tests/package.yaml
+++ b/tests/package.yaml
@@ -20,6 +20,9 @@ dependencies:
   partition-table:
     url: github.com/toitware/toit-partition-table-esp32
     version: ^1.4.0
+  semver:
+    url: github.com/toitware/toit-semver
+    version: ^1.2.0
   tar:
     url: github.com/toitlang/pkg-tar
     version: ^2.1.0

--- a/tests/qemu/run-tests.sh
+++ b/tests/qemu/run-tests.sh
@@ -31,9 +31,10 @@ done
 TEMP_DIR="$(mktemp -d)"
 QEMU_PID=""
 QEMU_LOG=""
+SERIAL_PORT=""
 
 stop_qemu() {
-  exec 3>&- 2>/dev/null || true
+  exec 3>&- || true
   if [[ -n "${QEMU_PID}" ]]; then
     kill "${QEMU_PID}" 2>/dev/null || true
     wait "${QEMU_PID}" 2>/dev/null || true
@@ -97,6 +98,41 @@ start_qemu() {
   QEMU_PID="$!"
 }
 
+start_qemu_download_mode() {
+  local image="$1"
+  QEMU_LOG="${TEMP_DIR}/${image}-download.log"
+
+  "${QEMU_SYSTEM_XTENSA}" \
+    -M esp32 \
+    -accel tcg,thread=single \
+    -global driver=esp32.gpio,property=strap_mode,value=15 \
+    -display none \
+    -monitor none \
+    -no-reboot \
+    -serial pty \
+    -drive "file=${TEMP_DIR}/${image}.bin,if=mtd,format=raw" \
+    >"${QEMU_LOG}" 2>&1 &
+  QEMU_PID="$!"
+}
+
+wait_for_serial_port() {
+  SERIAL_PORT=""
+  for ((tick = 0; tick < QEMU_TIMEOUT_TICKS; tick++)); do
+    SERIAL_PORT="$(awk '/char device redirected to/ { print $5; exit }' "${QEMU_LOG}")"
+    if [[ -n "${SERIAL_PORT}" ]]; then
+      return 0
+    fi
+    if ! kill -0 "${QEMU_PID}" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  echo "Timed out waiting for QEMU's serial port." >&2
+  cat "${QEMU_LOG}" >&2
+  return 1
+}
+
 wait_for() {
   local marker="$1"
   for ((tick = 0; tick < QEMU_TIMEOUT_TICKS; tick++)); do
@@ -128,6 +164,28 @@ run_stdio_test() {
   echo "PASS: ${machine} ${console} stdin/stdout/stderr"
 }
 
+run_esptool_flash_test() {
+  local image=esptool-flashed
+  local image_size
+  image_size="$(stat --format=%s "${TEMP_DIR}/stdio-uart.bin")"
+  truncate --size="${image_size}" "${TEMP_DIR}/${image}.bin"
+
+  start_qemu_download_mode "${image}"
+  wait_for_serial_port
+  "${TOIT}" tool firmware \
+    --envelope="${TEMP_DIR}/stdio-uart.envelope" \
+    flash --port="${SERIAL_PORT}"
+  stop_qemu
+
+  start_qemu esp32 "${image}" uart
+  wait_for STDIO-READY
+  printf 'hello-flashed-qemu\n' >&3
+  wait_for STDOUT:hello-flashed-qemu
+  wait_for STDERR:hello-flashed-qemu
+  stop_qemu
+  echo "PASS: bundled esptool flashed and booted an ESP32 in QEMU"
+}
+
 run_uart_sharing_test() {
   start_qemu esp32 uart-share uart
   wait_for IO-READY
@@ -144,6 +202,7 @@ make_image stdio.toit "${UART_ENVELOPE}" stdio-uart
 make_image stdio-uart-console.toit "${UART_ENVELOPE}" uart-share
 make_image stdio.toit "${USB_ENVELOPE}" stdio-usb
 
+run_esptool_flash_test
 run_stdio_test esp32 stdio-uart uart
 run_uart_sharing_test
 run_stdio_test esp32s3 stdio-usb usb-serial-jtag

--- a/tools/firmware.toit
+++ b/tools/firmware.toit
@@ -34,6 +34,7 @@ import host.file
 import host.os
 import host.pipe
 import partition-table show *
+import semver
 import tar
 
 import ..system.extensions.host.run-image-boot-sh
@@ -929,6 +930,23 @@ detect-flash-size_ esptool/List --port/string --chip/string -> int?:
   mb := int.parse rest[..mb-index].trim --if-error=: return null
   return mb * 0x100000
 
+/**
+Returns the major version reported by 'esptool version'.
+
+Esptool 4 prints both "esptool.py v4.x.y" and "4.x.y", while esptool 5
+  similarly uses "esptool v5.x.y". Scan every whitespace-separated word so
+  this keeps working with either form.
+*/
+esptool-major-version_ esptool/List -> int?:
+  output := pipe.backticks (esptool + ["version"])
+  (output.split "\n").do: | line/string |
+    (line.trim.split " ").do: | word/string |
+      candidate := word
+      if candidate.starts-with "v": candidate = candidate[1..]
+      version := semver.SemanticVersion.parse candidate --if-error=: null
+      if version: return version.major
+  return null
+
 write-partitions_ output-path/string partitions/Map --flashing/Map --ui/cli.Ui:
   flash-size := parse-flash-size_ flashing["flash_settings"]["flash_size"] --ui=ui
 
@@ -1053,20 +1071,9 @@ find-esptool_ -> List:
       return ["python3$bin-extension", esptool-path]
     return [esptool-path]
 
-  if jag-toit-repo-path := os.env.get "JAG_TOIT_REPO_PATH":
-    return [
-      "python3$bin-extension",
-      "$jag-toit-repo-path/third_party/esp-idf/components/esptool_py/esptool/esptool.py"
-    ]
-
   list := bin-name.split "/"
   dir := list[..list.size - 1].join "/"
-  if bin-name.ends-with ".toit":
-    if dir == "": dir = "."
-    esptool-py := "$dir/../third_party/esp-idf/components/esptool_py/esptool/esptool.py"
-    if file.is-file esptool-py:
-      return ["python3$bin-extension", esptool-py]
-  else if dir != "":
+  if not bin-name.ends-with ".toit" and dir != "":
     // This executable is supposed to live in 'bin', whereas the esptool is in 'lib/toit/bin'.
     esptool := "$dir/../lib/toit/bin/esptool$bin-extension"
     if file.is-file esptool:
@@ -1195,6 +1202,11 @@ flash invocation/cli.Invocation -> none:
             partition-args.add tmp-file
 
           esptool := find-esptool_
+          esptool-major := esptool-major-version_ esptool
+          if not esptool-major:
+            ui.abort "Could not determine the esptool version."
+          if esptool-major < 5:
+            ui.abort "Esptool 5 or newer is required, but found version $esptool-major."
 
           // Verify that the device's flash is big enough for the partition
           // table. 'build-esp32-image' derived the required flash size from the
@@ -1211,9 +1223,6 @@ flash invocation/cli.Invocation -> none:
             if not detected-flash-size:
               ui.emit --warning "Could not determine the device's flash size; skipping the flash-size check."
 
-          // The new esptool has deprecated underscores in some arguments.
-          // TODO(floitsch): remove these replacements when the esp-idf has been updated
-          //   to a version that uses the new arguments.
           before-args := flashing["extra_esptool_args"]["before"]
           after-args := flashing["extra_esptool_args"]["after"]
           write-flash-args := flashing["write_flash_args"]
@@ -1233,7 +1242,7 @@ flash invocation/cli.Invocation -> none:
             "--chip", chip,
             "--before", before-args,
             "--after", after-args
-          ] + [ "write-flash" ] + write-flash-args + partition-args
+          ] + ["write-flash"] + write-flash-args + partition-args
           if code != 0: exit 1
         finally:
           directory.rmdir --recursive tmp

--- a/tools/install-esptool.sh
+++ b/tools/install-esptool.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2026 Toit contributors.
+# Use of this source code is governed by a Zero-Clause BSD license that can
+# be found in the tests/LICENSE file.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 SDK-DIRECTORY" >&2
+  exit 1
+fi
+
+SDK_DIR="$1"
+VERSION="${ESPTOOL_VERSION:-v5.1.0%2Btoitlang.universal}"
+SYSTEM="$(uname -s)"
+MACHINE="$(uname -m)"
+EXTENSION=""
+ARCHIVE_EXTENSION=".tar.gz"
+
+case "${SYSTEM}" in
+  Linux)
+    case "${MACHINE}" in
+      x86_64) ARCH="linux-amd64" ;;
+      armv7l) ARCH="linux-armv7" ;;
+      aarch64|arm64) ARCH="linux-aarch64" ;;
+      riscv64) ARCH="linux-riscv64" ;;
+      *) echo "unsupported Linux architecture: ${MACHINE}" >&2; exit 1 ;;
+    esac
+    ;;
+  Darwin)
+    # The macOS aarch64 artifact is a universal binary.
+    ARCH="macos-aarch64"
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    ARCH="windows-amd64"
+    EXTENSION=".exe"
+    ARCHIVE_EXTENSION=".zip"
+    ;;
+  *)
+    echo "unsupported operating system: ${SYSTEM}" >&2
+    exit 1
+    ;;
+esac
+
+TARGET_DIR="${SDK_DIR}/lib/toit/bin"
+TARGET="${TARGET_DIR}/esptool${EXTENSION}"
+EXPECTED_VERSION="${VERSION#v}"
+EXPECTED_VERSION="${EXPECTED_VERSION%%\%*}"
+if [[ -x "${TARGET}" ]]; then
+  INSTALLED_VERSION="$("${TARGET}" version 2>/dev/null || true)"
+  if [[ "${INSTALLED_VERSION}" == *"esptool v${EXPECTED_VERSION}"* ]]; then
+    echo "esptool ${EXPECTED_VERSION} is already installed in ${SDK_DIR}"
+    exit 0
+  fi
+fi
+
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/toit-esptool.XXXXXX")"
+trap 'rm -rf "${TEMP_DIR}"' EXIT
+
+ARCHIVE="esptool-${ARCH}${ARCHIVE_EXTENSION}"
+URL="https://github.com/toitlang/esptool/releases/download/${VERSION}/${ARCHIVE}"
+curl --location --fail --output "${TEMP_DIR}/${ARCHIVE}" "${URL}"
+
+if [[ "${ARCHIVE_EXTENSION}" == ".zip" ]]; then
+  unzip -q "${TEMP_DIR}/${ARCHIVE}" -d "${TEMP_DIR}"
+else
+  tar -xzf "${TEMP_DIR}/${ARCHIVE}" -C "${TEMP_DIR}"
+fi
+
+mkdir -p "${TARGET_DIR}"
+cp "${TEMP_DIR}/esptool-${ARCH}/esptool${EXTENSION}" "${TARGET}"
+chmod +x "${TARGET}"


### PR DESCRIPTION
## Summary

- prefer the SDK-bundled esptool over source-tree Python wrappers and PATH
- require esptool 5 or newer for flashing
- add a reusable installer for the same pinned esptool artifact used by release CI
- flash and boot an ESP32 QEMU through the real bundled esptool in CI

## Testing

- reproduced the original failure with the actual Arch esptool 4.8.1
- verified esptool 4 now produces a clear version error
- downloaded and installed the pinned esptool 5.1 artifact with the new installer
- flashed an ESP32 QEMU and booted the flashed marker program
- `toit analyze tools/firmware.toit`
- shell syntax and diff checks