### PR TITLE
Add AES-CMAC support

### DIFF
--- a/lib/crypto/cmac.toit
+++ b/lib/crypto/cmac.toit
@@ -1,0 +1,69 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the lib/LICENSE file.
+
+import crypto.aes show AesEcb
+
+import ..io as io
+
+BLOCK-SIZE_ ::= 16
+SUBKEY-CONSTANT_ ::= 0x87
+
+/**
+Computes an AES-CMAC authentication code for $data using $key.
+
+The $key must contain 16, 24, or 32 bytes.
+*/
+cmac -> ByteArray
+    --key/ByteArray
+    data/io.Data:
+  bytes := ByteArray data.byte-size
+  data.write-to-byte-array bytes --at=0 0 data.byte-size
+
+  cipher := AesEcb.encryptor key
+  try:
+    zero := ByteArray BLOCK-SIZE_
+    encrypted-zero := cipher.encrypt zero
+    first-subkey := subkey_ encrypted-zero
+    second-subkey := subkey_ first-subkey
+    complete := bytes.size > 0 and bytes.size % BLOCK-SIZE_ == 0
+    block-count := max 1 ((bytes.size + BLOCK-SIZE_ - 1) / BLOCK-SIZE_)
+
+    last := ByteArray BLOCK-SIZE_
+    if complete:
+      last.replace 0 bytes bytes.size - BLOCK-SIZE_ bytes.size
+      xor_ last first-subkey
+    else:
+      remainder := bytes.size % BLOCK-SIZE_
+      if remainder > 0:
+        last.replace 0 bytes bytes.size - remainder bytes.size
+      last[remainder] = 0x80
+      xor_ last second-subkey
+
+    state := ByteArray BLOCK-SIZE_
+    (block-count - 1).repeat: |index|
+      block := bytes[index * BLOCK-SIZE_..(index + 1) * BLOCK-SIZE_]
+      xor_ block state
+      state = cipher.encrypt block
+    xor_ last state
+    return cipher.encrypt last
+  finally:
+    cipher.close
+
+subkey_ -> ByteArray
+    input/ByteArray:
+  output := ByteArray BLOCK-SIZE_
+  carry := 0
+  BLOCK-SIZE_.repeat: |offset|
+    index := BLOCK-SIZE_ - 1 - offset
+    value := input[index]
+    output[index] = (value << 1) & 0xff | carry
+    carry = value >> 7
+  if input[0] & 0x80 != 0:
+    output[BLOCK-SIZE_ - 1] ^= SUBKEY-CONSTANT_
+  return output
+
+xor_ -> none
+    target/ByteArray
+    other/ByteArray:
+  target.size.repeat: |index| target[index] ^= other[index]

--- a/src/primitive_crypto.cc
+++ b/src/primitive_crypto.cc
@@ -740,11 +740,13 @@ PRIMITIVE(aes_ecb_crypt) {
 
   ByteArray::Bytes output_bytes(result);
 
-  mbedtls_aes_crypt_ecb(
-      &context->context_,
-      encrypt ? MBEDTLS_AES_ENCRYPT : MBEDTLS_AES_DECRYPT,
-      input.address(),
-      output_bytes.address());
+  for (word offset = 0; offset < input.length(); offset += AesContext::AES_BLOCK_SIZE) {
+    mbedtls_aes_crypt_ecb(
+        &context->context_,
+        encrypt ? MBEDTLS_AES_ENCRYPT : MBEDTLS_AES_DECRYPT,
+        input.address() + offset,
+        output_bytes.address() + offset);
+  }
 
   return result;
 }

--- a/tests/crypto-aes-test.toit
+++ b/tests/crypto-aes-test.toit
@@ -98,6 +98,15 @@ test-aes-ecb:
   expect.expect-bytes-equal
       PLAINTEXT
       (decryptor.decrypt ECB-CIPHERTEXT32)
+
+  plaintext := ByteArray 32
+  plaintext.replace 0 PLAINTEXT
+  plaintext.replace 16 PLAINTEXT
+  expected := ByteArray 32
+  expected.replace 0 ECB-CIPHERTEXT32
+  expected.replace 16 ECB-CIPHERTEXT32
+  expect.expect-bytes-equal expected (encryptor.encrypt plaintext)
+  expect.expect-bytes-equal plaintext (decryptor.decrypt expected)
   
   // Repeat with 192 bit key.
   encryptor = aes.AesEcb.encryptor

--- a/tests/crypto-cmac-test.toit
+++ b/tests/crypto-cmac-test.toit
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can be
+// found in the tests/LICENSE file.
+
+import crypto.cmac show cmac
+import encoding.hex as hex
+import expect show *
+
+main:
+  key := hex.decode "2b7e151628aed2a6abf7158809cf4f3c"
+  verify_ key "" "bb1d6929e95937287fa37d129b756746"
+  verify_ key
+      "6bc1bee22e409f96e93d7e117393172a"
+      "070a16b46b4d4144f79bdd9dd04a287c"
+  verify_ key
+      "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411"
+      "dfa66747de9ae63030ca32611497c827"
+  verify_ key
+      "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710"
+      "51f0bebf7e3b9d92fc49741779363cfe"
+
+verify_ -> none
+    key/ByteArray
+    message/string
+    expected/string:
+  expect-equals (hex.decode expected) (cmac --key=key (hex.decode message))


### PR DESCRIPTION
Adds a one-shot `crypto.cmac` API backed by AES-ECB and covers the four RFC 4493 examples.

The first commit also fixes the existing AES-ECB primitive to process every block in a multi-block input; previously it only wrote the first 16 output bytes. A 32-byte encrypt/decrypt regression test covers that behavior.

Tested with:
- `toit analyze -Werror tests/crypto-cmac-test.toit tests/crypto-aes-test.toit`
- `toit run tests/crypto-aes-test.toit`
- `toit run tests/crypto-cmac-test.toit`