### PR TITLE
Fix SDK library path in info output

### DIFF
--- a/tests/toit/info-test.toit
+++ b/tests/toit/info-test.toit
@@ -4,6 +4,7 @@
 
 import encoding.json
 import expect show *
+import fs
 import host.file
 import system
 
@@ -28,7 +29,9 @@ test-info-sdk toit-exe/ToitExecutable:
   parsed := json.parse json-output
   expect-equals system.vm-sdk-version parsed["version"]
   expect (parsed.contains "path")
-  expect (parsed.contains "lib-path")
+  expect-equals
+      (fs.join parsed["path"] "lib" "toit" "lib")
+      parsed["lib-path"]
   expect (parsed.contains "bin-path")
   expect (parsed.contains "platform")
   expect-equals system.platform parsed["platform"]

--- a/tools/info.toit
+++ b/tools/info.toit
@@ -77,7 +77,7 @@ info-sdk invocation/cli.Invocation --sdk-dir-from-args/Lambda:
   result := {
     "version": system.vm-sdk-version,
     "path": sdk-dir,
-    "lib-path": fs.join sdk-dir "lib",
+    "lib-path": fs.join sdk-dir "lib" "toit" "lib",
     "bin-path": fs.join sdk-dir "bin",
     "platform": system.platform,
   }


### PR DESCRIPTION
## Summary

- report the installed SDK library directory from `toit info sdk`
- verify the exact `lib-path` value in the SDK info test

## Testing

- `ctest --test-dir build/host -C slow --output-on-failure -R "^tests/toit/info-test\.toit$"`
- `toit analyze --project-root tools tools/info.toit`