### PR TITLE
Fix propagated-type crash and ESP32 short-sleep test

### DIFF
--- a/src/compiler/method_selector_offsets.h
+++ b/src/compiler/method_selector_offsets.h
@@ -23,7 +23,8 @@ namespace toit {
 namespace compiler {
 
 // Maps runtime method IDs to the full selector offsets used during compilation.
-// Negative offsets encode class-check indexes and are not needed at runtime.
+// The compiler-side type propagator uses this copy for newly emitted programs;
+// runtime method headers also retain the offsets needed by runtime propagation.
 using MethodSelectorOffsets = std::unordered_map<int, word>;
 
 } // namespace toit::compiler

--- a/src/objects.h
+++ b/src/objects.h
@@ -806,14 +806,14 @@ class Method {
   bool is_lambda_method() const { return kind_() == LAMBDA; }
   bool is_block_method() const { return  kind_() == BLOCK; }
 
-  int arity() const { return bytes_[ARITY_OFFSET] & ARITY_MASK; }
+  int arity() const { return bytes_[ARITY_AND_FLAGS_OFFSET] & ARITY_MASK; }
   int captured_count() const { return value_(); }
   int selector_offset() const {
     int value = value_();
-    if (value == NO_SELECTOR) return -1;
-    if ((bytes_[ARITY_OFFSET] & STATICALLY_RESOLVED_INSTANCE_BIT) != 0) {
-      return value - (UINT16_MAX + 1);
+    if ((bytes_[ARITY_AND_FLAGS_OFFSET] & STATICALLY_RESOLVED_INSTANCE_BIT) != 0) {
+      return -value;
     }
+    if (value == NO_SELECTOR) return -1;
     return value;
   }
   uint8* entry() const { return &bytes_[ENTRY_OFFSET]; }
@@ -841,16 +841,16 @@ class Method {
 
   void _initialize_method(word selector_offset, bool is_field_accessor, int arity, List<uint8> bytecodes, int max_height) {
     // Statically resolved instance methods use negative selector offsets to
-    // encode a class-check-table index. Preserve the signed 16-bit value in
-    // the value field and mark it with the high bit of the arity field. This
-    // keeps it distinct from positive selector offsets.
+    // encode a class-check-table index. Store the magnitude in the value field
+    // and mark it with the high bit of the arity field. This keeps it distinct
+    // from positive selector offsets.
     bool is_statically_resolved_instance = selector_offset < -1;
     word encoded_selector_offset = selector_offset;
     if (is_statically_resolved_instance) {
-      if (selector_offset < INT16_MIN) {
+      if (selector_offset < -static_cast<word>(UINT16_MAX)) {
         FATAL("Selector offset too small: %" PRIdPTR, selector_offset);
       }
-      encoded_selector_offset += UINT16_MAX + 1;
+      encoded_selector_offset = -selector_offset;
     } else if (selector_offset == -1) {
       encoded_selector_offset = NO_SELECTOR;
     } else if (selector_offset >= NO_SELECTOR) {
@@ -859,7 +859,7 @@ class Method {
     Kind kind = is_field_accessor ? FIELD_ACCESSOR : METHOD;
     _initialize(kind, encoded_selector_offset, arity, bytecodes, max_height);
     if (is_statically_resolved_instance) {
-      bytes_[ARITY_OFFSET] |= STATICALLY_RESOLVED_INSTANCE_BIT;
+      bytes_[ARITY_AND_FLAGS_OFFSET] |= STATICALLY_RESOLVED_INSTANCE_BIT;
     }
     ASSERT(this->arity() == arity);
     ASSERT(this->selector_offset() == selector_offset);
@@ -868,8 +868,8 @@ class Method {
   friend class compiler::ProgramBuilder;
 
  private:
-  static const word ARITY_OFFSET = 0;
-  static const word KIND_HEIGHT_OFFSET = ARITY_OFFSET + BYTE_SIZE;
+  static const word ARITY_AND_FLAGS_OFFSET = 0;
+  static const word KIND_HEIGHT_OFFSET = ARITY_AND_FLAGS_OFFSET + BYTE_SIZE;
   static const word KIND_BITS = 2;
   static const word KIND_MASK = (1 << KIND_BITS) - 1;
   static const word HEIGHT_BITS = 8 - KIND_BITS;
@@ -922,7 +922,7 @@ class Method {
     if (arity < 0 || arity > ARITY_MASK) {
       FATAL("Method arity out of range: %d", arity);
     }
-    bytes_[ARITY_OFFSET] = arity;
+    bytes_[ARITY_AND_FLAGS_OFFSET] = arity;
   }
   void _set_kind_height(Kind kind, int max_height) {
     // We need two bits for the kind.

--- a/src/objects.h
+++ b/src/objects.h
@@ -806,11 +806,15 @@ class Method {
   bool is_lambda_method() const { return kind_() == LAMBDA; }
   bool is_block_method() const { return  kind_() == BLOCK; }
 
-  int arity() const { return bytes_[ARITY_OFFSET]; }
+  int arity() const { return bytes_[ARITY_OFFSET] & ARITY_MASK; }
   int captured_count() const { return value_(); }
   int selector_offset() const {
     int value = value_();
-    return value == UINT16_MAX ? -1 : value;
+    if (value == NO_SELECTOR) return -1;
+    if ((bytes_[ARITY_OFFSET] & STATICALLY_RESOLVED_INSTANCE_BIT) != 0) {
+      return value - (UINT16_MAX + 1);
+    }
+    return value;
   }
   uint8* entry() const { return &bytes_[ENTRY_OFFSET]; }
   int max_height() const { return (bytes_[KIND_HEIGHT_OFFSET] >> KIND_BITS) * 4; }
@@ -836,15 +840,29 @@ class Method {
   }
 
   void _initialize_method(word selector_offset, bool is_field_accessor, int arity, List<uint8> bytecodes, int max_height) {
-    // The runtime uses UINT16_MAX to identify non-virtual methods. The compiler
-    // keeps their exact negative selector offsets in separate metadata.
-    if (selector_offset >= UINT16_MAX) {
+    // Statically resolved instance methods use negative selector offsets to
+    // encode a class-check-table index. Preserve the signed 16-bit value in
+    // the value field and mark it with the high bit of the arity field. This
+    // keeps it distinct from positive selector offsets.
+    bool is_statically_resolved_instance = selector_offset < -1;
+    word encoded_selector_offset = selector_offset;
+    if (is_statically_resolved_instance) {
+      if (selector_offset < INT16_MIN) {
+        FATAL("Selector offset too small: %" PRIdPTR, selector_offset);
+      }
+      encoded_selector_offset += UINT16_MAX + 1;
+    } else if (selector_offset == -1) {
+      encoded_selector_offset = NO_SELECTOR;
+    } else if (selector_offset >= NO_SELECTOR) {
       FATAL("Selector offset too big: %" PRIdPTR, selector_offset);
     }
-    if (selector_offset < 0) selector_offset = UINT16_MAX;
     Kind kind = is_field_accessor ? FIELD_ACCESSOR : METHOD;
-    _initialize(kind, selector_offset, arity, bytecodes, max_height);
+    _initialize(kind, encoded_selector_offset, arity, bytecodes, max_height);
+    if (is_statically_resolved_instance) {
+      bytes_[ARITY_OFFSET] |= STATICALLY_RESOLVED_INSTANCE_BIT;
+    }
     ASSERT(this->arity() == arity);
+    ASSERT(this->selector_offset() == selector_offset);
   }
 
   friend class compiler::ProgramBuilder;
@@ -858,6 +876,9 @@ class Method {
   static const word VALUE_OFFSET = KIND_HEIGHT_OFFSET + BYTE_SIZE;
   static const word ENTRY_OFFSET = VALUE_OFFSET + 2;
   static const word HEADER_SIZE = ENTRY_OFFSET;
+  static const int STATICALLY_RESOLVED_INSTANCE_BIT = 1 << (BYTE_BIT_SIZE - 1);
+  static const int ARITY_MASK = STATICALLY_RESOLVED_INSTANCE_BIT - 1;
+  static const int NO_SELECTOR = UINT16_MAX;
 
   uint8* bytes_;
 
@@ -898,7 +919,9 @@ class Method {
   }
 
   void _set_arity(int arity) {
-    ASSERT(arity <= 0xFF);
+    if (arity < 0 || arity > ARITY_MASK) {
+      FATAL("Method arity out of range: %d", arity);
+    }
     bytes_[ARITY_OFFSET] = arity;
   }
   void _set_kind_height(Kind kind, int max_height) {

--- a/tests/hw/esp32/short-sleep-test.toit
+++ b/tests/hw/esp32/short-sleep-test.toit
@@ -9,6 +9,7 @@ import .test
 PARALLEL-TASKS ::= 40
 SLEEPS-PER-TASK ::= 20
 PARALLEL-LATENCY-LIMIT-US ::= 10_000
+MAX-PARALLEL-WORKERS-ABOVE-LIMIT ::= PARALLEL-TASKS / 10
 
 main:
   run-test: test
@@ -46,10 +47,12 @@ test-parallel:
   // Under load, this also measures the time it takes the scheduler to run a
   // woken task. Use the old 10ms tick as the limit rather than requiring the
   // same absolute latency from sleeps whose requested durations vary from 1
-  // to 5ms.
+  // to 5ms. Allow a small scheduler tail, but require 90% of the workers to
+  // beat the old tick.
   message := "Only $low-latency-workers/$PARALLEL-TASKS workers slept for less than "
   message += "$(PARALLEL-LATENCY-LIMIT-US)us: $(results.values)"
-  expect low-latency-workers >= PARALLEL-TASKS * 3 / 4 --message=message
+  expect low-latency-workers >= PARALLEL-TASKS - MAX-PARALLEL-WORKERS-ABOVE-LIMIT
+      --message=message
 
 run-sleeper index/int -> int:
   requested-ms := 1 + index % 5

--- a/tests/hw/esp32/short-sleep-test.toit
+++ b/tests/hw/esp32/short-sleep-test.toit
@@ -8,6 +8,7 @@ import .test
 
 PARALLEL-TASKS ::= 40
 SLEEPS-PER-TASK ::= 20
+PARALLEL-LATENCY-LIMIT-US ::= 10_000
 
 main:
   run-test: test
@@ -41,11 +42,14 @@ test-parallel:
   expect-equals PARALLEL-TASKS results.size
   low-latency-workers := 0
   results.values.do: |minimum-us/int|
-    if minimum-us < 6_000: low-latency-workers++
-  // The 10ms FreeRTOS tick would keep every worker above this limit. Allow
-  // some workers to suffer scheduling jitter while requiring concurrent
-  // short sleeps to consistently avoid tick quantization.
-  expect low-latency-workers >= PARALLEL-TASKS * 3 / 4
+    if minimum-us < PARALLEL-LATENCY-LIMIT-US: low-latency-workers++
+  // Under load, this also measures the time it takes the scheduler to run a
+  // woken task. Use the old 10ms tick as the limit rather than requiring the
+  // same absolute latency from sleeps whose requested durations vary from 1
+  // to 5ms.
+  message := "Only $low-latency-workers/$PARALLEL-TASKS workers slept for less than "
+  message += "$(PARALLEL-LATENCY-LIMIT-US)us: $(results.values)"
+  expect low-latency-workers >= PARALLEL-TASKS * 3 / 4 --message=message
 
 run-sleeper index/int -> int:
   requested-ms := 1 + index % 5

--- a/tools/snapshot.toit
+++ b/tools/snapshot.toit
@@ -504,14 +504,17 @@ class ToitMethod:
   max-height ::= 0
   value  ::= 0
   bytecodes / ByteArray := ?
+  is-statically-resolved-instance-method / bool := false
 
   constructor all-bytecodes/ByteArray at/int bytecode-size/int:
     id = at
-    arity = all-bytecodes[at++]
+    encoded-arity := all-bytecodes[at++]
     kind-height := all-bytecodes[at++]
     kind       = kind-height & 0x3
     max-height = (kind-height >> 2) * 4
     value = LITTLE-ENDIAN.uint16 all-bytecodes at
+    is-statically-resolved-instance-method = (encoded-arity & 0x80) != 0
+    arity = encoded-arity & 0x7f
     at += 2
     assert: at - id == HEADER-SIZE
     bytecodes = all-bytecodes.copy at (at + bytecode-size)
@@ -525,7 +528,9 @@ class ToitMethod:
     return HEADER-SIZE + bytecodes.size
 
   selector-offset:
-    return value == 0xffff ? -1 : value
+    if is-statically-resolved-instance-method: return value - 0x1_0000
+    if value == 0xffff: return -1
+    return value
 
   absolute-entry-bci -> int:
     return id + HEADER-SIZE

--- a/tools/snapshot.toit
+++ b/tools/snapshot.toit
@@ -508,13 +508,13 @@ class ToitMethod:
 
   constructor all-bytecodes/ByteArray at/int bytecode-size/int:
     id = at
-    encoded-arity := all-bytecodes[at++]
+    arity-and-flags := all-bytecodes[at++]
     kind-height := all-bytecodes[at++]
     kind       = kind-height & 0x3
     max-height = (kind-height >> 2) * 4
     value = LITTLE-ENDIAN.uint16 all-bytecodes at
-    is-statically-resolved-instance-method = (encoded-arity & 0x80) != 0
-    arity = encoded-arity & 0x7f
+    is-statically-resolved-instance-method = (arity-and-flags & 0x80) != 0
+    arity = arity-and-flags & 0x7f
     at += 2
     assert: at - id == HEADER-SIZE
     bytecodes = all-bytecodes.copy at (at + bytecode-size)

--- a/tools/snapshot.toit
+++ b/tools/snapshot.toit
@@ -528,7 +528,7 @@ class ToitMethod:
     return HEADER-SIZE + bytecodes.size
 
   selector-offset:
-    if is-statically-resolved-instance-method: return value - 0x1_0000
+    if is-statically-resolved-instance-method: return -value
     if value == 0xffff: return -1
     return value
 


### PR DESCRIPTION
## Summary

- preserve exact negative selector offsets in runtime method headers using magnitude encoding
- let runtime type propagation recover the receiver class range for statically resolved instance calls
- update the snapshot decoder for the compact method-header encoding
- make the parallel ESP32 short-sleep assertion measure the 10ms tick regression instead of scheduler latency against a fixed 6ms cutoff

## Type-propagation crash

The runtime method-header change in #3105 mapped every negative selector offset to the same `0xffff` value. Compile-time propagation still had the exact offsets in `MethodSelectorOffsets`, but runtime propagation did not. It consequently treated statically resolved instance methods as ordinary static methods.

In the failing firmware-tool snapshot this widened the receiver of `Heap.store` to `any`, made propagation enter a compiler-proven-impossible path, and let it continue past the method boundary. The following method header was interpreted as a `POP_LOAD_LOCAL`, underflowing the type stack and causing the segmentation fault.

This change retains the four-byte method header. Negative instance selector offsets are stored by magnitude in the 16-bit value field; the high bit of the combined arity-and-flags byte means to negate that value when decoding it. This preserves the full negative magnitude range (`-2` through `-65535`), positive offsets through `65534`, and the unmarked `0xffff` static-method sentinel. The runtime type propagator can therefore use the original class-check range again. The representation now has an explicit maximum method arity of 127.

The new `semver` import in `firmware.toit` only exposed the compiler bug; it is left intact.

## ESP32 short sleeps

On a classic ESP32 the single-sleeper assertion passes, while the original parallel assertion consistently reports only 27-28 of 40 workers below 6ms. Instrumentation showed that all workers get a minimum below 10ms.

With 40 concurrent workers, the measurement includes the delay before the scheduler runs each woken task. A fixed 6ms cutoff gives a 1ms sleeper 5ms of dispatch slack but a 5ms sleeper only 1ms. The updated parallel check retains 40 workers and 800 sleeps, uses the old 10ms FreeRTOS tick as the regression boundary, and allows at most 10% of workers above that boundary. The tighter unloaded check remains unchanged.

## Verification

- `make HOST=host-ctp TOOLCHAIN=host TOIT_CHECK_PROPAGATED_TYPES=1 sdk`
- `make sdk`
- `make esp32`
- `tests/firmware-map-test.toit`
- `tests/toit/snapshot-to-image-test.toit`
- classic ESP32 `short-sleep-test.toit-esp32`, six consecutive runs

The broader host CTest sweep passed 967/995 tests. The remaining failures were environmental in the sandbox: denied socket operations, standalone test executables not built by the SDK target, and a PTY timeout.
