### PR TITLE
Add verbose compiler statistics

### DIFF
--- a/src/compiler/compiler.cc
+++ b/src/compiler/compiler.cc
@@ -21,6 +21,7 @@
 #include <sys/wait.h>
 #endif
 #include <string>
+#include <type_traits>
 #include <ctype.h>
 #include <limits.h>
 #include <unistd.h>
@@ -64,6 +65,7 @@
 #include "util.h"
 
 #include "../objects_inline.h"
+#include "../os.h"
 #include "../snapshot.h"
 #include "../flags.h"
 #include "../utils.h"
@@ -97,7 +99,185 @@ struct PipelineConfiguration {
   bool is_for_dependencies;
   /// Optimization level.
   int optimization_level;
+  /// Controls compiler timing and statistics output.
+  int verbosity;
 };
+
+class PipelineStatistics {
+ public:
+  enum Phase {
+    SETUP,
+    PARSING,
+    DEPENDENCIES,
+    RESOLUTION,
+    TYPE_CHECKS,
+    CODE_GENERATION,
+    OPTIMIZATION,
+    TYPE_PROPAGATION,
+    SNAPSHOT_GENERATION,
+    PHASE_COUNT,
+  };
+
+  enum Metric {
+    SOURCE_FILES,
+    SOURCE_BYTES,
+    TOKENS,
+    CLASSES,
+    INSTANTIATED_CLASSES,
+    METHODS,
+    GLOBALS,
+    BYTECODE_BYTES,
+    LITERALS,
+    PROGRAM_OBJECT_BYTES,
+    DISPATCH_TABLE_ENTRIES,
+    UNUSED_DISPATCH_TABLE_ENTRIES,
+    SNAPSHOT_BYTES,
+    SOURCE_MAP_BYTES,
+    BUNDLE_BYTES,
+    METRIC_COUNT,
+  };
+
+  PipelineStatistics() { initialize(0); }
+  explicit PipelineStatistics(int verbosity) { initialize(verbosity); }
+
+  void switch_phase(Phase phase) {
+    if (verbosity_ == 0) return;
+    int64 now = OS::get_monotonic_time();
+    finish_phase(now);
+    current_phase_ = phase;
+    phase_start_us_ = now;
+  }
+
+  void set(Metric metric, int64 value) {
+    if (verbosity_ >= 2) metrics_[metric] = value;
+  }
+
+  void finish() {
+    if (total_start_us_ < 0) return;
+    int64 now = OS::get_monotonic_time();
+    finish_phase(now);
+    total_us_ = now - total_start_us_;
+    int64 user_cpu_end;
+    int64 system_cpu_end;
+    if (user_cpu_start_us_ >= 0 &&
+        OS::get_process_cpu_times(&user_cpu_end, &system_cpu_end)) {
+      user_cpu_us_ = user_cpu_end - user_cpu_start_us_;
+      system_cpu_us_ = system_cpu_end - system_cpu_start_us_;
+    }
+  }
+
+  void print() const {
+    if (verbosity_ == 0) return;
+
+    fprintf(stderr, "Compiler timings:\n");
+    for (int i = 0; i < PHASE_COUNT; i++) {
+      print_duration(phase_name(static_cast<Phase>(i)), phase_times_us_[i]);
+    }
+    if (verbosity_ >= 2 && user_cpu_us_ >= 0) {
+      fprintf(stderr,
+              "  %-20s %9.3f ms (user %.3f ms, system %.3f ms)\n",
+              "Total",
+              total_us_ / 1000.0,
+              user_cpu_us_ / 1000.0,
+              system_cpu_us_ / 1000.0);
+    } else {
+      print_duration("Total", total_us_);
+    }
+
+    if (verbosity_ < 2) return;
+    fprintf(stderr, "Compiler statistics:\n");
+    for (int i = 0; i < METRIC_COUNT; i++) {
+      if (metrics_[i] < 0) continue;
+      fprintf(stderr,
+              "  %-32s %lld\n",
+              metric_name(static_cast<Metric>(i)),
+              static_cast<long long>(metrics_[i]));
+    }
+  }
+
+ private:
+  void initialize(int verbosity) {
+    verbosity_ = verbosity;
+    for (int i = 0; i < PHASE_COUNT; i++) phase_times_us_[i] = -1;
+    for (int i = 0; i < METRIC_COUNT; i++) metrics_[i] = -1;
+    current_phase_ = PHASE_COUNT;
+    phase_start_us_ = -1;
+    total_start_us_ = verbosity > 0 ? OS::get_monotonic_time() : -1;
+    total_us_ = -1;
+    user_cpu_start_us_ = -1;
+    system_cpu_start_us_ = -1;
+    user_cpu_us_ = -1;
+    system_cpu_us_ = -1;
+    if (verbosity >= 2) {
+      OS::get_process_cpu_times(&user_cpu_start_us_, &system_cpu_start_us_);
+    }
+  }
+
+  void finish_phase(int64 now) {
+    if (current_phase_ == PHASE_COUNT) return;
+    phase_times_us_[current_phase_] = now - phase_start_us_;
+    current_phase_ = PHASE_COUNT;
+    phase_start_us_ = -1;
+  }
+
+  static const char* phase_name(Phase phase) {
+    switch (phase) {
+      case SETUP: return "Setup";
+      case PARSING: return "Parsing";
+      case DEPENDENCIES: return "Dependencies";
+      case RESOLUTION: return "Resolution";
+      case TYPE_CHECKS: return "Type checks";
+      case CODE_GENERATION: return "Code generation";
+      case OPTIMIZATION: return "Optimization";
+      case TYPE_PROPAGATION: return "Type propagation";
+      case SNAPSHOT_GENERATION: return "Snapshot generation";
+      case PHASE_COUNT: UNREACHABLE();
+    }
+    UNREACHABLE();
+  }
+
+  static const char* metric_name(Metric metric) {
+    switch (metric) {
+      case SOURCE_FILES: return "Source files";
+      case SOURCE_BYTES: return "Source bytes";
+      case TOKENS: return "Tokens";
+      case CLASSES: return "Classes";
+      case INSTANTIATED_CLASSES: return "Instantiated classes";
+      case METHODS: return "Methods";
+      case GLOBALS: return "Globals";
+      case BYTECODE_BYTES: return "Bytecode bytes";
+      case LITERALS: return "Literals";
+      case PROGRAM_OBJECT_BYTES: return "Program object bytes";
+      case DISPATCH_TABLE_ENTRIES: return "Dispatch table entries";
+      case UNUSED_DISPATCH_TABLE_ENTRIES: return "Unused dispatch table entries";
+      case SNAPSHOT_BYTES: return "Snapshot bytes";
+      case SOURCE_MAP_BYTES: return "Source map bytes";
+      case BUNDLE_BYTES: return "Bundle bytes";
+      case METRIC_COUNT: UNREACHABLE();
+    }
+    UNREACHABLE();
+  }
+
+  static void print_duration(const char* name, int64 microseconds) {
+    if (microseconds < 0) return;
+    fprintf(stderr, "  %-20s %9.3f ms\n", name, microseconds / 1000.0);
+  }
+
+  int verbosity_;
+  int64 phase_times_us_[PHASE_COUNT];
+  int64 metrics_[METRIC_COUNT];
+  Phase current_phase_;
+  int64 phase_start_us_;
+  int64 total_start_us_;
+  int64 total_us_;
+  int64 user_cpu_start_us_;
+  int64 system_cpu_start_us_;
+  int64 user_cpu_us_;
+  int64 system_cpu_us_;
+};
+
+static_assert(std::is_trivially_copyable<PipelineStatistics>::value,
+              "Pipeline statistics must be transferable between compiler processes");
 
 class Pipeline {
  public:
@@ -106,6 +286,7 @@ class Pipeline {
     int snapshot_size;
     uint8* source_map_data;
     int source_map_size;
+    PipelineStatistics statistics;
 
     bool is_valid() const { return snapshot != null; }
 
@@ -122,6 +303,7 @@ class Pipeline {
         .snapshot_size = 0,
         .source_map_data = null,
         .source_map_size = 0,
+        .statistics = PipelineStatistics(),
       };
     }
   };
