### PR TITLE
Use import paths in package diagnostics

### DIFF
--- a/src/compiler/lock.cc
+++ b/src/compiler/lock.cc
@@ -13,8 +13,9 @@
 // The license can be found in the file `LICENSE` in the top level
 // directory of this repository.
 
-#include <string>
+#include <deque>
 #include <limits.h>
+#include <string>
 
 #include "third_party/libyaml/include/yaml.h"
 #include "third_party/nlohmann/json.hpp"
@@ -224,6 +225,78 @@ namespace {  // Anonymous.
       };
     }
   };
+
+  struct ImportPath {
+    int depth;
+    std::string path;
+  };
+}
+
+static bool is_better_import_path(const ImportPath& candidate,
+                                  const ImportPath& current) {
+  if (candidate.depth != current.depth) return candidate.depth < current.depth;
+  if (candidate.path.size() != current.path.size()) {
+    return candidate.path.size() < current.path.size();
+  }
+  return candidate.path < current.path;
+}
+
+// Finds the shortest prefix path from the entry package to each dependency.
+// Prefer shorter spellings and then lexical order when several paths have the
+// same number of imports, so diagnostic paths are deterministic.
+static Map<std::string, std::string> build_diagnostic_package_ids(
+    const LockFileContent& lock_content) {
+  Map<std::string, ImportPath> shortest_paths;
+  std::deque<std::string> worklist;
+
+  shortest_paths[Package::ENTRY_PACKAGE_ID] = { 0, "" };
+  worklist.push_back(Package::ENTRY_PACKAGE_ID);
+
+  while (!worklist.empty()) {
+    auto owner = worklist.front();
+    worklist.pop_front();
+    auto owner_path = shortest_paths.at(owner);
+
+    auto prefixes_probe = lock_content.prefixes.find(owner);
+    if (prefixes_probe == lock_content.prefixes.end()) continue;
+    const auto& prefixes = prefixes_probe->second;
+    for (auto prefix : prefixes.keys()) {
+      auto target = prefixes.at(prefix);
+      if (!lock_content.packages.contains_key(target)) continue;
+
+      auto path = owner_path.path.empty()
+          ? prefix
+          : owner_path.path + "/" + prefix;
+      ImportPath candidate = { owner_path.depth + 1, path };
+      auto current_probe = shortest_paths.find(target);
+      if (current_probe != shortest_paths.end() &&
+          !is_better_import_path(candidate, current_probe->second)) {
+        continue;
+      }
+      shortest_paths[target] = candidate;
+      worklist.push_back(target);
+    }
+  }
+
+  Map<std::string, int> name_counts;
+  for (auto package_id : lock_content.packages.keys()) {
+    auto name = lock_content.packages.at(package_id).name;
+    if (!name.empty()) name_counts[name]++;
+  }
+
+  Map<std::string, std::string> result;
+  for (auto package_id : lock_content.packages.keys()) {
+    auto path_probe = shortest_paths.find(package_id);
+    if (path_probe != shortest_paths.end()) {
+      result[package_id] = path_probe->second.path;
+      continue;
+    }
+    auto name = lock_content.packages.at(package_id).name;
+    result[package_id] = !name.empty() && name_counts.at(name) == 1
+        ? name
+        : package_id;
+  }
+  return result;
 }
 
 static bool is_valid_package_id(const std::string& package_id) {
@@ -1120,6 +1193,11 @@ PackageLock PackageLock::read(const std::string& lock_file_path,
     }
     packages[package_id] = package;
   }
+  auto diagnostic_package_ids = build_diagnostic_package_ids(lock_content);
+  for (auto package_id : lock_content.packages.keys()) {
+    packages[package_id].diagnostic_id_ = diagnostic_package_ids.at(package_id);
+  }
+
   return PackageLock(lock_content.source,
                      lock_content.sdk_constraint,
                      packages,

--- a/src/compiler/package.cc
+++ b/src/compiler/package.cc
@@ -41,9 +41,10 @@ std::string Package::build_error_path(Filesystem* fs, const std::string& path) c
     builder.join("<sdk>", relative);
     return builder.buffer();
   }
-  // For normal packages we prefix the relative path with the package id.
+  // For normal packages we prefix the relative path with the user-facing
+  // package id.
   PathBuilder builder(fs);
