### PR TITLE
QEMU: initialize stdin before readiness marker

### DIFF
--- a/tests/qemu/stdio.toit
+++ b/tests/qemu/stdio.toit
@@ -5,8 +5,11 @@
 import io
 
 main:
+  // Initialize stdin before announcing readiness.
+  // The ESP32 UART driver flushes pending input when installed.
+  input := io.stdin
   io.stdout.write "STDIO-READY\n"
-  data := io.stdin.read-line --keep-newline
+  data := input.read-line --keep-newline
   io.stdout.write "STDOUT:"
   if data: io.stdout.write data
   io.stderr.write "STDERR:"


### PR DESCRIPTION
## Summary

- initialize io.stdin before emitting STDIO-READY
- prevent the ESP32 UART driver installation flush from discarding test input
- make the QEMU readiness marker accurately signal that stdin can receive data

This addresses the flake observed in https://github.com/toitlang/toit/actions/runs/32194859438/job/95897650489. The guest booted and emitted STDIO-READY, but the harness input could arrive before lazy stdin initialization completed.

## Testing

- git diff --check
- Full QEMU coverage is left to CI because the local checkout does not have the required ESP32 firmware envelopes.