### PR TITLE
pkg: allow updating legacy packages without metadata

### DIFF
--- a/tests/pkg/assets/shared/GIT-SERVE-PKGS/pkg3/v3.1.2/package.yaml
+++ b/tests/pkg/assets/shared/GIT-SERVE-PKGS/pkg3/v3.1.2/package.yaml
@@ -1,2 +1,1 @@
-name: pkg3
-description: git-package 3
+# Legacy package without required publication metadata.

--- a/tests/pkg/update-gold-test.toit
+++ b/tests/pkg/update-gold-test.toit
@@ -17,6 +17,8 @@ test tester/GoldTester:
     ["pkg", "init"],
   ]
 
+  // pkg3@3.1.2 is a legacy published package without the metadata that is
+  // required for new publications.
   tester.gold "20-test" [
     ["pkg", "registry", "add", "test-reg", registry1],
     ["pkg", "list"],

--- a/tools/pkg/project/lock.toit
+++ b/tools/pkg/project/lock.toit
@@ -297,7 +297,6 @@ class LockFileBuilder:
       versions.do: | version/SemanticVersion |
         specification := project_.load-package-specification url version
         update-sdk-version.call specification.sdk-version
-        name := specification.name
         hash := project_.hash-for --url=url --version=version --registries=registries
         id-prefix := url-id-prefixes-map_[url]
         // Major versions are separate solver packages and may coexist in one


### PR DESCRIPTION
## Summary

- stop requiring the unused package name while rebuilding lock files
- allow projects to update through legacy published packages missing current metadata
- retain strict publication checks for name, description, and license

## Tests

- `build/host/sdk/bin/toit tests/pkg/update-gold-test.toit build/host/sdk/bin/toit`
- `build/host/sdk/bin/toit tests/pkg/describe-gold-test.toit build/host/sdk/bin/toit`
- `build/host/sdk/bin/toit pkg update --project-root tests/hw/esp32` (verified on a temporary project copy)
- `build/host/sdk/bin/toit analyze tools/pkg/project/lock.toit tests/pkg/update-gold-test.toit`
- `git diff --check`