### PR TITLE
pkg: recompute mismatched lock files

### DIFF
--- a/tests/pkg/assets/not-in-sync/gold/10-more-lock.gold
+++ b/tests/pkg/assets/not-in-sync/gold/10-more-lock.gold
@@ -4,3 +4,11 @@ Aborted
 [pkg, install, pkg3]
 Warning: The following prefixes are only in package.lock: pkg1, pkg2
 Error: The package.yaml file and package.lock file are not in sync.
+==================
+// --recompute should replace the stale lock file.
+==================
+OK
+[pkg, install, --recompute]
+==================
+== package.lock
+# Toit Package File.

--- a/tests/pkg/assets/not-in-sync/gold/20-more-package.gold
+++ b/tests/pkg/assets/not-in-sync/gold/20-more-package.gold
@@ -2,3 +2,30 @@ Aborted
 [pkg, install, pkg3]
 Warning: The following prefixes are only in package.yaml: pkg2
 Error: The package.yaml file and package.lock file are not in sync.
+==================
+// --recompute should add the missing package to the lock file.
+==================
+OK
+[pkg, install, --recompute]
+==================
+== package.lock
+prefixes:
+  pkg1: localhost_<[*PORT*]>/pkg/pkg1-1
+  pkg2: localhost_<[*PORT*]>/pkg/pkg2-2
+packages:
+  localhost_<[*PORT*]>/pkg/pkg1-1:
+    hash: <[*HASH*]>
+    prefixes:
+      pkg2: localhost_<[*PORT*]>/pkg/pkg2-2
+    url: localhost:<[*PORT*]>/pkg/pkg1
+    version: 1.0.0
+  localhost_<[*PORT*]>/pkg/pkg2-2:
+    hash: <[*HASH*]>
+    prefixes:
+      pre: localhost_<[*PORT*]>/pkg/pkg3-3
+    url: localhost:<[*PORT*]>/pkg/pkg2
+    version: 2.4.2
+  localhost_<[*PORT*]>/pkg/pkg3-3:
+    hash: <[*HASH*]>
+    url: localhost:<[*PORT*]>/pkg/pkg3
+    version: 3.1.2

--- a/tests/pkg/not-in-sync-gold-test.toit
+++ b/tests/pkg/not-in-sync-gold-test.toit
@@ -25,6 +25,9 @@ test tester/GoldTester:
   tester.gold "10-more-lock" [
     ["// Should error, as the lock file has more entries"],
     ["pkg", "install", "pkg3"],
+    ["// --recompute should replace the stale lock file."],
+    ["pkg", "install", "--recompute"],
+    ["package.lock"],
   ]
 
   file.delete package-path
@@ -46,4 +49,7 @@ test tester/GoldTester:
 
   tester.gold "20-more-package" [
     ["pkg", "install", "pkg3"],
+    ["// --recompute should add the missing package to the lock file."],
+    ["pkg", "install", "--recompute"],
+    ["package.lock"],
   ]

--- a/tools/pkg/commands/base_.toit
+++ b/tools/pkg/commands/base_.toit
@@ -46,8 +46,10 @@ class PkgCommand:
 class PkgProjectCommand extends PkgCommand:
   project/Project
 
-  constructor invocation/cli.Invocation:
+  constructor invocation/cli.Invocation --allow-lock-file-mismatch/bool=false:
     config := project-configuration-from-cli invocation
     config.verify
-    project = Project config --ui=invocation.cli.ui
+    project = Project config
+        --ui=invocation.cli.ui
+        --allow-lock-file-mismatch=allow-lock-file-mismatch
     super invocation

--- a/tools/pkg/commands/install.toit
+++ b/tools/pkg/commands/install.toit
@@ -69,7 +69,7 @@ class InstallCommand extends PkgProjectCommand:
     config := project-configuration-from-cli invocation
     config.verify
 
-    super invocation
+    super invocation --allow-lock-file-mismatch=recompute
 
   execute:
     if packages.is-empty:

--- a/tools/pkg/project/project.toit
+++ b/tools/pkg/project/project.toit
@@ -77,6 +77,7 @@ class Project:
 
   constructor .config/ProjectConfiguration
       --empty-lock-file/bool=false
+      --allow-lock-file-mismatch/bool=false
       --ui/cli.Ui:
     ui_ = ui
 
@@ -93,7 +94,7 @@ class Project:
     else if empty-lock-file:
       lock-file = LockFile specification
 
-    if config.lock-file-exists:
+    if config.lock-file-exists and not allow-lock-file-mismatch:
       assert: config.specification-file-exists
       // Check that the two files are (mostly) in sync.
       only-in-lock-file := []


### PR DESCRIPTION
## Summary

- allow `pkg install --recompute` to load projects whose package specification and lock file have different prefixes
- preserve the mismatch error for normal package commands
- cover stale locks with prefixes missing from either `package.yaml` or `package.lock`

## Testing

- `toit analyze --project-root tools tools/pkg/project/project.toit tools/pkg/commands/base_.toit tools/pkg/commands/install.toit`
- `toit analyze --project-root tests/pkg tests/pkg/not-in-sync-gold-test.toit`
- focused package tests: `install-local-project-root`, `install2`, `not-in-sync`, and `sdk-version3`