### PR TITLE
Improve compiler ownership and avoid unnecessary copies

### DIFF
--- a/src/compiler/compiler.cc
+++ b/src/compiler/compiler.cc
@@ -704,7 +704,7 @@ void Compiler::language_server(const Compiler::Configuration& compiler_config) {
     }
     auto source_paths = ListBuilder<const char*>::allocate(path_count);
     for (int i = 0; i < path_count; i++) {
-      source_paths[i] = strdup(reader.next("path"));
+      source_paths[i] = reader.next("path");
     }
     LanguageServerAnalysisDiagnostics diagnostics(&source_manager, &lsp);
     configuration.diagnostics = &diagnostics;
@@ -717,7 +717,7 @@ void Compiler::language_server(const Compiler::Configuration& compiler_config) {
     }
     auto source_paths = ListBuilder<const char*>::allocate(path_count);
     for (int i = 0; i < path_count; i++) {
-      source_paths[i] = strdup(reader.next("path"));
+      source_paths[i] = reader.next("path");
     }
 
     NullDiagnostics diagnostics(&source_manager);

--- a/src/compiler/cycle_detector.h
+++ b/src/compiler/cycle_detector.h
@@ -50,7 +50,7 @@ class CycleDetector {
   ///    in a cycle yet, calls the cycle_callback with the vector. Otherwise just returns true.
   ///  * Returns true.
   bool check_cycle(const T& entry,
-                   const std::function<void (const std::vector<T>& cycle)> cycle_callback) {
+                   const std::function<void (const std::vector<T>& cycle)>& cycle_callback) {
     auto probe = in_progress_map_.find(entry);
     if (probe == in_progress_map_.end()) return false;
     // We are in a cycle.

--- a/src/compiler/dep_writer.cc
+++ b/src/compiler/dep_writer.cc
@@ -26,7 +26,7 @@ namespace compiler {
 
 void DepWriter::write_deps_to_file_if_different(const char* dep_path,
                                                 const char* out_path,
-                                                std::vector<ast::Unit*> units,
+                                                const std::vector<ast::Unit*>& units,
                                                 int core_unit_index) {
   for (size_t i = 0; i < units.size(); i++) {
     auto unit = units[i];
@@ -66,24 +66,32 @@ void DepWriter::write_deps_to_file_if_different(const char* dep_path,
   char* old_deps = null;
   FILE* file = fopen(dep_path, "r");
   if (file != null) {
-    fseek(file, 0, SEEK_END);
-    long file_size = ftell(file);
-    rewind(file);
-    char* buffer = unvoid_cast<char*>(malloc(file_size + 1));
-    auto read_bytes = fread(buffer, 1, file_size, file);
-    if (read_bytes == 0) {
-      free(buffer);
-    } else {
-      buffer[file_size] = '\0';
-      old_deps = buffer;
+    if (fseek(file, 0, SEEK_END) == 0) {
+      long file_size = ftell(file);
+      if (file_size >= 0) {
+        rewind(file);
+        char* buffer = unvoid_cast<char*>(malloc(file_size + 1));
+        if (buffer != null) {
+          auto read_bytes = fread(buffer, 1, file_size, file);
+          if (read_bytes == static_cast<size_t>(file_size)) {
+            buffer[file_size] = '\0';
+            old_deps = buffer;
+          } else {
+            free(buffer);
+          }
+        }
+      }
     }
     fclose(file);
   }
 
   if (old_deps == null || new_deps != old_deps) {
     file = fopen(dep_path, "w");
-    fwrite(new_deps.c_str(), 1, new_deps.size(), file);
-    fclose(file);
+    if (file == null) FATAL("Couldn't open dependency file for writing");
+    size_t written = fwrite(new_deps.c_str(), 1, new_deps.size(), file);
+    if (written != new_deps.size() || fclose(file) != 0) {
+      FATAL("Couldn't write dependency file");
+    }
   }
   if (old_deps != null) free(old_deps);
 }
@@ -154,4 +162,3 @@ void ListDepWriter::generate_footer() {}
 
 } // namespace toit::compiler
 } // namespace toit
-

--- a/src/compiler/dep_writer.h
+++ b/src/compiler/dep_writer.h
@@ -27,7 +27,7 @@ class DepWriter {
  public:
   void write_deps_to_file_if_different(const char* dep_path,
                                        const char* out_path,
-                                       std::vector<ast::Unit*> units,
+                                       const std::vector<ast::Unit*>& units,
                                        int core_unit_index);
 
  protected:

--- a/src/compiler/dispatch_table.h
+++ b/src/compiler/dispatch_table.h
@@ -64,7 +64,7 @@ class DispatchTable {
   }
   int id_for(const ir::Class* klass) const { return klass->start_id(); }
 
-  void for_each_selector_offset(std::function<void (DispatchSelector, word)> callback) {
+  void for_each_selector_offset(const std::function<void (DispatchSelector, word)>& callback) {
     selector_offsets_.for_each(callback);
   }
 

--- a/src/compiler/executable.cc
+++ b/src/compiler/executable.cc
@@ -17,7 +17,14 @@
 
 #include <stdio.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <sys/stat.h>
+
+#ifdef TOIT_WINDOWS
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
 
 #ifdef TOIT_DARWIN
 // For spawning codesign.
@@ -90,7 +97,8 @@ int create_executable(const char* out_path,
   if (vessel_root != null) {
     builder.add(vessel_root);
   } else {
-    builder.add(fs.vessel_root());
+    vessel_root = fs.vessel_root();
+    builder.add(vessel_root);
   }
   if (os != null) {
     builder.join(os);
@@ -119,18 +127,18 @@ int create_executable(const char* out_path,
   builder.canonicalize();
   int length_without_extension = builder.length();
   FILE* file = null;
-  const char* vessel_path = strdup(builder.c_str());
+  std::string vessel_path;
   for (unsigned int i = 0; i < ARRAY_SIZE(EXECUTABLE_SUFFIXES); i++) {
     builder.reset_to(length_without_extension);
     builder.add(EXECUTABLE_SUFFIXES[i]);
-    vessel_path = strdup(builder.c_str());
+    vessel_path = builder.c_str();
     struct stat buffer;
-    if (stat(vessel_path, &buffer) != 0) {
+    if (stat(vessel_path.c_str(), &buffer) != 0) {
       continue;
     }
-    file = fopen(vessel_path, "rb");
+    file = fopen(vessel_path.c_str(), "rb");
     if (file == null) {
-      fprintf(stderr, "Unable to open vessel file %s\n", vessel_path);
+      fprintf(stderr, "Unable to open vessel file %s\n", vessel_path.c_str());
       return -1;
     }
     break;
@@ -143,6 +151,7 @@ int create_executable(const char* out_path,
     }
     return -1;
   }
+  Defer close_file { [&] { if (file != null) fclose(file); } };
   // Find content size of file.
   int status = fseek(file, 0, SEEK_END);
   if (status != 0) {
@@ -150,13 +159,18 @@ int create_executable(const char* out_path,
     return -1;
   }
   long fsize = ftell(file);
+  if (fsize < 0 || fsize > INT_MAX) {
+    fprintf(stderr, "Invalid vessel size for '%s'\n", vessel_path.c_str());
+    return -1;
+  }
   int size = fsize;
   // Read entire content.
   uint8* vessel_content = unvoid_cast<uint8*>(malloc(size));
   if (vessel_content == null) {
-    fprintf(stderr, "Unable to allocate buffer for vessel %s\n", vessel_path);
+    fprintf(stderr, "Unable to allocate buffer for vessel %s\n", vessel_path.c_str());
     return -1;
   }
+  Defer free_vessel_content { [&] { free(vessel_content); } };
   status = fseek(file, 0, SEEK_SET);
   if (status != 0) {
     perror("create_executable");
@@ -164,13 +178,14 @@ int create_executable(const char* out_path,
   }
   int read_count = fread(vessel_content, fsize, 1, file);
   fclose(file);
+  file = null;
   if (read_count != 1) {
-    free(vessel_content);
-    fprintf(stderr, "Unable to read vessel '%s'\n", vessel_path);
+    fprintf(stderr, "Unable to read vessel '%s'\n", vessel_path.c_str());
     return -1;
   }
   bool replaced_vessel_content = false;
-  for (size_t i = 0; i < size - sizeof(VESSEL_TOKEN); i++) {
+  size_t vessel_size = static_cast<size_t>(size);
+  for (size_t i = 0; i + 2 * sizeof(VESSEL_TOKEN) <= vessel_size; i++) {
     bool found_token = true;
     // We must find two copies of the token next to each other.
     for (size_t j = 0; j < sizeof(VESSEL_TOKEN) * 2; j++) {
@@ -180,12 +195,15 @@ int create_executable(const char* out_path,
       }
     }
     if (found_token) {
-      *reinterpret_cast<uint32*>(&vessel_content[i]) = bundle.size();
-      memcpy(&vessel_content[i + 4], bundle.buffer(), bundle.size());
+      size_t bundle_size = static_cast<size_t>(bundle.size());
+      if (i + sizeof(uint32) + bundle_size > vessel_size) continue;
+      uint32 encoded_size = bundle.size();
+      memcpy(&vessel_content[i], &encoded_size, sizeof(encoded_size));
+      memcpy(&vessel_content[i + sizeof(encoded_size)], bundle.buffer(), bundle_size);
       replaced_vessel_content = true;
       // Some architectures (macos fat binaries) have multiple executables
       // in the same file, so we need to replace all occurrences of the token.
-      i += bundle.size();
+      i += bundle_size;
     }
   }
 
@@ -196,17 +214,32 @@ int create_executable(const char* out_path,
 
   // Use 'open', so we can give executable permissions.
   int fd = open(out_path, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0777);
-  FILE* file_out = fdopen(fd, "wb");
-  if (file_out == NULL) {
+  if (fd < 0) {
     perror("create_executable");
     return -1;
   }
+  FILE* file_out = fdopen(fd, "wb");
+  if (file_out == NULL) {
+#ifdef TOIT_WINDOWS
+    _close(fd);
+#else
+    close(fd);
+#endif
+    perror("create_executable");
+    return -1;
+  }
+  Defer close_output { [&] { if (file_out != null) fclose(file_out); } };
   int written = fwrite(vessel_content, 1, size, file_out);
   if (written != size) {
     perror("create_executable");
     return -1;
   }
-  fclose(file_out);
+  if (fclose(file_out) != 0) {
+    file_out = null;
+    perror("create_executable");
+    return -1;
+  }
+  file_out = null;
   if (sign_if_necessary(out_path, os) != 0) {
     fprintf(stderr, "Error while signing the generated executable '%s'. The program might still work.\n", out_path);
   }

--- a/src/compiler/filesystem.cc
+++ b/src/compiler/filesystem.cc
@@ -35,6 +35,7 @@ const char* Filesystem::cwd() {
   if (cwd_ == null) {
     char buffer[PATH_MAX];
     auto result = getcwd(buffer, PATH_MAX);
+    if (result == null) FATAL("Couldn't get current working directory");
     cwd_ = strdup(result);
   }
   return cwd_;
@@ -221,7 +222,7 @@ void Filesystem::register_intercepted(const std::string& path, const uint8* cont
 }
 
 void Filesystem::list_toit_directory_entries(const char* path,
-                                             const std::function<bool (const char*, bool is_directory)> callback) {
+                                             const std::function<bool (const char*, bool is_directory)>& callback) {
   list_directory_entries(path, [&](const char* entry) {
     // TODO(florian): We would like to check here, whether the `full_path` is a directory
     // or not. However, we are not allowed to do another filesystem request

--- a/src/compiler/filesystem.h
+++ b/src/compiler/filesystem.h
@@ -30,7 +30,11 @@ class Diagnostics;
 
 class Filesystem {
  public:
-  virtual ~Filesystem() { free(const_cast<char*>(cwd_)); }
+  virtual ~Filesystem() {
+    free(const_cast<char*>(library_root_));
+    free(const_cast<char*>(vessel_root_));
+    free(const_cast<char*>(cwd_));
+  }
 
   /// Can be called multiple times.
   /// Subclasses must ensure that multiple calls don't lead to problems.
@@ -80,7 +84,7 @@ class Filesystem {
   // If the callback returns 'false', the operation is aborted and no further calls to
   // the callback are done.
   void list_toit_directory_entries(const char* path,
-                                   const std::function<bool (const char*, bool is_directory)> callback);
+                                   const std::function<bool (const char*, bool is_directory)>& callback);
 
   const char* cwd();
 
@@ -112,7 +116,7 @@ class Filesystem {
 
   virtual const char* getcwd(char* buffer, int buffer_size) = 0;
   virtual void list_directory_entries(const char* path,
-                                      const std::function<bool (const char*)> callback) = 0;
+                                      const std::function<bool (const char*)>& callback) = 0;
 
   friend class FilesystemHybrid;
 

--- a/src/compiler/filesystem_archive.cc
+++ b/src/compiler/filesystem_archive.cc
@@ -37,6 +37,12 @@ static const char* const CWD_PATH_PATH = "/<cwd>";
 static const char* const COMPILER_INPUT_PATH = "/<compiler-input>";
 static const char* const INFO_PATH = "/<info>";
 
+FilesystemArchive::~FilesystemArchive() {
+  for (auto& entry : archive_files_.underlying_map()) {
+    free(const_cast<char*>(entry.second.content));
+  }
+}
+
 void FilesystemArchive::initialize(Diagnostics* diagnostics) {
   if (is_initialized_) return;
   is_initialized_ = true;
@@ -45,6 +51,8 @@ void FilesystemArchive::initialize(Diagnostics* diagnostics) {
   auto code = untar(path_, [&](const char* name,
                                char* content,
                                int size) {
+    Defer free_name { [&] { free(const_cast<char*>(name)); } };
+    std::string archive_name;
     if (name[0] != '/') {
       // Not an absolute file.
       // Assume it's relative to the current working directory.
@@ -59,9 +67,15 @@ void FilesystemArchive::initialize(Diagnostics* diagnostics) {
       }
       PathBuilder builder(this);
       builder.join(current_working_dir, name);
-      name = builder.strdup();
+      archive_name = builder.buffer();
+    } else {
+      archive_name = name;
     }
-    archive_files_[std::string(name)] = {
+    auto existing = archive_files_.find(archive_name);
+    if (existing != archive_files_.end()) {
+      free(const_cast<char*>(existing->second.content));
+    }
+    archive_files_[archive_name] = {
       .content = content,
       .size = size,
     };
@@ -92,7 +106,7 @@ void FilesystemArchive::initialize(Diagnostics* diagnostics) {
     diagnostics->report_error("Missing package-cache-paths file in '%s'", path_);
     return;
   }
-  package_cache_paths_ = string_split(package_cache_paths_probe->second.content, "\n");
+  package_cache_paths_ = string_split(const_cast<char*>(package_cache_paths_probe->second.content), "\n");
 
   // Check whether the archive contains the SDK.
   // If there is a file with the same prefix, we consider it to be there.
@@ -158,7 +172,8 @@ void FilesystemArchive::initialize(Diagnostics* diagnostics) {
       if (!entry_path_list[0].is_string()) {
         goto bad_meta;
       }
-      entry_path_ = strdup(entry_path_list[0].get<std::string>().c_str());
+      entry_path_storage_ = entry_path_list[0].get<std::string>();
+      entry_path_ = entry_path_storage_.c_str();
     } else {
       // This path is deprecated.
       entry_path_ = compiler_input.content;
@@ -253,7 +268,7 @@ const uint8* FilesystemArchive::do_read_content(const char* path, int* size) {
 }
 
 void FilesystemArchive::list_directory_entries(const char* path,
-                                               const std::function<bool (const char*)> callback) {
+                                               const std::function<bool (const char*)>& callback) {
   auto probe = directory_listings_.find(std::string(path));
   if (probe == directory_listings_.end()) return;
   for (auto& entry : probe->second) {

--- a/src/compiler/filesystem_archive.h
+++ b/src/compiler/filesystem_archive.h
@@ -33,6 +33,7 @@ class FilesystemArchive : public Filesystem {
  public:
   FilesystemArchive(const char* path)
       : path_(path) {}
+  ~FilesystemArchive();
 
   /// Loads the given archive, caching the contained files.
   void initialize(Diagnostics* diagnostics);
@@ -73,7 +74,7 @@ class FilesystemArchive : public Filesystem {
 
   const char* getcwd(char* buffer, int buffer_size) { return cwd_path_; }
   void list_directory_entries(const char* path,
-                              const std::function<bool (const char*)> callback);
+                              const std::function<bool (const char*)>& callback);
 
  private:
   struct FileEntry {
@@ -92,6 +93,7 @@ class FilesystemArchive : public Filesystem {
 
   // These entries are overwritten in the initialize function.
   const char* entry_path_ = "/";
+  std::string entry_path_storage_;
   const char* sdk_path_ = "/";
   List<const char*> package_cache_paths_;
   const char* cwd_path_ = "/";

--- a/src/compiler/filesystem_hybrid.cc
+++ b/src/compiler/filesystem_hybrid.cc
@@ -99,7 +99,7 @@ const char* FilesystemHybrid::getcwd(char* buffer, int buffer_size) {
 }
 
 void FilesystemHybrid::list_directory_entries(const char* path,
-                                              const std::function<bool (const char*)> callback) {
+                                              const std::function<bool (const char*)>& callback) {
   auto f = [&](const char* path, Filesystem* fs) {
     return fs->list_directory_entries(path, callback);
   };
@@ -107,14 +107,14 @@ void FilesystemHybrid::list_directory_entries(const char* path,
 }
 
 template<typename T>
-T FilesystemHybrid::do_with_active_fs(const std::function<T (Filesystem* fs)> callback) {
+T FilesystemHybrid::do_with_active_fs(const std::function<T (Filesystem* fs)>& callback) {
   if (use_fs_archive_) return callback(&fs_archive_);
   return callback(&fs_local_);
 }
 
 template<typename T>
 T FilesystemHybrid::do_with_active_fs(const char* path,
-                                      const std::function<T (const char* path, Filesystem* fs)> callback) {
+                                      const std::function<T (const char* path, Filesystem* fs)>& callback) {
   if (use_fs_archive_) {
     if (path == null || fs_archive_.contains_sdk()) {
       return callback(path, &fs_archive_);

--- a/src/compiler/filesystem_hybrid.h
+++ b/src/compiler/filesystem_hybrid.h
@@ -51,7 +51,7 @@ class FilesystemHybrid : public Filesystem {
 
   const char* getcwd(char* buffer, int buffer_size);
   void list_directory_entries(const char* path,
-                              const std::function<bool (const char*)> callback);
+                              const std::function<bool (const char*)>& callback);
 
  private:
   bool use_fs_archive_;
@@ -59,11 +59,11 @@ class FilesystemHybrid : public Filesystem {
   FilesystemArchive fs_archive_;
 
   template<typename T>
-  T do_with_active_fs(const std::function<T (Filesystem* fs)> callback);
+  T do_with_active_fs(const std::function<T (Filesystem* fs)>& callback);
 
   template<typename T>
   T do_with_active_fs(const char* path,
-                      const std::function<T (const char* path, Filesystem* fs)> callback);
+                      const std::function<T (const char* path, Filesystem* fs)>& callback);
 };
 
 } // namespace compiler

--- a/src/compiler/filesystem_local.cc
+++ b/src/compiler/filesystem_local.cc
@@ -101,7 +101,8 @@ List<const char*> FilesystemLocal::package_cache_paths() {
       if (is_windows) {
         separator = ";";
       }
-      package_cache_paths_ = string_split(strdup(cache_paths), separator);
+      package_cache_paths_buffer_ = strdup(cache_paths);
+      package_cache_paths_ = string_split(package_cache_paths_buffer_, separator);
     } else {
       char* home_path;
       if (is_windows) {
@@ -114,8 +115,8 @@ List<const char*> FilesystemLocal::package_cache_paths() {
         // However, the LSP server currently only looks at the env var.
         FATAL("Couldn't determine home");
       }
-      package_cache_paths_ = ListBuilder<const char*>::build(
-        compute_package_cache_path_from_home(home_path, this));
+      package_cache_paths_buffer_ = const_cast<char*>(compute_package_cache_path_from_home(home_path, this));
+      package_cache_paths_ = ListBuilder<const char*>::build(package_cache_paths_buffer_);
     }
   }
   return package_cache_paths_;
@@ -139,15 +140,25 @@ const uint8* FilesystemLocal::do_read_content(const char* path, int* size) {
     fclose(file);
     return null;
   }
-  int byte_count = ftell(file);
+  long file_size = ftell(file);
+  if (file_size < 0 || file_size > INT_MAX) {
+    fclose(file);
+    return null;
+  }
+  int byte_count = static_cast<int>(file_size);
   rewind(file);
 
   // Read in the entire file.
   uint8* buffer = unvoid_cast<uint8*>(malloc(byte_count + 1));
+  if (buffer == null) {
+    fclose(file);
+    return null;
+  }
   int result = fread(buffer, 1, byte_count, file);
   fclose(file);
   if (result != byte_count) {
     fprintf(stderr, "ERROR: Unable to read entire file '%s'\n", path);
+    free(buffer);
     return null;
   }
   buffer[byte_count] = '\0';
@@ -156,7 +167,7 @@ const uint8* FilesystemLocal::do_read_content(const char* path, int* size) {
 }
 
 void FilesystemLocal::list_directory_entries(const char* path,
-                                             const std::function<bool (const char*)> callback) {
+                                             const std::function<bool (const char*)>& callback) {
   if (!is_directory(path)) return;
   DIR* dir = opendir(path);
   if (dir == null) return;

--- a/src/compiler/filesystem_local.h
+++ b/src/compiler/filesystem_local.h
@@ -25,6 +25,15 @@ namespace compiler {
 
 class FilesystemLocal : public Filesystem {
  public:
+  ~FilesystemLocal() {
+#ifdef TOIT_WINDOWS
+    free(const_cast<char*>(sdk_path_));
+#else
+    delete[] sdk_path_;
+#endif
+    free(package_cache_paths_buffer_);
+  }
+
   void initialize(Diagnostics* diagnostics) {}
 
   const char* entry_path() { return null; }
@@ -56,10 +65,11 @@ class FilesystemLocal : public Filesystem {
 
   const char* getcwd(char* buffer, int buffer_size);
   void list_directory_entries(const char* path,
-                              const std::function<bool (const char*)> callback);
+                              const std::function<bool (const char*)>& callback);
 
  private:
   const char* sdk_path_ = null;
+  char* package_cache_paths_buffer_ = null;
   List<const char*> package_cache_paths_;
   bool has_computed_cache_paths_ = false;
 };

--- a/src/compiler/filesystem_local_win.cc
+++ b/src/compiler/filesystem_local_win.cc
@@ -71,12 +71,17 @@ static int root_prefix_length(const char* path) {
 const char* FilesystemLocal::relative_anchor(const char* path) {
   ASSERT(!is_absolute(path));
   if (path[0] == '/') {  // Safe to access even for empty strings.
-    // TODO(florian): error checking.
     DWORD result_length = GetFullPathName("/", 0, NULL, NULL);
-    char* result = unvoid_cast<char*>(malloc(result_length));
+    if (result_length == 0) FATAL("Couldn't resolve the current drive root");
+    char* result = unvoid_cast<char*>(malloc(result_length + 1));
+    if (result == null) FATAL("Couldn't allocate the current drive root");
 
-    GetFullPathName("/", result_length, result, NULL);
-    result[result_length] = '\0';
+    DWORD written = GetFullPathName("/", result_length, result, NULL);
+    if (written == 0 || written >= result_length) {
+      free(result);
+      FATAL("Couldn't resolve the current drive root");
+    }
+    result[written] = '\0';
     return result;
   }
   return cwd();

--- a/src/compiler/filesystem_lsp.cc
+++ b/src/compiler/filesystem_lsp.cc
@@ -63,7 +63,7 @@ const uint8* FilesystemLsp::do_read_content(const char* path, int* size) {
 }
 
 void FilesystemLsp::list_directory_entries(const char* path,
-                                           const std::function<bool (const char*)> callback) {
+                                           const std::function<bool (const char*)>& callback) {
   protocol_->list_directory_entries(path, callback);
 }
 

--- a/src/compiler/filesystem_lsp.h
+++ b/src/compiler/filesystem_lsp.h
@@ -72,7 +72,7 @@ class FilesystemLsp : public Filesystem {
 
   const char* getcwd(char* buffer, int buffer_size) { UNREACHABLE(); }
   void list_directory_entries(const char* path,
-                              const std::function<bool (const char*)> callback);
+                              const std::function<bool (const char*)>& callback);
 
  private:
   UnorderedMap<std::string, LspFsProtocol::PathInfo> file_cache_;

--- a/src/compiler/ir.h
+++ b/src/compiler/ir.h
@@ -1677,7 +1677,7 @@ class Lambda : public CallStatic {
          Map<Local*, int> captured_depths,
          Source::Range range)
       : CallStatic(method, shape, arguments, range)
-      , captured_depths_(captured_depths) {}
+      , captured_depths_(std::move(captured_depths)) {}
   IMPLEMENTS(Lambda)
 
   Code* code() const { return arguments()[0]->as_Code(); }

--- a/src/compiler/list.h
+++ b/src/compiler/list.h
@@ -18,6 +18,7 @@
 #include "../top.h"
 
 #include <vector>
+#include <utility>
 
 #include "../utils.h"
 
@@ -36,8 +37,12 @@ class ListBuilder {
     data_.clear();
   }
 
-  void add(T element) {
+  void add(const T& element) {
     data_.push_back(element);
+  }
+
+  void add(T&& element) {
+    data_.push_back(std::move(element));
   }
 
   void add(List<T> elements) {
@@ -83,28 +88,28 @@ class ListBuilder {
   static List<T> build(T element) {
     int len = 1;
     List<T> result = allocate(len);
-    *result.data() = element;
+    *result.data() = std::move(element);
     return result;
   }
 
   static List<T> build(T element1, T element2) {
     int len = 2;
     List<T> result = allocate(len);
-    result[0] = element1;
-    result[1] = element2;
+    result[0] = std::move(element1);
+    result[1] = std::move(element2);
     return result;
   }
 
   static List<T> build(T element1, T element2, T element3) {
     int len = 3;
     List<T> result = allocate(len);
-    result[0] = element1;
-    result[1] = element2;
-    result[2] = element3;
+    result[0] = std::move(element1);
+    result[1] = std::move(element2);
+    result[2] = std::move(element3);
     return result;
   }
 
-  static List<T> build_from_vector(const std::vector<T> vector) {
+  static List<T> build_from_vector(const std::vector<T>& vector) {
     int len = vector.size();
     List<T> result = allocate(len);
     for (int i = 0; i < len; i++) {

--- a/src/compiler/lock.cc
+++ b/src/compiler/lock.cc
@@ -101,7 +101,7 @@ Package PackageLock::package_for(const std::string& path, Filesystem* fs) const 
       auto probe = path_to_package_cache_.find(sub);
       if (probe != path_to_package_cache_.end()) {
         path_to_package_cache_[path] = probe->second;
-        for (auto p : to_cache) {
+        for (const auto& p : to_cache) {
           path_to_package_cache_[p] = probe->second;
         }
         return packages_.at(probe->second);
@@ -176,7 +176,7 @@ static std::string build_canonical_sdk_dir(Filesystem* fs) {
 }
 
 void PackageLock::list_sdk_prefixes(const std::function<void (const std::string& candidate)>& callback) const {
-  for (auto sdk_prefix : sdk_prefixes_) {
+  for (const auto& sdk_prefix : sdk_prefixes_) {
     callback(sdk_prefix);
   }
 }
@@ -191,7 +191,7 @@ PackageLock::PackageLock(Source* lock_source,
     , sdk_prefixes_(sdk_prefixes)
     , packages_(packages)
     , sdk_constraint_(sdk_constraint) {
-  for (auto id : packages.keys()) {
+  for (const auto& id : packages.keys()) {
     auto package = packages.at(id);
     if (!package.has_valid_path()) continue;
     path_to_package_cache_[package.absolute_path()] = id;
@@ -260,7 +260,7 @@ static Map<std::string, std::string> build_diagnostic_package_ids(
     auto prefixes_probe = lock_content.prefixes.find(owner);
     if (prefixes_probe == lock_content.prefixes.end()) continue;
     const auto& prefixes = prefixes_probe->second;
-    for (auto prefix : prefixes.keys()) {
+    for (const auto& prefix : prefixes.keys()) {
       auto target = prefixes.at(prefix);
       if (!lock_content.packages.contains_key(target)) continue;
 
@@ -279,13 +279,13 @@ static Map<std::string, std::string> build_diagnostic_package_ids(
   }
 
   Map<std::string, int> name_counts;
-  for (auto package_id : lock_content.packages.keys()) {
+  for (const auto& package_id : lock_content.packages.keys()) {
     auto name = lock_content.packages.at(package_id).name;
     if (!name.empty()) name_counts[name]++;
   }
 
   Map<std::string, std::string> result;
-  for (auto package_id : lock_content.packages.keys()) {
+  for (const auto& package_id : lock_content.packages.keys()) {
     auto path_probe = shortest_paths.find(package_id);
     if (path_probe != shortest_paths.end()) {
       result[package_id] = path_probe->second.path;
@@ -1017,7 +1017,9 @@ PackageLock PackageLock::read(const std::string& lock_file_path,
   }
 
   ASSERT(!is_valid_package_id(Package::ENTRY_PACKAGE_ID));
-  std::string root(fs->root(entry_path));
+  char* root_buffer = fs->root(entry_path);
+  std::string root(root_buffer);
+  delete[] root_buffer;
   std::string absolute_error_path = root;
   std::string relative_error_path = root;
   if (!entry_is_absolute) {
@@ -1064,7 +1066,7 @@ PackageLock PackageLock::read(const std::string& lock_file_path,
   fill_package_mappings(&mappings, package_dirs, fs);
 
   Map<std::string, std::string> path_to_package;
-  for (auto package_id : lock_content.packages.keys()) {
+  for (const auto& package_id : lock_content.packages.keys()) {
     auto entry = lock_content.packages.at(package_id);
 
     auto locate_package = [&](std::string path, const std::string& error_path, bool is_path_package) -> Package {
@@ -1194,7 +1196,7 @@ PackageLock PackageLock::read(const std::string& lock_file_path,
     packages[package_id] = package;
   }
   auto diagnostic_package_ids = build_diagnostic_package_ids(lock_content);
-  for (auto package_id : lock_content.packages.keys()) {
+  for (const auto& package_id : lock_content.packages.keys()) {
     packages[package_id].diagnostic_id_ = diagnostic_package_ids.at(package_id);
   }
 

--- a/src/compiler/lsp/completion.cc
+++ b/src/compiler/lsp/completion.cc
@@ -89,7 +89,7 @@ void CompletionHandler::type(ast::Node* node,
     important_core_types.insert("Set");
   }
 
-  for (auto core_type : important_core_types) {
+  for (const auto& core_type : important_core_types) {
     complete(core_type, CompletionKind::CLASS);
   }
   scope->for_each([&](Symbol name, const ResolutionEntry& entry) {

--- a/src/compiler/lsp/fs_protocol.cc
+++ b/src/compiler/lsp/fs_protocol.cc
@@ -40,7 +40,7 @@ List<const char*> LspFsProtocol::package_cache_paths() {
 }
 
 void LspFsProtocol::list_directory_entries(const char* path,
-                                           const std::function<bool (const char*)> callback) {
+                                           const std::function<bool (const char*)>& callback) {
   connection_->putline("LIST DIRECTORY");
   connection_->putline(path);
 

--- a/src/compiler/lsp/fs_protocol.h
+++ b/src/compiler/lsp/fs_protocol.h
@@ -52,7 +52,7 @@ class LspFsProtocol {
   const char* sdk_path();
   List<const char*> package_cache_paths();
   void list_directory_entries(const char* path,
-                              const std::function<bool (const char*)> callback);
+                              const std::function<bool (const char*)>& callback);
 
   PathInfo fetch_info_for(const char* path);
 

--- a/src/compiler/lsp/goto_definition.cc
+++ b/src/compiler/lsp/goto_definition.cc
@@ -160,7 +160,7 @@ void GotoDefinitionHandler::call_virtual(ir::CallVirtual* node,
   }
 
   // Apparently we didn't find a full match. Propose the candidates instead.
-  for (auto shape : candidates.keys()) {
+  for (const auto& shape : candidates.keys()) {
     _print_range(candidates[shape]->range());
   }
 }
@@ -328,4 +328,3 @@ void GotoDefinitionHandler::import_path(const char* path,
 
 } // namespace toit::compiler
 } // namespace toit
-

--- a/src/compiler/lsp/protocol_summary.cc
+++ b/src/compiler/lsp/protocol_summary.cc
@@ -199,7 +199,7 @@ class ToitdocWriter : public toitdoc::Visitor {
   LspWriter* lsp_writer_;
 
   template<typename T, typename T2>
-  void print_list(T elements, void (ToitdocWriter::*callback)(T2)) {
+  void print_list(const T& elements, void (ToitdocWriter::*callback)(T2)) {
     this->printf("%d\n", length_of(elements));
     for (auto element : elements) { (this->*callback)(element); }
   }
@@ -329,25 +329,25 @@ class Writer {
 
 
   template<typename T, typename T2>
-  void print_list(T elements, void (Writer::*callback)(T2)) {
+  void print_list(const T& elements, void (Writer::*callback)(T2)) {
     this->printf("%d\n", length_of(elements));
     for (auto element : elements) { (this->*callback)(element); }
   }
 
   template<typename T, typename F>
-  void print_list(T elements, F callback) {
+  void print_list(const T& elements, F callback) {
     this->printf("%d\n", length_of(elements));
     for (auto element : elements) { callback(element); }
   }
 
   template<typename T, typename T2>
-  void print_list_external(T elements, void (Writer::*callback)(T2)) {
+  void print_list_external(const T& elements, void (Writer::*callback)(T2)) {
     this->printf_external("%d\n", length_of(elements));
     for (auto element : elements) { (this->*callback)(element); }
   }
 
   template<typename T, typename F>
-  void print_list_external(T elements, F callback) {
+  void print_list_external(const T& elements, F callback) {
     this->printf_external("%d\n", length_of(elements));
     for (auto element : elements) { callback(element); }
   }
@@ -765,7 +765,7 @@ class ToitdocPathMappingCreator {
   UnorderedMap<ir::Node*, ToitdocPath> mapping_;
 
   template<typename Container>
-  void visit_container(ToitdocPath::Kind kind, Module* module, ir::Class* klass, Container list) {
+  void visit_container(ToitdocPath::Kind kind, Module* module, ir::Class* klass, const Container& list) {
     for (auto element : list) {
       if (ref_targets_.contains(element)) {
         mapping_[element] = {

--- a/src/compiler/map.h
+++ b/src/compiler/map.h
@@ -44,12 +44,12 @@ template<typename K, typename V> class Map {
     }
   }
 
-  V at(const K& key) { return map_.at(key); }
-  const V at(const K& key) const { return map_.at(key); }
+  V& at(const K& key) { return map_.at(key); }
+  const V& at(const K& key) const { return map_.at(key); }
 
   template<typename F>
   void for_each(const F& callback) {
-    for (auto key : vector_) {
+    for (const auto& key : vector_) {
       callback(key, map_[key]);
     }
   }
@@ -99,10 +99,11 @@ template<typename K, typename V> class Map<K, V*> {
   }
 
   V* at(const K& key) { return map_.at(key); }
+  V* at(const K& key) const { return map_.at(key); }
 
   template<typename F>
   void for_each(const F& callback) {
-    for (auto key : vector_) {
+    for (const auto& key : vector_) {
       callback(key, map_[key]);
     }
   }

--- a/src/compiler/mixin.cc
+++ b/src/compiler/mixin.cc
@@ -414,7 +414,7 @@ static Map<ir::Field*, ir::Field*> apply_mixins(ir::Class* klass) {
 /// invoked.
 class ConstructorVisitor : protected SuperCallVisitor {
  public:
-  ConstructorVisitor(ir::Class* holder, Map<ir::Field*, ir::Field*> field_map)
+  ConstructorVisitor(ir::Class* holder, const Map<ir::Field*, ir::Field*>& field_map)
       : SuperCallVisitor(holder)
       , mixins_(holder->mixins())
       , field_map_(field_map) {}
@@ -606,12 +606,12 @@ class ConstructorVisitor : protected SuperCallVisitor {
 
  private:
   List<ir::Class*> mixins_;
-  Map<ir::Field*, ir::Field*> field_map_;
+  const Map<ir::Field*, ir::Field*>& field_map_;
   ir::Parameter* outer_this_param_;
 };
 
 /// Changes super calls so that they call mixin constructors as well.
-void adjust_super_calls(ir::Class* klass, Map<ir::Field*, ir::Field*> field_map) {
+void adjust_super_calls(ir::Class* klass, const Map<ir::Field*, ir::Field*>& field_map) {
   ConstructorVisitor visitor(klass, field_map);
   for (auto constructor : klass->unnamed_constructors()) {
     visitor.visit(constructor);

--- a/src/compiler/optimizations/optimizations.cc
+++ b/src/compiler/optimizations/optimizations.cc
@@ -78,14 +78,14 @@ class OptimizationVisitor : public ReplacingVisitor {
  public:
   OptimizationVisitor(TypeOracle* oracle,
                       List<ir::Type> literal_types,
-                      const UnorderedMap<Class*, QueryableClass> queryables,
-                      const UnorderedSet<Symbol>& field_names)
+                      UnorderedMap<Class*, QueryableClass> queryables,
+                      UnorderedSet<Symbol> field_names)
       : oracle_(oracle)
       , holder_(null)
       , method_(null)
       , literal_types_(literal_types)
-      , queryables_(queryables)
-      , field_names_(field_names) {}
+      , queryables_(std::move(queryables))
+      , field_names_(std::move(field_names)) {}
 
   Node* visit_Method(Method* node) {
     if (node->is_dead()) return node;
@@ -175,7 +175,10 @@ void optimize(Program* program, TypeOracle* oracle) {
     }
   }
 
-  OptimizationVisitor visitor(oracle, program->literal_types(), direct_queryables, field_names);
+  OptimizationVisitor visitor(oracle,
+                              program->literal_types(),
+                              std::move(direct_queryables),
+                              std::move(field_names));
 
   for (auto klass : classes) {
     visitor.set_class(klass);

--- a/src/compiler/package.cc
+++ b/src/compiler/package.cc
@@ -49,7 +49,7 @@ std::string Package::build_error_path(Filesystem* fs, const std::string& path) c
 }
 
 void Package::list_prefixes(const std::function<void (const std::string& candidate)>& callback) const{
-  for (auto prefix : prefixes_.keys()) {
+  for (const auto& prefix : prefixes_.keys()) {
     callback(prefix);
   }
 }

--- a/src/compiler/package.h
+++ b/src/compiler/package.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 #include <functional>
 
 #include "../top.h"
@@ -114,7 +115,7 @@ class Package {
       , absolute_error_path_(absolute_error_path)
       , relative_error_path_(relative_error_path)
       , error_state_(state)
-      , prefixes_(prefixes)
+      , prefixes_(std::move(prefixes))
       , is_path_package_(is_path_package) {}
 
   std::string id_ = std::string(INVALID_PACKAGE_ID);

--- a/src/compiler/propagation/type_database.cc
+++ b/src/compiler/propagation/type_database.cc
@@ -39,9 +39,11 @@ TypeDatabase::TypeDatabase(Program* program, int words_per_type)
 }
 
 TypeDatabase::~TypeDatabase() {
-  for (auto it : types_) {
-    delete it;
-  }
+  auto probe = cache_.find(program_);
+  if (probe != cache_.end() && probe->second == this) cache_.erase(probe);
+  for (auto& entry : methods_) delete entry.second;
+  for (auto& entry : input_) delete entry.second;
+  for (auto stack : types_) delete stack;
 }
 
 void TypeDatabase::check_top(uint8* bcp, Object* value) const {
@@ -212,7 +214,7 @@ std::string TypeDatabase::as_json() const {
   out << "[\n";
 
   bool first = true;
-  for (auto it : output_) {
+  for (const auto& it : output_) {
     if (first) {
       first = false;
     } else {
@@ -238,7 +240,7 @@ std::string TypeDatabase::as_json() const {
     out << ", \"output\": " << output_string << "}";
   }
 
-  for (auto it : methods_) {
+  for (const auto& it : methods_) {
     if (first) {
       first = false;
     } else {

--- a/src/compiler/propagation/type_propagator.cc
+++ b/src/compiler/propagation/type_propagator.cc
@@ -76,6 +76,19 @@ TypePropagator::TypePropagator(
   TypePrimitive::set_up();
 }
 
+TypePropagator::~TypePropagator() {
+  for (auto& entry : methods_) delete entry.second;
+  for (auto& entry : blocks_) delete entry.second;
+  for (auto& entry : globals_) delete entry.second;
+  for (auto& type_entry : fields_) {
+    for (auto& field_entry : type_entry.second) delete field_entry.second;
+  }
+  for (auto& entry : outers_) delete entry.second;
+  for (auto& entry : input_.underlying_map()) {
+    for (auto variable : entry.second) delete variable;
+  }
+}
+
 word TypePropagator::selector_offset(Method method) const {
   if (method_selector_offsets_ == null ||
       (!method.is_normal_method() && !method.is_field_accessor())) {
@@ -800,7 +813,7 @@ void TypePropagator::add_output(uint8* site, TypeVariable* output) {
   output_[site].insert(output);
 }
 
-MethodTemplate* TypePropagator::find_method(Method target, std::vector<ConcreteType> arguments) {
+MethodTemplate* TypePropagator::find_method(Method target, const std::vector<ConcreteType>& arguments) {
   uint32 key = ConcreteType::hash(target, arguments, false);
   auto it = methods_.find(key);
   MethodTemplate* head = (it != methods_.end()) ? it->second : null;
@@ -1557,7 +1570,7 @@ static TypeScope* process(TypeScope* scope, uint8* bcp, std::vector<Worklist*>& 
   OPCODE_END();
 }
 
-bool MethodTemplate::matches(Method target, std::vector<ConcreteType>& arguments) const {
+bool MethodTemplate::matches(Method target, const std::vector<ConcreteType>& arguments) const {
   if (target.entry() != method_.entry()) return false;
   return ConcreteType::equals(arguments_, arguments, false);
 }

--- a/src/compiler/propagation/type_propagator.h
+++ b/src/compiler/propagation/type_propagator.h
@@ -48,6 +48,7 @@ class TypePropagator {
   TypePropagator(
       Program* program,
       const MethodSelectorOffsets* method_selector_offsets = null);
+  ~TypePropagator();
 
   Program* program() const { return program_; }
   int words_per_type() const { return words_per_type_; }
@@ -114,13 +115,13 @@ class TypePropagator {
                        int arity,
                        std::vector<Worklist*>& worklists);
 
-  MethodTemplate* find_method(Method target, std::vector<ConcreteType> arguments);
+  MethodTemplate* find_method(Method target, const std::vector<ConcreteType>& arguments);
   BlockTemplate* find_block(MethodTemplate* origin, Method method, int level, int sp);
 };
 
 class MethodTemplate {
  public:
-  MethodTemplate(MethodTemplate* next, TypePropagator* propagator, Method method, std::vector<ConcreteType> arguments)
+  MethodTemplate(MethodTemplate* next, TypePropagator* propagator, Method method, const std::vector<ConcreteType>& arguments)
       : next_(next)
       , propagator_(propagator)
       , method_(method)
@@ -140,7 +141,7 @@ class MethodTemplate {
   Method method() const { return method_; }
   int method_id() const;
 
-  bool matches(Method target, std::vector<ConcreteType>& arguments) const;
+  bool matches(Method target, const std::vector<ConcreteType>& arguments) const;
 
   bool analyzed() const { return analyzed_; }
   bool enqueued() const { return enqueued_; }

--- a/src/compiler/propagation/type_set.h
+++ b/src/compiler/propagation/type_set.h
@@ -75,8 +75,7 @@ class TypeSet {
     uword* const end_;
   };
 
-  TypeSet(const TypeSet& other)
-      : bits_(other.bits_) {}
+  TypeSet(const TypeSet& other) = default;
 
   static TypeSet invalid() {
     return TypeSet(null);

--- a/src/compiler/resolver.cc
+++ b/src/compiler/resolver.cc
@@ -425,7 +425,7 @@ void Resolver::check_clashing_or_conflicting(Symbol name, List<ir::Node*> declar
       }
     }
 
-    for (auto key : declarations_per_selector.keys()) {
+    for (const auto& key : declarations_per_selector.keys()) {
       auto declarations = declarations_per_selector[key];
       if (declarations.size() != 1) {
         // If we have duplicate fields we don't want to report setter and getter
@@ -590,7 +590,7 @@ void Resolver::check_clashing_or_conflicting(Symbol name, List<ir::Node*> declar
   }
 }
 
-void Resolver::check_clashing_or_conflicting(std::vector<Module*> modules) {
+void Resolver::check_clashing_or_conflicting(const std::vector<Module*>& modules) {
   for (auto module : modules) {
     // Check the top-level entries first.
     auto module_entries = module->scope()->entries();
@@ -630,7 +630,7 @@ void Resolver::check_clashing_or_conflicting(std::vector<Module*> modules) {
   }
 }
 
-void Resolver::check_future_reserved_globals(std::vector<Module*> modules) {
+void Resolver::check_future_reserved_globals(const std::vector<Module*>& modules) {
   // We have checked already all identifiers except for globals. This is,
   // because we didn't know yet which methods were from the core libraries.
   // This information is present now.
@@ -687,7 +687,7 @@ static void report_unresolved_show(Module::PrefixedModule& prefixed_module,
   diagnostics->report_error(ast_identifier, "Unresolved show '%s'", name.c_str());
 }
 
-static void report_cyclic_export(std::vector<Module*> cyclic_modules,
+static void report_cyclic_export(const std::vector<Module*>& cyclic_modules,
                                  Symbol name,
                                  UnorderedSet<Module*>* already_reported_modules,
                                  Diagnostics* diagnostics) {
@@ -1232,7 +1232,7 @@ ir::Class* Resolver::resolve_class_interface_or_mixin(ast::Expression* ast_node,
 /// - the supers of classes exist.
 /// - the class hierarchy isn't cyclic.
 /// - there aren't any mismatches (classes extending interfaces, ...)
-void Resolver::setup_inheritance(std::vector<Module*> modules, int core_module_index) {
+void Resolver::setup_inheritance(const std::vector<Module*>& modules, int core_module_index) {
   Module* core_module = modules[core_module_index];
   auto core_scope = core_module->scope();
   ir::Class* top = core_scope->lookup_shallow(Symbols::Object).klass();
@@ -1752,7 +1752,7 @@ void Resolver::check_class(ast::Class* klass) {
 /// Fills in skeleton information of classes.
 ///
 /// Fills in all members.
-void Resolver::fill_classes_with_skeletons(std::vector<Module*> modules) {
+void Resolver::fill_classes_with_skeletons(const std::vector<Module*>& modules) {
   for (auto module : modules) {
     // Fill in all members.
     for (auto ir_class : module->classes()) {
@@ -1971,7 +1971,7 @@ static void fill_abstract_methods_map(ir::Class* ir_class,
   }
 
   Map<Selector<ResolutionShape>, ir::Method*> class_abstracts;
-  for (auto selector : super_abstracts.keys()) {
+  for (const auto& selector : super_abstracts.keys()) {
     ir::Method* method = super_abstracts.at(selector);
     if (method->is_abstract()) {
       class_abstracts[selector] = method;
@@ -1980,7 +1980,7 @@ static void fill_abstract_methods_map(ir::Class* ir_class,
   for (auto mixin : ir_class->mixins()) {
     fill_abstract_methods_map(mixin, abstract_methods, diagnostics);
     auto mixin_abstracts = abstract_methods->at(mixin);
-    for (auto selector : mixin_abstracts.keys()) {
+    for (const auto& selector : mixin_abstracts.keys()) {
       ir::Method* method = mixin_abstracts.at(selector);
       class_abstracts[selector] = method;
     }
@@ -2010,7 +2010,7 @@ static void fill_abstract_methods_map(ir::Class* ir_class,
 
 /// Checks that the klass has its mixins flattened.
 /// Only does a conservative check.
-static bool mixins_are_flattened(std::vector<Module*> modules) {
+static bool mixins_are_flattened(const std::vector<Module*>& modules) {
   for (auto module : modules) {
     for (auto klass : module->classes()) {
       if (klass->mixins().is_empty()) continue;
@@ -2040,16 +2040,16 @@ static bool mixins_are_flattened(std::vector<Module*> modules) {
   return true;
 }
 
-void Resolver::report_abstract_classes(std::vector<Module*> modules) {
+void Resolver::report_abstract_classes(const std::vector<Module*>& modules) {
   ASSERT(mixins_are_flattened(modules));
   UnorderedMap<ir::Class*, Map<Selector<ResolutionShape>, ir::Method*>> abstract_methods;
 
   Map<ir::Class*, Map<Symbol, std::vector<ResolutionShape>>> all_method_shapes;
   // Lazily fill the method shapes.
-  auto method_shapes_for = [&](ir::Class* klass) {
+  auto method_shapes_for = [&](ir::Class* klass) -> const Map<Symbol, std::vector<ResolutionShape>>& {
     auto probe = all_method_shapes.find(klass);
     if (probe != all_method_shapes.end()) return probe->second;
-    Map<Symbol, std::vector<ResolutionShape>> result;
+    auto& result = all_method_shapes[klass];
     for (auto method : klass->methods()) {
       if (method->is_abstract()) continue;
       auto name = method->name();
@@ -2095,7 +2095,7 @@ void Resolver::report_abstract_classes(std::vector<Module*> modules) {
       auto class_abstracts = abstract_methods.at(ir_class);
       if (class_abstracts.empty()) continue;
       bool has_abstract_method = false;
-      for (auto selector : class_abstracts.keys()) {
+      for (const auto& selector : class_abstracts.keys()) {
         if (class_abstracts[selector]->is_abstract()) {
           has_abstract_method = true;
           break;
@@ -2108,7 +2108,7 @@ void Resolver::report_abstract_classes(std::vector<Module*> modules) {
       // We might have a non-implemented abstract method.
       // Do a more thorough check that handles optional arguments as well.
       // We also look at super classes of the abstract class now.
-      for (auto selector : class_abstracts.keys()) {
+      for (const auto& selector : class_abstracts.keys()) {
         auto method = class_abstracts[selector];
         if (method->is_abstract()) {
           auto shape = method->resolution_shape();
@@ -2119,10 +2119,10 @@ void Resolver::report_abstract_classes(std::vector<Module*> modules) {
           auto contributing_classes = contributing_for(ir_class);
 
           for (auto contributing : contributing_classes) {
-            auto shapes = method_shapes_for(contributing);
+            const auto& shapes = method_shapes_for(contributing);
             auto probe = shapes.find(name);
             if (probe != shapes.end()) {
-              for (auto shape : probe->second) {
+              for (const auto& shape : probe->second) {
                 potentially_implementing.push_back(shape);
               }
             }
@@ -2163,7 +2163,7 @@ void Resolver::report_abstract_classes(std::vector<Module*> modules) {
   }
 }
 
-void Resolver::check_interface_implementations_and_flatten(std::vector<Module*> modules) {
+void Resolver::check_interface_implementations_and_flatten(const std::vector<Module*>& modules) {
   ASSERT(mixins_are_flattened(modules));
   // For each interface, the set it represents.
   UnorderedMap<ir::Class*, Set<ir::Class*>> flattened_interfaces;
@@ -2236,7 +2236,7 @@ void Resolver::check_interface_implementations_and_flatten(std::vector<Module*> 
         // Do a more expensive check.
         UnorderedMap<Selector<ResolutionShape>, CallShape> really_missing_methods;
 
-        for (auto method_selector : maybe_missing_methods.underlying_set())  {
+        for (const auto& method_selector : maybe_missing_methods.underlying_set())  {
           auto name = method_selector.name();
           auto shape = method_selector.shape();
           auto probe = all_existing_shapes.find(name);
@@ -2276,7 +2276,7 @@ void Resolver::check_interface_implementations_and_flatten(std::vector<Module*> 
   }
 }
 
-void Resolver::flatten_mixins(std::vector<Module*> modules) {
+void Resolver::flatten_mixins(const std::vector<Module*>& modules) {
   // For each mixin, the flatten list of mixins it represents.
   // For example:
   //     mixin Mix1:

--- a/src/compiler/resolver.h
+++ b/src/compiler/resolver.h
@@ -145,16 +145,16 @@ class Resolver {
   void build_module_scopes(std::vector<Module*>& modules);
 
   void check_clashing_or_conflicting(Symbol name, List<ir::Node*> declarations);
-  void check_clashing_or_conflicting(std::vector<Module*> modules);
-  void check_future_reserved_globals(std::vector<Module*> modules);
+  void check_clashing_or_conflicting(const std::vector<Module*>& modules);
+  void check_future_reserved_globals(const std::vector<Module*>& modules);
 
   void mark_runtime(Module* core_module);
   void mark_non_returning(Module* core_module);
 
-  void setup_inheritance(std::vector<Module*> modules, int core_module_index);
-  void report_abstract_classes(std::vector<Module*> modules);
-  void check_interface_implementations_and_flatten(std::vector<Module*> modules);
-  void flatten_mixins(std::vector<Module*> modules);
+  void setup_inheritance(const std::vector<Module*>& modules, int core_module_index);
+  void report_abstract_classes(const std::vector<Module*>& modules);
+  void check_interface_implementations_and_flatten(const std::vector<Module*>& modules);
+  void flatten_mixins(const std::vector<Module*>& modules);
   List<ir::Class*> find_tree_roots(Module* core_module);
   List<ir::Method*> find_entry_points(Module* core_module);
   List<ir::Type> find_literal_types(Module* core_module);
@@ -164,7 +164,7 @@ class Resolver {
                     bool allow_future_reserved);
   void check_field(ast::Field* method, ir::Class* holder);
   void check_class(ast::Class* klass);
-  void fill_classes_with_skeletons(std::vector<Module*> modules);
+  void fill_classes_with_skeletons(const std::vector<Module*>& modules);
   void resolve_fill_module(Module* module,
                            Module* entry_module,
                            Module* core_module);

--- a/src/compiler/resolver_scope.h
+++ b/src/compiler/resolver_scope.h
@@ -210,7 +210,7 @@ class FilteredIterableScope : public IterableScope {
   FilteredIterableScope(IterableScope* wrapped,
                         std::function<bool (Symbol, const ResolutionEntry&)> predicate)
       : wrapped_(wrapped)
-      , predicate_(predicate) {}
+      , predicate_(std::move(predicate)) {}
 
   void for_each(const std::function<void (Symbol, const ResolutionEntry&)>& callback) {
     wrapped_->for_each([&] (Symbol symbol, const ResolutionEntry& entry) {
@@ -627,7 +627,7 @@ class ModuleScope : public Scope {
   ResolutionEntryMap exported_identifiers_map() const { return exported_identifiers_map_; }
 
   void set_exported_identifiers_map(ResolutionEntryMap exported_identifiers_map) {
-    exported_identifiers_map_ = exported_identifiers_map;
+    exported_identifiers_map_ = std::move(exported_identifiers_map);
     exported_identifiers_map_has_been_set_ = true;
   }
 

--- a/src/compiler/selector.cc
+++ b/src/compiler/selector.cc
@@ -149,7 +149,7 @@ void CallBuilder::sort_arguments(std::vector<Arg>* args) {
 // The given [fun] function may freely reorder all arguments without
 // worrying about evaluation order.
 ir::Expression* CallBuilder::with_hoisted_args(ir::Expression* target,
-                                               std::function<ir::Expression* (ir::Expression*)> fun) {
+                                               const std::function<ir::Expression* (ir::Expression*)>& fun) {
 
   // Just a few shortcuts.
   if (target == null || !target->is_block()) {
@@ -198,7 +198,7 @@ ir::Expression* CallBuilder::with_hoisted_args(ir::Expression* target,
 
 ir::Expression* CallBuilder::do_call_static(ResolutionShape shape,
                                             bool has_implicit_this,
-                                            std::function<ir::Call* (CallShape shape, List<ir::Expression*>)> create_call) {
+                                            const std::function<ir::Call* (CallShape shape, List<ir::Expression*>)>& create_call) {
   return with_hoisted_args(null, [&](ir::Expression* _) {
     // For simplicity, remove the implicit this from the shape if necessary.
     if (has_implicit_this) shape = shape.without_implicit_this();
@@ -277,7 +277,7 @@ ir::Expression* CallBuilder::do_call_static(ResolutionShape shape,
 }
 
 ir::Expression* CallBuilder::do_call_instance(ir::Dot* dot,
-                                              std::function<ir::Call* (ir::Dot* dot, CallShape shape, List<ir::Expression*>)> create_call) {
+                                              const std::function<ir::Call* (ir::Dot* dot, CallShape shape, List<ir::Expression*>)>& create_call) {
   return with_hoisted_args(dot->receiver(), [&](ir::Expression* new_receiver) {
     dot->replace_receiver(new_receiver);
     int arity = args_.size();
@@ -307,7 +307,7 @@ ir::Expression* CallBuilder::do_call_instance(ir::Dot* dot,
 }
 
 ir::Expression* CallBuilder::do_block_call(ir::Expression* block,
-                                           std::function<ir::Call* (ir::Expression* block, CallShape shape, List<ir::Expression*>)> create_call) {
+                                           const std::function<ir::Call* (ir::Expression* block, CallShape shape, List<ir::Expression*>)>& create_call) {
   return with_hoisted_args(block, [&](ir::Expression* new_block) {
     int arity = args_.size();
     auto ir_arguments = ListBuilder<ir::Expression*>::allocate(arity);
@@ -319,7 +319,7 @@ ir::Expression* CallBuilder::do_block_call(ir::Expression* block,
 
 void CallBuilder::match_arguments_with_parameters(CallShape call_shape,
                                                   ResolutionShape resolution_shape,
-                                                  const std::function<void (int argument_index, int parameter_index)> callback) {
+                                                  const std::function<void (int argument_index, int parameter_index)>& callback) {
   ASSERT(resolution_shape.accepts(call_shape));
   int arg_index = 0;
   int parameter_index = 0;
@@ -347,4 +347,3 @@ void CallBuilder::match_arguments_with_parameters(CallShape call_shape,
 
 } // namespace toit::compiler
 } // namespace toit
-

--- a/src/compiler/selector.h
+++ b/src/compiler/selector.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <functional>
+#include <utility>
 #include <vector>
 
 #include "list.h"
@@ -47,7 +48,7 @@ namespace ast {
 template<typename Shape>
 class Selector {
  public:
-  Selector(Symbol name, Shape shape) : name_(name), shape_(shape) {}
+  Selector(Symbol name, Shape shape) : name_(name), shape_(std::move(shape)) {}
 
   Symbol name() const { return name_; }
 
@@ -114,7 +115,7 @@ class CallBuilder {
 
   static void match_arguments_with_parameters(CallShape call_shape,
                                               ResolutionShape resolution_shape,
-                                              const std::function<void (int argument_index, int parameter_index)> callback);
+                                              const std::function<void (int argument_index, int parameter_index)>& callback);
  private:
   struct Arg {
     Arg() : expression(null), is_block(false), name(Symbol::invalid()) {}
@@ -143,15 +144,15 @@ class CallBuilder {
   // The given [fun] function may freely reorder all arguments without
   // worrying about evaluation order.
   ir::Expression* with_hoisted_args(ir::Expression* target,
-                                    std::function<ir::Expression* (ir::Expression*)> fun);
+                                    const std::function<ir::Expression* (ir::Expression*)>& fun);
 
   ir::Expression* do_call_static(ResolutionShape shape,
                                  bool has_implicit_this,
-                                 std::function<ir::Call* (CallShape shape, List<ir::Expression*>)> create_call);
+                                 const std::function<ir::Call* (CallShape shape, List<ir::Expression*>)>& create_call);
   ir::Expression* do_call_instance(ir::Dot* dot,
-                                   std::function<ir::Call* (ir::Dot* dot, CallShape shape, List<ir::Expression*>)> create_call);
+                                   const std::function<ir::Call* (ir::Dot* dot, CallShape shape, List<ir::Expression*>)>& create_call);
   ir::Expression* do_block_call(ir::Expression* block,
-                                std::function<ir::Call* (ir::Expression* block, CallShape shape, List<ir::Expression*>)> create_call);
+                                const std::function<ir::Call* (ir::Expression* block, CallShape shape, List<ir::Expression*>)>& create_call);
 };
 
 } // namespace toit::compiler

--- a/src/compiler/set.h
+++ b/src/compiler/set.h
@@ -26,7 +26,7 @@ namespace compiler {
 
 template<typename T> class Set {
  public:
-  bool insert(T x) {
+  bool insert(const T& x) {
     auto p = set_.insert(x);
     if (!p.second) return false;
     vector_.push_back(x);
@@ -63,7 +63,7 @@ template<typename T> class Set {
     }
   }
 
-  void erase_last(T x) {
+  void erase_last(const T& x) {
     ASSERT(vector_.back() == x);
     set_.erase(x);
     vector_.pop_back();
@@ -74,7 +74,7 @@ template<typename T> class Set {
   typename std::vector<T>::const_iterator begin() const { return vector_.begin(); }
   typename std::vector<T>::const_iterator end() const { return vector_.end(); }
 
-  bool contains(T x) const { return set_.find(x) != set_.end(); }
+  bool contains(const T& x) const { return set_.find(x) != set_.end(); }
   bool empty() const { return set_.empty(); }
   void clear() { set_.clear(); vector_.clear(); }
   int size() const { return static_cast<int>(set_.size()); }
@@ -91,7 +91,7 @@ template<typename T> class Set {
 /// how we use it.
 template<typename T> class UnorderedSet {
  public:
-  void insert(T x) { set_.insert(x); }
+  void insert(const T& x) { set_.insert(x); }
   template<class InputIt> void insert(InputIt begin, InputIt end) { set_.insert(begin, end); }
   void insert_all(const UnorderedSet<T>& other_set) {
     set_.insert(other_set.set_.begin(), other_set.set_.end());
@@ -99,7 +99,7 @@ template<typename T> class UnorderedSet {
   void insert_all(const Set<T>& other_set) {
     set_.insert(other_set.begin(), other_set.end());
   }
-  bool erase(T x) { return set_.erase(x) > 0; }
+  bool erase(const T& x) { return set_.erase(x) > 0; }
 
   template<typename F>
   void erase_if(const F& callback) {
@@ -125,7 +125,7 @@ template<typename T> class UnorderedSet {
     set_.erase(other_set.set_.begin(), other_set.set_.end());
   }
 
-  bool contains(T x) const { return set_.find(x) != set_.end(); }
+  bool contains(const T& x) const { return set_.find(x) != set_.end(); }
   bool empty() const { return set_.empty(); }
   void clear() { set_.clear(); }
   int size() const { return static_cast<int>(set_.size()); }

--- a/src/compiler/shape.cc
+++ b/src/compiler/shape.cc
@@ -163,8 +163,8 @@ bool ResolutionShape::overlaps_with(const ResolutionShape& other) {
 /// All shapes of the [overrider_iterators] must overlap with the shape.
 /// All shapes of the [overrider_iterators] must accept the [taken_names].
 static bool is_fully_shadowed_positional_phase(const NameIterator& shape_iterator,
-                                               const std::vector<NameIterator> overrider_iterators,
-                                               const std::vector<Symbol> taken_names,
+                                               const std::vector<NameIterator>& overrider_iterators,
+                                               const std::vector<Symbol>& taken_names,
                                                CallShape* see_through) {
   auto shape = shape_iterator.shape();
   // We only care for the non-block parameters, as the block ones must match.
@@ -173,7 +173,7 @@ static bool is_fully_shadowed_positional_phase(const NameIterator& shape_iterato
 
   std::vector<bool> positionals(max_positional - min_positional + 1);
 
-  for (auto overrider_iterator : overrider_iterators) {
+  for (const auto& overrider_iterator : overrider_iterators) {
     // For each overrider mark the positional parameters that are covered by the
     // by the overrider.
     auto overrider = overrider_iterator.shape();
@@ -293,14 +293,14 @@ static bool is_fully_shadowed_names_phase(NameIterator shape,
   return is_fully_shadowed_positional_phase(shape, *overriders, taken_names, see_through);
 }
 
-bool ResolutionShape::is_fully_shadowed_by(const std::vector<ResolutionShape> overriders,
+bool ResolutionShape::is_fully_shadowed_by(const std::vector<ResolutionShape>& overriders,
                                            CallShape* see_through) {
   *see_through = CallShape::invalid();
 
   // Start by filtering the overriders that clearly can't have any influence on
   // the result.
   std::vector<ResolutionShape> overlapping;
-  for (auto shape : overriders) {
+  for (const auto& shape : overriders) {
     if (overlaps_with(shape)) overlapping.push_back(shape);
   }
 
@@ -312,7 +312,7 @@ bool ResolutionShape::is_fully_shadowed_by(const std::vector<ResolutionShape> ov
 
   std::vector<NameIterator> overrider_iterators;
   overrider_iterators.reserve(overlapping.size());
-  for (auto shape : overlapping) {
+  for (const auto& shape : overlapping) {
     overrider_iterators.push_back(NameIterator(shape));
   }
   NameIterator this_iterator(*this);
@@ -454,4 +454,3 @@ PlainShape CallShape::to_plain_shape() const {
 
 } // namespace toit::compiler
 } // namespace toit
-

--- a/src/compiler/shape.h
+++ b/src/compiler/shape.h
@@ -383,7 +383,7 @@ class ResolutionShape {
   /// [see_through] shape with an example of a call-shape that would not be
   /// intercepted by the overriders.
   /// If it is not shadowed at all, then the [see_through] shape is invalid.
-  bool is_fully_shadowed_by(const std::vector<ResolutionShape> overriders, CallShape* see_through);
+  bool is_fully_shadowed_by(const std::vector<ResolutionShape>& overriders, CallShape* see_through);
 
   size_t hash() const {
     return call_shape_.hash()

--- a/src/compiler/source_mapper.cc
+++ b/src/compiler/source_mapper.cc
@@ -65,7 +65,7 @@ class SourceInfoCollector {
 
 void StringTable::visit(SourceInfoCollector* collector) {
   collector->write_int(table.size());
-  for (auto string : table) collector->write_string_content(string.c_str());
+  for (const auto& string : table) collector->write_string_content(string.c_str());
 }
 
 class SourceInfoAllocator: public SourceInfoCollector {
@@ -147,11 +147,11 @@ void SourceMapper::visit_selectors(SourceInfoCollector* collector) {
   collector->write_int(selectors_.size());
   for (auto location_id : selectors_.keys()) {
     collector->write_int(location_id);
-    auto selector_class_entry = selectors_.at(location_id);
+    const auto& selector_class_entry = selectors_.at(location_id);
     int encoded_super_id = selector_class_entry.super_location_id + 1;
     collector->write_int(encoded_super_id);
     collector->write_int(selector_class_entry.selectors.size());
-    for (auto selector : selector_class_entry.selectors) {
+    for (const auto& selector : selector_class_entry.selectors) {
       collector->write_string(selector.c_str());
     }
   }
@@ -159,7 +159,7 @@ void SourceMapper::visit_selectors(SourceInfoCollector* collector) {
 
 void SourceMapper::visit_method_info(SourceInfoCollector* collector) {
   collector->write_int(source_information_.size());
-  for (auto entry : source_information_) {
+  for (const auto& entry : source_information_) {
     collector->write_int(entry.id);
     collector->write_int(entry.bytecode_size);
     collector->write_byte(static_cast<uint8>(entry.type));
@@ -182,13 +182,13 @@ void SourceMapper::visit_method_info(SourceInfoCollector* collector) {
     collector->write_int(entry.position.line);
     collector->write_int(entry.position.column);
     collector->write_int(entry.bytecode_positions.size());
-    for (auto pair : entry.bytecode_positions) {
+    for (const auto& pair : entry.bytecode_positions) {
       collector->write_int(pair.first);
       collector->write_int(pair.second.line);
       collector->write_int(pair.second.column);
     }
     collector->write_int(entry.as_class_names.size());
-    for (auto pair : entry.as_class_names) {
+    for (const auto& pair : entry.as_class_names) {
       collector->write_int(pair.first);
       collector->write_string(pair.second);
     }
@@ -201,7 +201,7 @@ void SourceMapper::visit_class_info(SourceInfoCollector* collector) {
   for (auto klass : class_information_.keys()) {
     // We don't need to encode the id, as it's given by the index in the class-table.
     ASSERT(klass->id() == id++);
-    auto entry = class_information_[klass];
+    const auto& entry = class_information_[klass];
     int encoded_super = entry.super + 1;
     collector->write_int(encoded_super);
     collector->write_int(entry.location_id);
@@ -232,7 +232,7 @@ void SourceMapper::visit_primitive_info(SourceInfoCollector* collector) {
 
 void SourceMapper::visit_selector_offset_info(SourceInfoCollector* collector) {
   collector->write_int(selector_offsets_.size());
-  for (auto p : selector_offsets_) {
+  for (const auto& p : selector_offsets_) {
     collector->write_int(p.first);
     collector->write_string(p.second);
   }
@@ -240,7 +240,7 @@ void SourceMapper::visit_selector_offset_info(SourceInfoCollector* collector) {
 
 void SourceMapper::visit_global_info(SourceInfoCollector* collector) {
   collector->write_int(global_information_.size());
-  for (auto info : global_information_) {
+  for (const auto& info : global_information_) {
     collector->write_string(info.name);
     collector->write_string(info.holder_name);
     int encoded_holder_class_id = info.holder_class_id + 1;

--- a/src/compiler/tar.cc
+++ b/src/compiler/tar.cc
@@ -14,6 +14,8 @@
 // directory of this repository.
 
 #include <string.h>
+#include <errno.h>
+#include <limits.h>
 
 #include "tar.h"
 
@@ -50,6 +52,7 @@ UntarCode untar(FILE* file,
   // - the first one gives the name (as contents), and
   // - the second contains the actual content of the file.
   const char* long_name = null;
+  Defer free_pending_long_name { [&] { free(const_cast<char*>(long_name)); } };
   bool encountered_zero_header = false;
   while (true) {
     char header[HEADER_SIZE];
@@ -71,19 +74,22 @@ UntarCode untar(FILE* file,
     }
 
     char* file_name_suffix = &header[0];
-    int size_in_bytes = strtol(&header[124], null, 8);
+    // Tar strings are fixed-width and aren't necessarily terminated.
+    header[136] = '\0';  // Immediately after the 12-byte size field.
+    errno = 0;
+    char* size_end = null;
+    long parsed_size = strtol(&header[124], &size_end, 8);
+    if (errno != 0 || size_end == &header[124] || parsed_size < 0 || parsed_size > INT_MAX) {
+      return UntarCode::other;
+    }
+    int size_in_bytes = static_cast<int>(parsed_size);
     char file_type = header[156];
     char* ustar = &header[257];
-    const char* file_name_prefix = &header[345];
+    char* file_name_prefix = &header[345];
 
-    // Trim the ustar string.
-    int ustar_len = strlen(ustar);
-    for (int i = ustar_len - 1; i >= 0; i--) {
-      if (ustar[i] != ' ') {
-        ustar[i + 1] = '\0';
-        break;
-      }
-    }
+    file_name_suffix[100] = '\0';
+    ustar[5] = '\0';
+    file_name_prefix[155] = '\0';
     if (strcmp("ustar", ustar) != 0) return UntarCode::not_ustar;
 
     const char* file_name;
@@ -91,35 +97,47 @@ UntarCode untar(FILE* file,
       file_name = long_name;
       long_name = null;
     } else if (file_name_prefix[0] != '\0') {
-      // Reuse the header.
       int prefix_len = strlen(file_name_prefix);
       int suffix_len = strlen(file_name_suffix);
-      memmove(&header[prefix_len], &header[0], suffix_len);
-      memmove(&header[0], file_name_prefix, prefix_len);
-      header[prefix_len + suffix_len] = '\0';
-      // The header is stack-allocated and the file name must be copied to the heap.
-      file_name = strdup(&header[0]);
+      char* combined_name = unvoid_cast<char*>(malloc(prefix_len + 1 + suffix_len + 1));
+      if (combined_name == null) return UntarCode::other;
+      memcpy(combined_name, file_name_prefix, prefix_len);
+      combined_name[prefix_len] = '/';
+      memcpy(&combined_name[prefix_len + 1], file_name_suffix, suffix_len + 1);
+      file_name = combined_name;
     } else {
-      file_name_suffix[100] = '\0';  // In case the file was exactly 100 characters long.
       // The header is stack-allocated and the file name must be copied to the heap.
       file_name = strdup(file_name_suffix);
     }
-    char* content = unvoid_cast<char*>(malloc(size_in_bytes + 1));
+    if (file_name == null) return UntarCode::other;
+    char* content = unvoid_cast<char*>(malloc(static_cast<size_t>(size_in_bytes) + 1));
+    if (content == null) {
+      free(const_cast<char*>(file_name));
+      return UntarCode::other;
+    }
     read_count = fread(content, 1, size_in_bytes, file);
-    if (read_count != size_in_bytes) return UntarCode::other;
+    if (read_count != size_in_bytes) {
+      free(const_cast<char*>(file_name));
+      free(content);
+      return UntarCode::other;
+    }
 
     content[size_in_bytes] = '\0';  // Terminate with '\0'.
-    if (file_type == '0') {
+    if (file_type == '0' || file_type == '\0') {
       callback(file_name, content, size_in_bytes);
     } else if (file_type == 'L') {
       // Gnu's long-link format.
       ASSERT(strcmp("././@LongLink", file_name) == 0);
       long_name = content;  // Content was heap-allocated and can be reused in the next iteration.
+      free(const_cast<char*>(file_name));
+    } else {
+      free(const_cast<char*>(file_name));
+      free(content);
     }
 
     // Skip over the padded section.
     // Round up to the next 512 boundary.
-    int rounded_up = ((size_in_bytes + 0x1FF) & (~0x1FF));
+    size_t rounded_up = (static_cast<size_t>(size_in_bytes) + 0x1FF) & (~static_cast<size_t>(0x1FF));
     int to_read = rounded_up - size_in_bytes;
     ASSERT(to_read <= HEADER_SIZE);
     // Reuse the header, which isn't needed anymore.

--- a/src/compiler/tar.h
+++ b/src/compiler/tar.h
@@ -32,6 +32,7 @@ enum class UntarCode {
 };
 
 /// If `path` is equal to `-` uses `stdin`.
+/// The callback takes ownership of `name` and `source`, both allocated with `malloc`.
 UntarCode untar(const char* path,
                 const std::function<void (const char* name,
                                           char* source,

--- a/src/compiler/tree.cc
+++ b/src/compiler/tree.cc
@@ -50,9 +50,9 @@ class TypedSelectorSet {
   /// Ignores all methods that are in the 'ignored_methods' set.
   /// Ignores all selectors that are in the 'ignored_selectors' set.
   void insert_all(TypedSelectorSet& other,
-                  const Set<Method*> ignored_methods,
-                  const Set<CallSelector> ignored_selectors) {
-    other.selectors_.for_each([&](const CallSelector& selector, const UnorderedSet<Method*> methods) {
+                  const Set<Method*>& ignored_methods,
+                  const Set<CallSelector>& ignored_selectors) {
+    other.selectors_.for_each([&](const CallSelector& selector, const UnorderedSet<Method*>& methods) {
       if (ignored_selectors.contains(selector)) return;
       for (auto method : methods.underlying_set()) {
         if (ignored_methods.contains(method)) continue;
@@ -177,9 +177,9 @@ class TreeLogger {
   virtual void root(Method* method) {}
   virtual void root(Class* klass) {}
   virtual void add(Method* method,
-                   Set<Class*> classes,
-                   Set<Method*> methods,
-                   Set<CallSelector> selectors) {}
+                   const Set<Class*>& classes,
+                   const Set<Method*>& methods,
+                   const Set<CallSelector>& selectors) {}
   virtual void add_method_with_selector(CallSelector selector, Method* method) {}
 
   virtual void print() {}
@@ -192,9 +192,9 @@ class GraphvizTreeLogger : public TreeLogger {
   void root(Method* method) { root_methods_.push_back(method); }
   void root(Class* klass) { root_classes_.push_back(klass); }
   void add(Method* method,
-           Set<Class*> classes,
-           Set<Method*> methods,
-           Set<CallSelector> selectors) {
+           const Set<Class*>& classes,
+           const Set<Method*>& methods,
+           const Set<CallSelector>& selectors) {
     auto& class_vector = method_to_classes_[method];
     class_vector.insert(class_vector.end(), classes.begin(), classes.end());
     auto& method_vector = method_to_methods_[method];
@@ -337,9 +337,9 @@ class TreeGrower {
  public:
   void grow(Program* program);
 
-  Set<Class*> grown_classes() const { return grown_classes_; }
+  const Set<Class*>& grown_classes() const { return grown_classes_; }
   // Includes globals, static functions and instance functions.
-  Set<Method*> grown_methods() const { return grown_methods_; }
+  const Set<Method*>& grown_methods() const { return grown_methods_; }
 
  private:
   Set<Class*> grown_classes_;
@@ -477,8 +477,8 @@ void TreeGrower::grow(Program* program) {
 
 class Fixup : public ReplacingVisitor {
  public:
-  explicit Fixup(Set<Class*>& grown_classes,
-                 Set<Method*>& grown_methods,
+  explicit Fixup(const Set<Class*>& grown_classes,
+                 const Set<Method*>& grown_methods,
                  Type null_type,
                  Method* as_check_failure)
       : null_type_(null_type)
@@ -592,7 +592,7 @@ class Fixup : public ReplacingVisitor {
  private:
   Type null_type_;
   Set<Class*> valid_check_targets_;
-  Set<Method*> grown_methods_;
+  const Set<Method*>& grown_methods_;
   Method* as_check_failure_;
 };
 
@@ -608,7 +608,7 @@ static List<T*> shake_methods(List<T*> methods,
   return remaining_methods.build();
 }
 
-static std::vector<Method*> shake_methods(std::vector<Method*> methods,
+static std::vector<Method*> shake_methods(const std::vector<Method*>& methods,
                                           const Set<Method*>& grown_methods) {
   std::vector<Method*> remaining_methods;
   for (auto method : methods) {
@@ -620,8 +620,8 @@ static std::vector<Method*> shake_methods(std::vector<Method*> methods,
 }
 
 static void shake(Program* program,
-                  Set<Class*> grown_classes,
-                  Set<Method*> grown_methods) {
+                  const Set<Class*>& grown_classes,
+                  const Set<Method*>& grown_methods) {
   auto null_type = Type::invalid();
   for (auto type : program->literal_types()) {
     if (type.klass()->name() == Symbols::Null_) {


### PR DESCRIPTION
## Summary

- avoid unnecessary container, range-loop, callback, and parameter copies across the compiler
- clean up straightforward filesystem, archive, executable, and type-propagation ownership
- harden tar, executable, dependency-file, and filesystem error handling
- fix resolver method-shape caching and several bounds and lifetime bugs found during the review

AST and IR node ownership, plus other ambiguous process-lifetime allocations, remain intentionally out of scope for a later zone-allocation/lifecycle pass.

## Testing

- `cmake --build build/host --target toit.compile -j 8`
- focused compiler, archive, and dependency tests (6/6 passed)
- executable vessel tests (17/17 passed)
- compiler-wide `performance-for-range-copy` and `performance-unnecessary-value-param` clang-tidy pass; only vendored nlohmann/json warnings remain
- focused Clang static-analyzer ownership checks