@@ -159,6 +341,7 @@ class Pipeline {
   PipelineConfiguration configuration_;
   SymbolCanonicalizer symbols_;
   ToitdocRegistry toitdoc_registry_;
+  int token_count_ = 0;
 
   ast::Unit* _parse_source(Source* source);
 
@@ -511,6 +694,7 @@ void Compiler::language_server(const Compiler::Configuration& compiler_config) {
     .is_for_analysis = true,
     .is_for_dependencies = false,
     .optimization_level = compiler_config.optimization_level,
+    .verbosity = compiler_config.verbosity,
   };
 
   if (strcmp("ANALYZE", mode) == 0) {
@@ -770,6 +954,7 @@ void Compiler::analyze(List<const char*> source_paths,
     .is_for_analysis = !for_dependencies,
     .is_for_dependencies = for_dependencies,
     .optimization_level = compiler_config.optimization_level,
+    .verbosity = compiler_config.verbosity,
   };
   Pipeline pipeline(configuration);
   pipeline.run(source_paths, false);
@@ -782,8 +967,10 @@ static Pipeline::Result receive_pipeline_result(int read_fd) {
   uint8* snapshot = null;
   int source_map_size = -1;
   uint8* source_map_data = null;
+  PipelineStatistics statistics;
 
   if (!read_from_pipe(read_fd, &snapshot_size, sizeof(int))) return Pipeline::Result::invalid();
+  if (!read_from_pipe(read_fd, &statistics, sizeof(statistics))) FATAL("Incomplete data");
   snapshot = unvoid_cast<uint8*>(malloc(snapshot_size));
   if (!read_from_pipe(read_fd, snapshot, snapshot_size)) FATAL("Incomplete data");
   if (!read_from_pipe(read_fd, &source_map_size, sizeof(int))) FATAL("Incomplete data");
@@ -797,6 +984,7 @@ static Pipeline::Result receive_pipeline_result(int read_fd) {
     .snapshot_size = snapshot_size,
     .source_map_data = source_map_data,
     .source_map_size = source_map_size,
+    .statistics = statistics,
   };
 }
 
@@ -814,6 +1002,7 @@ static void send_pipeline_result(int write_fd, const Pipeline::Result& pipeline_
   };
 
   write_to_fd(&pipeline_result.snapshot_size, sizeof(int));
+  write_to_fd(&pipeline_result.statistics, sizeof(pipeline_result.statistics));
   write_to_fd(pipeline_result.snapshot, pipeline_result.snapshot_size);
   write_to_fd(&pipeline_result.source_map_size, sizeof(int));
   write_to_fd(pipeline_result.source_map_data, pipeline_result.source_map_size);
@@ -899,6 +1088,7 @@ SnapshotBundle Compiler::compile(const char* source_path,
     .is_for_analysis = false,
     .is_for_dependencies = false,
     .optimization_level = compiler_config.optimization_level,
+    .verbosity = compiler_config.verbosity,
   };
 
   return compile(source_path, configuration);
@@ -956,6 +1146,8 @@ SnapshotBundle Compiler::compile(const char* source_path,
                                     pipeline_main_result.snapshot_size),
                         List<uint8>(pipeline_main_result.source_map_data,
                                     pipeline_main_result.source_map_size));
+  pipeline_main_result.statistics.set(PipelineStatistics::BUNDLE_BYTES, result.size());
+  pipeline_main_result.statistics.print();
   // The snapshot bundle copies all given data. It's thus safe to free
   //   the pipeline data.
   pipeline_main_result.free_all();
@@ -1012,7 +1204,9 @@ static int compute_source_offset(const uint8* source, int line_number, int utf16
 ast::Unit* Pipeline::parse(Source* source) {
   Scanner scanner(source, symbol_canonicalizer(), diagnostics());
   Parser parser(source, &scanner, diagnostics());
-  return parser.parse_unit();
+  auto result = parser.parse_unit();
+  token_count_ += scanner.token_count();
+  return result;
 }
 
 void Pipeline::setup_lsp_selection_handler() {
@@ -2070,6 +2264,9 @@ static void sort_classes(List<ir::Class*> classes) {
 }
 
 Pipeline::Result Pipeline::run(List<const char*> source_paths, bool propagate) {
+  PipelineStatistics statistics(configuration_.verbosity);
+  statistics.switch_phase(PipelineStatistics::SETUP);
+
   // TODO(florian): this is hackish. We want to analyze asserts also in release mode,
   // but then remove the code when we generate code.
   // For now just enable asserts when we are analyzing.
@@ -2101,9 +2298,21 @@ Pipeline::Result Pipeline::run(List<const char*> source_paths, bool propagate) {
     }
   }
 
+  statistics.switch_phase(PipelineStatistics::PARSING);
   auto units = _parse_units(source_paths, package_lock);
+  int source_count = 0;
+  int source_bytes = 0;
+  for (auto unit : units) {
+    if (unit->source() == null) continue;
+    source_count++;
+    source_bytes += unit->source()->size();
+  }
+  statistics.set(PipelineStatistics::SOURCE_FILES, source_count);
+  statistics.set(PipelineStatistics::SOURCE_BYTES, source_bytes);
+  statistics.set(PipelineStatistics::TOKENS, token_count_);
 
   if (configuration_.dep_file != null) {
+    statistics.switch_phase(PipelineStatistics::DEPENDENCIES);
     ASSERT(configuration_.dep_format != Compiler::DepFormat::none);
     PlainDepWriter plain_writer;
     NinjaDepWriter ninja_writer;
@@ -2127,15 +2336,22 @@ Pipeline::Result Pipeline::run(List<const char*> source_paths, bool propagate) {
                                                    units,
                                                    CORE_UNIT_INDEX);
     if (configuration_.is_for_dependencies) {
+      statistics.finish();
+      statistics.print();
       return Result::invalid();
     }
   }
 
-  if (configuration_.parse_only) return Result::invalid();
+  if (configuration_.parse_only) {
+    statistics.finish();
+    statistics.print();
+    return Result::invalid();
+  }
 
   // Give subclasses a chance to handle parse-only requests (e.g. selection ranges).
   parsed_units(units);
 
+  statistics.switch_phase(PipelineStatistics::RESOLUTION);
   ir::Program* ir_program = resolve(units, ENTRY_UNIT_INDEX, CORE_UNIT_INDEX);
   sort_classes(ir_program->classes());
 
@@ -2143,6 +2359,7 @@ Pipeline::Result Pipeline::run(List<const char*> source_paths, bool propagate) {
 
   if (Flags::print_ir_tree) ir_program->print(true);
 
+  statistics.switch_phase(PipelineStatistics::TYPE_CHECKS);
   check_types_and_deprecations(ir_program);
   post_type_check();
   check_definite_assignments_returns(ir_program, diagnostics());
@@ -2154,6 +2371,18 @@ Pipeline::Result Pipeline::run(List<const char*> source_paths, bool propagate) {
 
   if (configuration_.is_for_analysis) {
     if (encountered_error) exit(1);
+    int instantiated_class_count = 0;
+    int method_count = ir_program->methods().length();
+    for (auto klass : ir_program->classes()) {
+      if (klass->is_instantiated()) instantiated_class_count++;
+      method_count += klass->methods().length();
+    }
+    statistics.set(PipelineStatistics::CLASSES, ir_program->classes().length());
+    statistics.set(PipelineStatistics::INSTANTIATED_CLASSES, instantiated_class_count);
+    statistics.set(PipelineStatistics::METHODS, method_count);
+    statistics.set(PipelineStatistics::GLOBALS, ir_program->globals().length());
+    statistics.finish();
+    statistics.print();
     return Result::invalid();
   }
 
@@ -2178,6 +2407,7 @@ Pipeline::Result Pipeline::run(List<const char*> source_paths, bool propagate) {
   auto source_mapper = &unoptimized_source_mapper;
   TypeOracle oracle(source_mapper);
   MethodSelectorOffsets method_selector_offsets;
+  statistics.switch_phase(PipelineStatistics::CODE_GENERATION);
   auto program = construct_program(ir_program,
                                    source_mapper,
                                    &oracle,
@@ -2187,6 +2417,7 @@ Pipeline::Result Pipeline::run(List<const char*> source_paths, bool propagate) {
 
   SourceMapper optimized_source_mapper(source_manager());
   if (run_optimizations && configuration_.optimization_level >= 2) {
+    statistics.switch_phase(PipelineStatistics::OPTIMIZATION);
     bool quiet = true;
     ir_program = resolve(units, ENTRY_UNIT_INDEX, CORE_UNIT_INDEX, quiet);
     sort_classes(ir_program->classes());
@@ -2211,23 +2442,46 @@ Pipeline::Result Pipeline::run(List<const char*> source_paths, bool propagate) {
   }
 
   if (propagate) {
+    statistics.switch_phase(PipelineStatistics::TYPE_PROPAGATION);
     TypeDatabase* types = TypeDatabase::compute(program, &method_selector_offsets);
     auto json = types->as_json();
     printf("%s", json.c_str());
     delete types;
   }
 
+  int method_count = ir_program->methods().length();
+  for (auto klass : ir_program->classes()) {
+    method_count += klass->methods().length();
+  }
+  statistics.set(PipelineStatistics::CLASSES, ir_program->classes().length());
+  statistics.set(PipelineStatistics::INSTANTIATED_CLASSES, program->class_bits.length());
+  statistics.set(PipelineStatistics::METHODS, method_count);
+  statistics.set(PipelineStatistics::GLOBALS, program->global_variables.length());
+  statistics.set(PipelineStatistics::BYTECODE_BYTES, program->bytecodes.length());
+  statistics.set(PipelineStatistics::LITERALS, program->literals.length());
+  statistics.set(PipelineStatistics::PROGRAM_OBJECT_BYTES, program->object_size());
+  statistics.set(PipelineStatistics::DISPATCH_TABLE_ENTRIES, program->dispatch_table.length());
+  statistics.set(PipelineStatistics::UNUSED_DISPATCH_TABLE_ENTRIES,
+                 program->number_of_unused_dispatch_table_entries());
+
+  int source_map_size;
+  uint8* source_map_data;
+  int snapshot_size;
+  uint8* snapshot;
+  statistics.switch_phase(PipelineStatistics::SNAPSHOT_GENERATION);
   SnapshotGenerator generator(program);
   generator.generate(program);
-  int source_map_size;
-  uint8* source_map_data = source_mapper->cook(&source_map_size);
-  int snapshot_size;
-  uint8* snapshot = generator.take_buffer(&snapshot_size);
+  source_map_data = source_mapper->cook(&source_map_size);
+  snapshot = generator.take_buffer(&snapshot_size);
+  statistics.set(PipelineStatistics::SNAPSHOT_BYTES, snapshot_size);
+  statistics.set(PipelineStatistics::SOURCE_MAP_BYTES, source_map_size);
+  statistics.finish();
   return {
     .snapshot = snapshot,
     .snapshot_size = snapshot_size,
     .source_map_data = source_map_data,
     .source_map_size = source_map_size,
+    .statistics = statistics,
   };
 }
 

--- a/src/compiler/compiler.h
+++ b/src/compiler/compiler.h
@@ -70,6 +70,9 @@ class Compiler {
     bool print_diagnostics_on_stdout;
     /// Optimization level.
     int optimization_level;
+    /// Controls compiler statistics: 0 disables them, 1 prints timings,
+    /// and 2 also prints compilation and output metrics.
+    int verbosity;
   };
 
   Compiler();

--- a/src/compiler/scanner.cc
+++ b/src/compiler/scanner.cc
@@ -57,6 +57,7 @@ Symbol Scanner::make_utf8_string(int begin, int end) {
 }
 
 Scanner::State Scanner::create_state(Token::Kind token) {
+  token_count_++;
   bool is_attached = (last_ - begin_) == 0;
   return {
     .from = last_,

--- a/src/compiler/scanner.h
+++ b/src/compiler/scanner.h
@@ -353,6 +353,7 @@ class Scanner {
 
   Source* source() const { return source_; }
   SymbolCanonicalizer* symbol_canonicalizer() const { return symbols_; }
+  int token_count() const { return token_count_; }
 
   static bool is_identifier_start(int c);
 
@@ -404,6 +405,7 @@ class Scanner {
 
   int begin_ = -1;
   int last_ = -1;
+  int token_count_ = 0;
 
   ListBuilder<Comment> comments_;
 

--- a/src/compiler/toitc.cc
+++ b/src/compiler/toitc.cc
@@ -43,6 +43,9 @@ static void print_usage(int exit_code) {
   printf("  [--os <system>]                          // Cross-compilation system target.\n");
   printf("  [--arch <architecture>]                  // Cross-compilation architecture target.\n");
   printf("  [--strip]                                // Strip the output of debug information.\n");
+  printf("  [--verbose]                              // Print compiler phase timings.\n");
+  printf("  [--verbosity-level {debug|info|verbose|quiet|silent}]\n");
+  printf("                                            // Set compiler statistics verbosity.\n");
   printf("  { -o <executable> <toitfile|snapshot> |  // Write executable.\n");
   printf("    -w <snapshot> <toitfile|snapshot> |    // Write snapshot file.\n");
   printf("    --analyze <toitfiles>...               // Analyze Toit files.\n");
@@ -110,6 +113,7 @@ int main(int argc, char **argv) {
   const char* cross_arch = null;
   int optimization_level = DEFAULT_OPTIMIZATION_LEVEL;
   bool should_strip = false;
+  int verbosity = 0;
 
   int processed_args = 1;  // The executable name has already been processed.
 
@@ -252,6 +256,28 @@ int main(int argc, char **argv) {
     } else if (strcmp(argv[processed_args], "--strip") == 0) {
       should_strip = true;
       processed_args++;
+    } else if (strcmp(argv[processed_args], "--verbose") == 0) {
+      verbosity = 1;
+      processed_args++;
+    } else if (strcmp(argv[processed_args], "--verbosity-level") == 0) {
+      processed_args++;
+      if (processed_args == argc) {
+        fprintf(stderr, "Missing argument to '--verbosity-level'\n");
+        print_usage(1);
+      }
+      const char* level = argv[processed_args++];
+      if (strcmp(level, "debug") == 0) {
+        verbosity = 2;
+      } else if (strcmp(level, "verbose") == 0) {
+        verbosity = 1;
+      } else if (strcmp(level, "info") == 0 ||
+                 strcmp(level, "quiet") == 0 ||
+                 strcmp(level, "silent") == 0) {
+        verbosity = 0;
+      } else {
+        fprintf(stderr, "Unknown verbosity level '%s'\n", level);
+        print_usage(1);
+      }
     } else if (argv[processed_args][0] == '-' &&
                 strcmp(argv[processed_args], "--") != 0) {
       fprintf(stderr, "Unknown flag '%s'\n", argv[processed_args]);
@@ -353,6 +379,7 @@ int main(int argc, char **argv) {
     .show_package_warnings = show_package_warnings,
     .print_diagnostics_on_stdout = true,
     .optimization_level = optimization_level,
+    .verbosity = for_language_server ? 0 : verbosity,
   };
 
   if (for_language_server) {

--- a/src/os.h
+++ b/src/os.h
@@ -114,6 +114,9 @@ class OS {
   static int64 get_monotonic_time();
   static void reset_monotonic_time();
 
+  // Returns user and system CPU time consumed by the current process.
+  static bool get_process_cpu_times(int64* user_us, int64* system_us);
+
   /// Computes the executable path.
   ///
   /// Returns a malloced data structure that should be freed

--- a/src/os_posix.cc
+++ b/src/os_posix.cc
@@ -26,6 +26,7 @@
 
 #include <errno.h>
 #include <pthread.h>
+#include <sys/resource.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <sys/mman.h>
@@ -42,6 +43,14 @@ int64 OS::get_system_time() {
     FATAL("failed getting system time");
   }
   return us;
+}
+
+bool OS::get_process_cpu_times(int64* user_us, int64* system_us) {
+  struct rusage usage;
+  if (getrusage(RUSAGE_SELF, &usage) != 0) return false;
+  *user_us = usage.ru_utime.tv_sec * 1000000LL + usage.ru_utime.tv_usec;
+  *system_us = usage.ru_stime.tv_sec * 1000000LL + usage.ru_stime.tv_usec;
+  return true;
 }
 
 class ConditionVariable {

--- a/src/os_win.cc
+++ b/src/os_win.cc
@@ -108,6 +108,27 @@ int64 OS::get_system_time() {
   return us;
 }
 
+bool OS::get_process_cpu_times(int64* user_us, int64* system_us) {
+  FILETIME creation_time;
+  FILETIME exit_time;
+  FILETIME kernel_time;
+  FILETIME user_time;
+  if (!GetProcessTimes(GetCurrentProcess(),
+                       &creation_time,
+                       &exit_time,
+                       &kernel_time,
+                       &user_time)) {
+    return false;
+  }
+  uint64 kernel_ticks = (static_cast<uint64>(kernel_time.dwHighDateTime) << 32) |
+      kernel_time.dwLowDateTime;
+  uint64 user_ticks = (static_cast<uint64>(user_time.dwHighDateTime) << 32) |
+      user_time.dwLowDateTime;
+  *user_us = user_ticks / 10;
+  *system_us = kernel_ticks / 10;
+  return true;
+}
+
 class ConditionVariable {
  public:
   explicit ConditionVariable(Mutex* mutex)

--- a/src/toit.cc
+++ b/src/toit.cc
@@ -52,6 +52,7 @@ int main(int argc, char **argv) {
       .show_package_warnings = false,
       .print_diagnostics_on_stdout = true,
       .optimization_level = DEFAULT_OPTIMIZATION_LEVEL,
+      .verbosity = 0,
     };
     compiler::Compiler compiler;
     compiler.language_server(compiler_config);

--- a/src/toit_run.cc
+++ b/src/toit_run.cc
@@ -367,6 +367,7 @@ int main(int argc, char **argv) {
       // running the language-server, in which case the diagnostics must be on stdout.
       .print_diagnostics_on_stdout = for_analysis || generating_bundle,
       .optimization_level = optimization_level,
+      .verbosity = 0,
     };
 
     if (for_language_server) {

--- a/tests/toit/compiler-statistics-test.toit
+++ b/tests/toit/compiler-statistics-test.toit
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+import host.file
+
+import .utils
+
+main args:
+  toit-exe := ToitExecutable args
+
+  with-tmp-dir: | tmp-dir/string |
+    source := "$tmp-dir/main.toit"
+    snapshot := "$tmp-dir/main.snapshot"
+    file.write-contents --path=source "main: print 42"
+
+    normal := toit-exe.fork ["compile", "--snapshot", "-o", snapshot, source]
+    expect-equals 0 normal.exit-code
+    expect-not (normal.stderr.contains "Compiler timings:")
+
+    verbose := toit-exe.fork [
+      "compile",
+      "--verbose",
+      "--snapshot",
+      "-o", snapshot,
+      source,
+    ]
+    expect-equals 0 verbose.exit-code
+    expect (verbose.stderr.contains "Compiler timings:")
+    expect (verbose.stderr.contains "Parsing")
+    expect (verbose.stderr.contains "Resolution")
+    expect (verbose.stderr.contains "Type checks")
+    expect (verbose.stderr.contains "Code generation")
+    expect (verbose.stderr.contains "Snapshot generation")
+    expect (verbose.stderr.contains "Total")
+    expect-not (verbose.stderr.contains "(user ")
+    expect-not (verbose.stderr.contains "Compiler statistics:")
+
+    debug := toit-exe.fork [
+      "compile",
+      "--verbosity-level=debug",
+      "--snapshot",
+      "-o", snapshot,
+      source,
+    ]
+    expect-equals 0 debug.exit-code
+    expect (debug.stderr.contains "Compiler timings:")
+    expect (debug.stderr.contains "Total")
+    expect (debug.stderr.contains "(user ")
+    expect (debug.stderr.contains "system ")
+    expect (debug.stderr.contains "Compiler statistics:")
+    expect (debug.stderr.contains "Source files")
+    expect (debug.stderr.contains "Tokens")
+    expect (debug.stderr.contains "Classes")
+    expect (debug.stderr.contains "Bytecode bytes")
+    expect (debug.stderr.contains "Program object bytes")
+    expect (debug.stderr.contains "Dispatch table entries")
+    expect (debug.stderr.contains "Snapshot bytes")
+    expect (debug.stderr.contains "Bundle bytes")

--- a/tools/toit.toit
+++ b/tools/toit.toit
@@ -410,6 +410,13 @@ compile-or-analyze-or-run --command/string invocation/cli.Invocation:
 
   args := []
 
+  if command != "run":
+    if ui.level == Ui.DEBUG-LEVEL:
+      args.add "--verbosity-level"
+      args.add "debug"
+    else if ui.level >= Ui.VERBOSE-LEVEL:
+      args.add "--verbose"
+
   xflags := invocation["X"]
   if not xflags.is-empty:
     xflags.do:


### PR DESCRIPTION
## Summary

- report compiler phase timings for verbose compile and analyze commands
- add detailed source, program, dispatch-table, and output metrics at debug verbosity
- include aggregate user and system CPU time in the debug total
- forward user-facing verbosity through the toit command

## Testing

- cmake --build build/host --target toit.compile -j4
- build/host/sdk/lib/toit/bin/toit.run tests/toit/compiler-statistics-test.toit build/host/sdk/bin/toit
- build/host/sdk/bin/toit compile --verbosity-level=debug --snapshot -o /tmp/toit-compiler-stats-pr.snapshot examples/hello.toit
- git diff --check