-  builder.join("<pkg:" + id() + ">", relative);
+  builder.join("<pkg:" + diagnostic_id_ + ">", relative);
   return builder.buffer();
 }
 

--- a/src/compiler/package.h
+++ b/src/compiler/package.h
@@ -109,6 +109,7 @@ class Package {
           bool is_path_package)
       : id_(id)
       , name_(name)
+      , diagnostic_id_(id)
       , absolute_path_(absolute_path)
       , absolute_error_path_(absolute_error_path)
       , relative_error_path_(relative_error_path)
@@ -118,6 +119,9 @@ class Package {
 
   std::string id_ = std::string(INVALID_PACKAGE_ID);
   std::string name_ = std::string("");
+  // A user-facing identifier for diagnostics. For packages reachable from the
+  // entry package this is their shortest import path.
+  std::string diagnostic_id_ = std::string(INVALID_PACKAGE_ID);
   std::string absolute_path_ = std::string("");
   // The absolute location of the relative error path.
   // Usually the same as the absolute_path. Can be different for the entry package.

--- a/tests/health/gold/sdk/tests__hw__esp32__dht11-board2.toit.gold
+++ b/tests/health/gold/sdk/tests__hw__esp32__dht11-board2.toit.gold
@@ -1,6 +1,6 @@
-<pkg:github.com/toitware/toit-dhtxx-1>/driver_.toit:43:26: warning: Deprecated type 'Pin' for parameter 'pin'. Provide an integer instead
+<pkg:dhtxx>/driver_.toit:43:26: warning: Deprecated type 'Pin' for parameter 'pin'. Provide an integer instead
     channel-in_ = rmt.In pin --resolution=1_000_000
                          ^~~
-<pkg:github.com/toitware/toit-dhtxx-1>/driver_.toit:44:28: warning: Deprecated type 'Pin' for parameter 'pin'. Provide an integer instead
+<pkg:dhtxx>/driver_.toit:44:28: warning: Deprecated type 'Pin' for parameter 'pin'. Provide an integer instead
     channel-out_ = rmt.Out pin --resolution=1_000_000 --open-drain
                            ^~~

--- a/tests/health/gold/sdk/tests__hw__esp32__ds18b20-board2.toit.gold
+++ b/tests/health/gold/sdk/tests__hw__esp32__ds18b20-board2.toit.gold
@@ -1,6 +1,6 @@
-<pkg:github.com/toitware/toit-1-wire-2>/one_wire.toit:564:26: warning: Deprecated type 'Pin' for parameter 'pin'. Provide an integer instead
+<pkg:ds18b20/one-wire>/one_wire.toit:564:26: warning: Deprecated type 'Pin' for parameter 'pin'. Provide an integer instead
     channel-in_ = rmt.In pin --memory-blocks=memory-blocks --resolution=1_000_000
                          ^~~
-<pkg:github.com/toitware/toit-1-wire-2>/one_wire.toit:565:28: warning: Deprecated type 'Pin' for parameter 'pin'. Provide an integer instead
+<pkg:ds18b20/one-wire>/one_wire.toit:565:28: warning: Deprecated type 'Pin' for parameter 'pin'. Provide an integer instead
     channel-out_ = rmt.Out pin --resolution=1_000_000
                            ^~~

--- a/tests/health/gold/sdk/tests__hw__esp32__ultrasound-board2.toit.gold
+++ b/tests/health/gold/sdk/tests__hw__esp32__ultrasound-board2.toit.gold
@@ -1,6 +1,6 @@
-<pkg:github.com/lask/toit-hc-sr04-2>/driver.toit:49:24: warning: Deprecated type 'Pin' for parameter 'pin'. Provide an integer instead
+<pkg:hc-sr04>/driver.toit:49:24: warning: Deprecated type 'Pin' for parameter 'pin'. Provide an integer instead
     trigger_ = rmt.Out trigger --resolution=1_000_000
                        ^~~~~~~
-<pkg:github.com/lask/toit-hc-sr04-2>/driver.toit:50:20: warning: Deprecated type 'Pin' for parameter 'pin'. Provide an integer instead
+<pkg:hc-sr04>/driver.toit:50:20: warning: Deprecated type 'Pin' for parameter 'pin'. Provide an integer instead
     echo_ = rmt.In echo --resolution=(80_000_000 / 233)
                    ^~~~

--- a/tests/negative/gold/pkg_errors_in_pkg/dynamic-test.gold
+++ b/tests/negative/gold/pkg_errors_in_pkg/dynamic-test.gold
@@ -1,4 +1,4 @@
 EXCEPTION error. 
 throw in pkg
-  0: say-hi                    <pkg:target-1.0>/foo-dynamic.toit:6:3
+  0: say-hi                    <pkg:target>/foo-dynamic.toit:6:3
   1: main                      tests/negative/pkg_errors_in_pkg/dynamic-test.toit:8:9

--- a/tests/negative/gold/pkg_errors_in_pkg/static-test.gold
+++ b/tests/negative/gold/pkg_errors_in_pkg/static-test.gold
@@ -1,4 +1,4 @@
-<pkg:target-1.0>/foo-static.toit:6:3: error: Can't call result of evaluating expression
+<pkg:target>/foo-static.toit:6:3: error: Can't call result of evaluating expression
   "it's" "an error to use a string as target"
   ^~~~~~
 Compilation failed

--- a/tests/negative/gold/pkg_errors_in_pkg/transitive-test.gold
+++ b/tests/negative/gold/pkg_errors_in_pkg/transitive-test.gold
@@ -1,0 +1,4 @@
+<pkg:target/dependency>/foo.toit:6:3: error: Can't call result of evaluating expression
+  "it's" "an error to use a string as target"
+  ^~~~~~
+Compilation failed

--- a/tests/negative/gold/pkg_group_errors_in_pkg/with-package-warnings-test.gold
+++ b/tests/negative/gold/pkg_group_errors_in_pkg/with-package-warnings-test.gold
@@ -1,43 +1,43 @@
-<pkg:target-1.0>/foo.toit:16:3: error: Method 'foo' with overlapping signature
+<pkg:target>/foo.toit:16:3: error: Method 'foo' with overlapping signature
   foo x y=499:
   ^~~
-<pkg:target-1.0>/foo.toit:15:3: note: Overlaps with method 'foo'
+<pkg:target>/foo.toit:15:3: note: Overlaps with method 'foo'
   foo x:
   ^~~
-<pkg:target-1.0>/foo.toit:17:3: note: Overlaps with method 'foo'
+<pkg:target>/foo.toit:17:3: note: Overlaps with method 'foo'
   foo x y=43 z=23:
   ^~~
-<pkg:target-1.0>/foo.toit:17:3: error: Method 'foo' with overlapping signature
+<pkg:target>/foo.toit:17:3: error: Method 'foo' with overlapping signature
   foo x y=43 z=23:
   ^~~
-<pkg:target-1.0>/foo.toit:15:3: note: Overlaps with method 'foo'
+<pkg:target>/foo.toit:15:3: note: Overlaps with method 'foo'
   foo x:
   ^~~
 tests/negative/pkg_group_errors_in_pkg/with-package-warnings-test.toit:8:7: error: Missing implementations for interface methods
 class A implements target.I1:
       ^
-<pkg:target-1.0>/foo.toit:9:3: note: Missing implementation for 'foo'
+<pkg:target>/foo.toit:9:3: note: Missing implementation for 'foo'
   foo -> string
   ^~~
-<pkg:target-1.0>/foo.toit:10:3: note: Missing implementation for 'bar'
+<pkg:target>/foo.toit:10:3: note: Missing implementation for 'bar'
   bar x y
   ^~~
-<pkg:target-1.0>/foo.toit:12:7: error: Missing implementations for interface methods
+<pkg:target>/foo.toit:12:7: error: Missing implementations for interface methods
 class B implements I1:
       ^
-<pkg:target-1.0>/foo.toit:9:3: note: Missing implementation for 'foo'
+<pkg:target>/foo.toit:9:3: note: Missing implementation for 'foo'
   foo -> string
   ^~~
-<pkg:target-1.0>/foo.toit:10:3: note: Missing implementation for 'bar'
+<pkg:target>/foo.toit:10:3: note: Missing implementation for 'bar'
   bar x y
   ^~~
-<pkg:target-1.0>/foo.toit:20:3: error: Ambiguous resolution of 'ambiguous'
+<pkg:target>/foo.toit:20:3: error: Ambiguous resolution of 'ambiguous'
   ambiguous
   ^~~~~~~~~
-<pkg:target-1.0>/bar.toit:5:1: note: Resolution candidate for 'ambiguous'
+<pkg:target>/bar.toit:5:1: note: Resolution candidate for 'ambiguous'
 ambiguous:
 ^~~~~~~~~
-<pkg:target-1.0>/gee.toit:5:1: note: Resolution candidate for 'ambiguous'
+<pkg:target>/gee.toit:5:1: note: Resolution candidate for 'ambiguous'
 ambiguous:
 ^~~~~~~~~
 Compilation failed

--- a/tests/negative/gold/pkg_group_errors_in_pkg/without-package-warnings-test.gold
+++ b/tests/negative/gold/pkg_group_errors_in_pkg/without-package-warnings-test.gold
@@ -1,43 +1,43 @@
-<pkg:target-1.0>/foo.toit:16:3: error: Method 'foo' with overlapping signature
+<pkg:target>/foo.toit:16:3: error: Method 'foo' with overlapping signature
   foo x y=499:
   ^~~
-<pkg:target-1.0>/foo.toit:15:3: note: Overlaps with method 'foo'
+<pkg:target>/foo.toit:15:3: note: Overlaps with method 'foo'
   foo x:
   ^~~
-<pkg:target-1.0>/foo.toit:17:3: note: Overlaps with method 'foo'
+<pkg:target>/foo.toit:17:3: note: Overlaps with method 'foo'
   foo x y=43 z=23:
   ^~~
-<pkg:target-1.0>/foo.toit:17:3: error: Method 'foo' with overlapping signature
+<pkg:target>/foo.toit:17:3: error: Method 'foo' with overlapping signature
   foo x y=43 z=23:
   ^~~
-<pkg:target-1.0>/foo.toit:15:3: note: Overlaps with method 'foo'
+<pkg:target>/foo.toit:15:3: note: Overlaps with method 'foo'
   foo x:
   ^~~
 tests/negative/pkg_group_errors_in_pkg/without-package-warnings-test.toit:7:7: error: Missing implementations for interface methods
 class A implements target.I1:
       ^
-<pkg:target-1.0>/foo.toit:9:3: note: Missing implementation for 'foo'
+<pkg:target>/foo.toit:9:3: note: Missing implementation for 'foo'
   foo -> string
   ^~~
-<pkg:target-1.0>/foo.toit:10:3: note: Missing implementation for 'bar'
+<pkg:target>/foo.toit:10:3: note: Missing implementation for 'bar'
   bar x y
   ^~~
-<pkg:target-1.0>/foo.toit:12:7: error: Missing implementations for interface methods
+<pkg:target>/foo.toit:12:7: error: Missing implementations for interface methods
 class B implements I1:
       ^
-<pkg:target-1.0>/foo.toit:9:3: note: Missing implementation for 'foo'
+<pkg:target>/foo.toit:9:3: note: Missing implementation for 'foo'
   foo -> string
   ^~~
-<pkg:target-1.0>/foo.toit:10:3: note: Missing implementation for 'bar'
+<pkg:target>/foo.toit:10:3: note: Missing implementation for 'bar'
   bar x y
   ^~~
-<pkg:target-1.0>/foo.toit:20:3: error: Ambiguous resolution of 'ambiguous'
+<pkg:target>/foo.toit:20:3: error: Ambiguous resolution of 'ambiguous'
   ambiguous
   ^~~~~~~~~
-<pkg:target-1.0>/bar.toit:5:1: note: Resolution candidate for 'ambiguous'
+<pkg:target>/bar.toit:5:1: note: Resolution candidate for 'ambiguous'
 ambiguous:
 ^~~~~~~~~
-<pkg:target-1.0>/gee.toit:5:1: note: Resolution candidate for 'ambiguous'
+<pkg:target>/gee.toit:5:1: note: Resolution candidate for 'ambiguous'
 ambiguous:
 ^~~~~~~~~
 Compilation failed

--- a/tests/negative/gold/pkg_not_found/main-test.gold
+++ b/tests/negative/gold/pkg_not_found/main-test.gold
@@ -7,25 +7,25 @@ import error
 tests/negative/pkg_not_found/main-test.toit:6:1: error: Failed to import 'error2'
 import error2
 ^~~~~~
-tests/negative/pkg_not_found/main-test.toit:6:8: note: Folder '<pkg:path2>/.' exists, but is missing a 'error2.toit' file
+tests/negative/pkg_not_found/main-test.toit:6:8: note: Folder '<pkg:error2>/.' exists, but is missing a 'error2.toit' file
 import error2
        ^~~~~~
 tests/negative/pkg_not_found/main-test.toit:7:1: error: Failed to import 'error2.foo'
 import error2.foo
 ^~~~~~
-tests/negative/pkg_not_found/main-test.toit:7:15: note: Missing library file. Tried '<pkg:path2>/foo.toit' and '<pkg:path2>/foo/foo.toit'
+tests/negative/pkg_not_found/main-test.toit:7:15: note: Missing library file. Tried '<pkg:error2>/foo.toit' and '<pkg:error2>/foo/foo.toit'
 import error2.foo
               ^~~
 tests/negative/pkg_not_found/main-test.toit:8:1: error: Failed to import 'error2.foo.bar'
 import error2.foo.bar
 ^~~~~~
-tests/negative/pkg_not_found/main-test.toit:8:15: note: Cannot enter '<pkg:path2>/foo': folder does not exist
+tests/negative/pkg_not_found/main-test.toit:8:15: note: Cannot enter '<pkg:error2>/foo': folder does not exist
 import error2.foo.bar
               ^~~
 tests/negative/pkg_not_found/main-test.toit:9:1: error: Failed to import 'error2.not-a-directory.bar'
 import error2.not-a-directory.bar
 ^~~~~~
-tests/negative/pkg_not_found/main-test.toit:9:15: note: Cannot enter '<pkg:path2>/not_a_directory': not a folder
+tests/negative/pkg_not_found/main-test.toit:9:15: note: Cannot enter '<pkg:error2>/not_a_directory': not a folder
 import error2.not-a-directory.bar
               ^~~~~~~~~~~~~~~
 tests/negative/pkg_not_found/main-test.toit:12:15: error: Unresolved identifier: 'foo'

--- a/tests/negative/gold/pkg_not_found/relative-test.gold
+++ b/tests/negative/gold/pkg_not_found/relative-test.gold
@@ -7,25 +7,25 @@ import error
 tests/negative/pkg_not_found/dir/dir.toit:6:1: error: Failed to import 'error2'
 import error2
 ^~~~~~
-tests/negative/pkg_not_found/dir/dir.toit:6:8: note: Folder '<pkg:path2>/.' exists, but is missing a 'error2.toit' file
+tests/negative/pkg_not_found/dir/dir.toit:6:8: note: Folder '<pkg:error2>/.' exists, but is missing a 'error2.toit' file
 import error2
        ^~~~~~
 tests/negative/pkg_not_found/dir/dir.toit:7:1: error: Failed to import 'error2.foo'
 import error2.foo
 ^~~~~~
-tests/negative/pkg_not_found/dir/dir.toit:7:15: note: Missing library file. Tried '<pkg:path2>/foo.toit' and '<pkg:path2>/foo/foo.toit'
+tests/negative/pkg_not_found/dir/dir.toit:7:15: note: Missing library file. Tried '<pkg:error2>/foo.toit' and '<pkg:error2>/foo/foo.toit'
 import error2.foo
               ^~~
 tests/negative/pkg_not_found/dir/dir.toit:8:1: error: Failed to import 'error2.foo.bar'
 import error2.foo.bar
 ^~~~~~
-tests/negative/pkg_not_found/dir/dir.toit:8:15: note: Cannot enter '<pkg:path2>/foo': folder does not exist
+tests/negative/pkg_not_found/dir/dir.toit:8:15: note: Cannot enter '<pkg:error2>/foo': folder does not exist
 import error2.foo.bar
               ^~~
 tests/negative/pkg_not_found/dir/dir.toit:9:1: error: Failed to import 'error2.not-a-directory.bar'
 import error2.not-a-directory.bar
 ^~~~~~
-tests/negative/pkg_not_found/dir/dir.toit:9:15: note: Cannot enter '<pkg:path2>/not_a_directory': not a folder
+tests/negative/pkg_not_found/dir/dir.toit:9:15: note: Cannot enter '<pkg:error2>/not_a_directory': not a folder
 import error2.not-a-directory.bar
               ^~~~~~~~~~~~~~~
 Compilation failed

--- a/tests/negative/gold/pkg_rel_not_found/main-test.gold
+++ b/tests/negative/gold/pkg_rel_not_found/main-test.gold
@@ -1,7 +1,7 @@
 tests/negative/pkg_rel_not_found/main-test.toit:5:1: error: Failed to import 'pre.not-exist'
 import pre.not-exist as pre
 ^~~~~~
-tests/negative/pkg_rel_not_found/main-test.toit:5:12: note: Missing library file. Tried '<pkg:nested/id>/not_exist.toit' and '<pkg:nested/id>/not_exist/not-exist.toit'
+tests/negative/pkg_rel_not_found/main-test.toit:5:12: note: Missing library file. Tried '<pkg:pre>/not_exist.toit' and '<pkg:pre>/not_exist/not-exist.toit'
 import pre.not-exist as pre
            ^~~~~~~~~
 tests/negative/pkg_rel_not_found/main-test.toit:8:13: error: Unresolved identifier: 'foo'

--- a/tests/negative/gold/pkg_warnings_in_local_pkg/with-package-warnings-test.gold
+++ b/tests/negative/gold/pkg_warnings_in_local_pkg/with-package-warnings-test.gold
@@ -1,4 +1,4 @@
-<pkg:target-1.0>/foo.toit:9:3: warning: Deprecated 'deprecated'
+<pkg:target>/foo.toit:9:3: warning: Deprecated 'deprecated'
   deprecated
   ^~~~~~~~~~
 Compilation failed

--- a/tests/negative/gold/pkg_warnings_in_local_pkg/without-package-warnings-test.gold
+++ b/tests/negative/gold/pkg_warnings_in_local_pkg/without-package-warnings-test.gold
@@ -1,5 +1,5 @@
 should still be a warning, as they are in a local package
 hello
-<pkg:target-1.0>/foo.toit:9:3: warning: Deprecated 'deprecated'
+<pkg:target>/foo.toit:9:3: warning: Deprecated 'deprecated'
   deprecated
   ^~~~~~~~~~

--- a/tests/negative/gold/pkg_warnings_in_pkg/with-package-warnings-test.gold
+++ b/tests/negative/gold/pkg_warnings_in_pkg/with-package-warnings-test.gold
@@ -1,4 +1,4 @@
-<pkg:target-1.0>/foo.toit:9:3: warning: Deprecated 'deprecated'
+<pkg:target>/foo.toit:9:3: warning: Deprecated 'deprecated'
   deprecated
   ^~~~~~~~~~
 Compilation failed

--- a/tests/negative/pkg_errors_in_pkg/dependency/src/foo.toit
+++ b/tests/negative/pkg_errors_in_pkg/dependency/src/foo.toit
@@ -1,0 +1,6 @@
+// Copyright (C) 2026 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+say-hi:
+  "it's" "an error to use a string as target"

--- a/tests/negative/pkg_errors_in_pkg/package.lock
+++ b/tests/negative/pkg_errors_in_pkg/package.lock
@@ -2,5 +2,9 @@ prefixes:
   target: target-1.0
 
 packages:
+  dependency-1.0:
+    path: dependency
   target-1.0:
     path: target
+    prefixes:
+      dependency: dependency-1.0

--- a/tests/negative/pkg_errors_in_pkg/target/src/transitive.toit
+++ b/tests/negative/pkg_errors_in_pkg/target/src/transitive.toit
@@ -1,0 +1,8 @@
+// Copyright (C) 2026 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import dependency.foo as dependency
+
+say-hi:
+  dependency.say-hi

--- a/tests/negative/pkg_errors_in_pkg/transitive-test.toit
+++ b/tests/negative/pkg_errors_in_pkg/transitive-test.toit
@@ -1,0 +1,8 @@
+// Copyright (C) 2026 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import target.transitive as target
+
+main:
+  target.say-hi


### PR DESCRIPTION
## Summary

- show direct package dependencies using their selected import prefix
- show transitive dependencies using a deterministic shortest import path
- fall back to a unique package name or the package ID for unreachable lock entries
- update affected diagnostic gold files

## Testing

- built `toit.compile` and `toit.run`
- ran all 17 `tests/negative/pkg_*` tests
- ran the affected DHT11, DS18B20, and ultrasound health tests