### PR TITLE
compiler: add pretty-printer safety foundations

### DIFF
--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -1,0 +1,152 @@
+# Toit pretty-printer
+
+The Toit pretty-printer renders a canonical program from the parsed AST.  It
+is not a whitespace-preserving formatter: it may move syntax such as a method
+return type, reconstruct parentheses, and choose a different physical shape
+for calls and collections.
+
+## Invariants
+
+The implementation must:
+
+* reject input with parse errors without changing the destination;
+* produce output that reparses to an equivalent AST;
+* preserve every comment exactly once and in source order;
+* preserve resolver-sensitive receiver parentheses when resolution data is
+  unavailable;
+* be deterministic and idempotent;
+* emit no trailing whitespace and end files with one newline; and
+* install changed files atomically.
+
+Source whitespace, redundant parentheses, and source line breaks are not
+layout preferences.  The exceptions are syntax whose bytes carry information
+not represented in the AST, comments, and deliberately frozen lines.
+
+## Comments
+
+Comments are attached to semantic AST pieces and punctuation slots before
+printing.  Moving a return type, parameter, expression, or punctuation also
+moves its attached comments.
+
+A line with code followed by `//` is frozen.  The complete physical line,
+including code and spacing, is preserved.  Only its leading indentation may
+shift with its enclosing construct.  No token may move into or out of the
+line.  An own-line `//` comment may move with the statement or declaration to
+which it is attached.
+
+A multiline block comment is opaque.  Its bytes, internal spaces, and line
+breaks are preserved.  When the comment moves, every physical line is shifted
+by the same indentation delta as its first line; the comment is never
+reflowed.
+
+Every comment is consumed exactly once.  Own-line comments are assigned to
+the following list item, or to the enclosing list when they follow its final
+AST node.  Indentation disambiguates comments in nested statement sequences.
+
+## Layout selection
+
+AST printers construct a small set of legal, node-specific output shapes.
+There is no general token-order layout IR and no post-selection relocation or
+syntax-repair phase.  Required parentheses and reordered semantic pieces are
+part of each candidate before it is measured.
+
+Candidates are selected with a soft score rather than a maximum width.  The
+score considers:
+
+* line extent beyond a preferred region;
+* the number of additional physical lines;
+* the number of items split across lines;
+* construct-specific readability costs; and
+* optional, slight pressure from the current indentation.
+
+An indented construct may extend farther right than a top-level construct.
+Indentation may nevertheless move the soft breaking point slightly left
+relative to the construct.  Neither condition is a hard limit.
+
+Compact calls with many arguments may stay flat beyond the preferred extent
+when breaking would introduce many lines.  A `\` continuation is a legal
+candidate when it provides a better result than either one long physical line
+or one argument per line.
+
+Initial canonical choices are:
+
+* two spaces for suites, members, and collection contents;
+* four spaces for continuation lines;
+* trailing `and` and `or` at a logical line break;
+* leading operators for other broken binary expressions;
+* at most two preserved blank lines; and
+* two spaces before a trailing comment unless it is lexically attached.
+
+Collection and call shapes deliberately remain scoring experiments.  Internal
+style switches may compare alternatives during development, but the released
+formatter will expose one canonical style rather than user configuration.
+
+## Grammar constraints
+
+The AST printers must account for the following Toit grammar rules:
+
+* A continuation-line call argument is one complete expression.  All such
+  arguments use the same indentation, and once they start, subsequent
+  arguments must also start on new lines.
+* Same-line nested calls may need parentheses; a continuation line can provide
+  the required delimiter without parentheses.
+* Leading operators preserve left-associative binary trees.  Trailing
+  `and`/`or` is safe because logical operators are right-associative.
+* Prefix minus is attached while binary minus is surrounded by spaces.
+* Suite-bearing conditions and suite arguments followed by more arguments
+  require explicit delimiters.
+* `{}` is an empty set and `{:}` is an empty map.
+* Parentheses in `(Foo).bar` may affect resolution.  Preserve them without
+  resolution data; remove them only when resolution proves that lookup is
+  unchanged.
+
+## Roadmap and review stack
+
+Every step is intended to compile and test independently.  Each step should
+be one commit and may be submitted as one PR in a stacked review.
+
+1. **Document the contract.** Add this roadmap and freeze the architectural
+   and grammar decisions before implementation.
+2. **Add output safety foundations.** Add in-memory reparsing, structural AST
+   equivalence, comment fingerprints, and focused verifier tests.  No printer
+   is introduced in this step.
+3. **Add atomic file installation.** Introduce and test a reusable atomic
+   writer independently of formatting.
+4. **Capture source facts and trivia.** Record comments, physical lines,
+   punctuation gaps, frozen trailing-comment lines, and opaque multiline
+   comments.  Test ownership and indentation shifting without formatting AST
+   nodes.
+5. **Add scoring and output primitives.** Add a small line-oriented output
+   builder and candidate scorer.  Test soft width, line/item pressure,
+   indentation pressure, and dominance pruning.  This layer contains no Toit
+   syntax policy.
+6. **Print atoms and precedence expressions.** Cover identifiers, literals,
+   unary, binary, dot, index, slice, and ternary expressions.  Reconstruct
+   only required or selected clarity parentheses and verify every result by
+   reparsing.
+7. **Print method and declaration headers.** Cover parameters, return-type
+   movement, fields, classes, imports, and exports, including comments that
+   move with semantic pieces.
+8. **Print calls and suites.** Add flat, unnamed-prefix/named-continuation,
+   fully broken, and backslash-continuation candidates.  Cover blocks,
+   lambdas, greedy calls, and layout-dependent parentheses.
+9. **Print collections.** Add flat, packed-row, and one-item-per-line
+   candidates for lists, sets, maps, and byte arrays, including all comment
+   slots and trailing commas.
+10. **Print statements and bodies.** Cover declarations, assignments,
+    returns, control flow, loops, try/finally, empty suites, inline suites, and
+    complete comment ownership across nested sequences.
+11. **Print complete units.** Preserve preambles, Toitdoc, declaration order,
+    blank lines, and the final newline.  Unsupported AST kinds fail explicitly
+    rather than silently copying arbitrary source regions.
+12. **Integrate `toit format`.** Add the hidden CLI command, verifier gate,
+    atomic in-place writes, golden tests, idempotence tests, and corpus-level
+    formatting over `lib`, `tools`, and `examples`.
+13. **Calibrate canonical choices.** Run experimental call, collection,
+    binary-argument, and indentation-pressure modes over representative Toit
+    repositories.  Record churn and shape counts, choose one mode for each,
+    and remove the development switches before enabling the command.
+
+The golden corpus is specification data.  Each case checks exact output,
+idempotence, reparsing, AST equivalence, and comment preservation.  Corpus
+runs supplement these focused cases but do not replace them.

--- a/src/compiler/ast.h
+++ b/src/compiler/ast.h
@@ -814,7 +814,9 @@ class Index : public Expression {
   }
 
   Source::Range full_range() const override {
-    return selection_range().extend(closing_range_);
+    return selection_range()
+        .extend(receiver_->full_range())
+        .extend(closing_range_);
   }
 
  private:
@@ -842,7 +844,9 @@ class IndexSlice : public Expression {
   }
 
   Source::Range full_range() const override {
-    return selection_range().extend(closing_range_);
+    return selection_range()
+        .extend(receiver_->full_range())
+        .extend(closing_range_);
   }
 
  private:

--- a/src/compiler/ast_equivalence.cc
+++ b/src/compiler/ast_equivalence.cc
@@ -1,0 +1,453 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#include <cstring>
+
+#include "ast_equivalence.h"
+#include "symbol.h"
+
+namespace toit {
+namespace compiler {
+
+using namespace ast;
+
+namespace {
+
+// Owns all state for one recursive comparison. Keeping the recursion in an
+// object makes comparisons naturally thread-safe and avoids hidden global
+// state while still recording the deepest mismatching node pair.
+class AstComparator {
+ public:
+  bool compare(Node* a, Node* b) { return equiv(a, b); }
+  Node* mismatch_a() const { return mismatch_a_; }
+  Node* mismatch_b() const { return mismatch_b_; }
+
+ private:
+  Node* mismatch_a_ = null;
+  Node* mismatch_b_ = null;
+  bool mismatch_recorded_ = false;
+
+
+  // Symbols from two separate SymbolCanonicalizers don't share backing
+  // storage, so the pointer-equality operator== on Symbol doesn't apply.
+  // Compare the textual content instead.
+  bool sym_eq(Symbol a, Symbol b) {
+    if (!a.is_valid() && !b.is_valid()) return true;
+    if (!a.is_valid() || !b.is_valid()) return false;
+    return strcmp(a.c_str(), b.c_str()) == 0;
+  }
+
+  template <typename T>
+  bool equiv_list(List<T*> a, List<T*> b) {
+    if (a.length() != b.length()) return false;
+    for (int i = 0; i < a.length(); i++) {
+      if (!equiv(a[i], b[i])) return false;
+    }
+    return true;
+  }
+
+  bool equiv_opt(Node* a, Node* b) {
+    if (a == null && b == null) return true;
+    if (a == null || b == null) return false;
+    return equiv(a, b);
+  }
+
+  // Peels Parenthesis wrappers from the given node. `(x)` is equivalent to
+  // `x` at the AST level — the formatter can legitimately add or drop parens
+  // to satisfy layout constraints without changing meaning.
+  Node* unwrap(Node* n) {
+    while (n != null && n->is_Parenthesis()) {
+      n = n->as_Parenthesis()->expression();
+    }
+    return n;
+  }
+
+  bool equiv_unit(Unit* a, Unit* b) {
+    if (a->is_error_unit() != b->is_error_unit()) return false;
+    if (a->toitdoc().is_valid() != b->toitdoc().is_valid()) return false;
+    if (!equiv_list(a->imports(), b->imports())) return false;
+    if (!equiv_list(a->exports(), b->exports())) return false;
+    if (a->declarations().length() != b->declarations().length()) return false;
+    for (int i = 0; i < a->declarations().length(); i++) {
+      if (!equiv(a->declarations()[i], b->declarations()[i])) return false;
+    }
+    return true;
+  }
+
+  bool equiv_import(Import* a, Import* b) {
+    if (a->is_relative() != b->is_relative()) return false;
+    if (a->dot_outs() != b->dot_outs()) return false;
+    if (a->show_all() != b->show_all()) return false;
+    if (!equiv_list(a->segments(), b->segments())) return false;
+    if (!equiv_opt(a->prefix(), b->prefix())) return false;
+    if (!equiv_list(a->show_identifiers(), b->show_identifiers())) return false;
+    return true;
+  }
+
+  bool equiv_export(Export* a, Export* b) {
+    if (a->export_all() != b->export_all()) return false;
+    return equiv_list(a->identifiers(), b->identifiers());
+  }
+
+  bool equiv_class(Class* a, Class* b) {
+    if (a->kind() != b->kind()) return false;
+    if (a->has_abstract_modifier() != b->has_abstract_modifier()) return false;
+    if (a->toitdoc().is_valid() != b->toitdoc().is_valid()) return false;
+    if (!equiv(a->name(), b->name())) return false;
+    if (!equiv_opt(a->super(), b->super())) return false;
+    if (!equiv_list(a->interfaces(), b->interfaces())) return false;
+    if (!equiv_list(a->mixins(), b->mixins())) return false;
+    if (!equiv_list(a->members(), b->members())) return false;
+    return true;
+  }
+
+  bool equiv_field(Field* a, Field* b) {
+    if (a->is_static() != b->is_static()) return false;
+    if (a->is_abstract() != b->is_abstract()) return false;
+    if (a->is_final() != b->is_final()) return false;
+    if (a->toitdoc().is_valid() != b->toitdoc().is_valid()) return false;
+    if (!equiv(a->name_or_dot(), b->name_or_dot())) return false;
+    if (!equiv_opt(a->type(), b->type())) return false;
+    if (!equiv_opt(a->initializer(), b->initializer())) return false;
+    return true;
+  }
+
+  bool equiv_method(Method* a, Method* b) {
+    if (a->is_setter() != b->is_setter()) return false;
+    if (a->is_static() != b->is_static()) return false;
+    if (a->is_abstract() != b->is_abstract()) return false;
+    if (a->toitdoc().is_valid() != b->toitdoc().is_valid()) return false;
+    if (!equiv(a->name_or_dot(), b->name_or_dot())) return false;
+    if (!equiv_opt(a->return_type(), b->return_type())) return false;
+    if (!equiv_list(a->parameters(), b->parameters())) return false;
+    Sequence* ab = a->body();
+    Sequence* bb = b->body();
+    if (ab == null && bb == null) return true;
+    if (ab == null || bb == null) return false;
+    return equiv(ab, bb);
+  }
+
+  bool equiv_parameter(Parameter* a, Parameter* b) {
+    if (a->is_named() != b->is_named()) return false;
+    if (a->is_field_storing() != b->is_field_storing()) return false;
+    if (a->is_block() != b->is_block()) return false;
+    if (!equiv(a->name(), b->name())) return false;
+    if (!equiv_opt(a->type(), b->type())) return false;
+    if (!equiv_opt(a->default_value(), b->default_value())) return false;
+    return true;
+  }
+
+  bool equiv_named_arg(NamedArgument* a, NamedArgument* b) {
+    if (a->inverted() != b->inverted()) return false;
+    if (!equiv(a->name(), b->name())) return false;
+    return equiv_opt(a->expression(), b->expression());
+  }
+
+  bool equiv_break_continue(BreakContinue* a, BreakContinue* b) {
+    if (a->is_break() != b->is_break()) return false;
+    if (!equiv_opt(a->value(), b->value())) return false;
+    return equiv_opt(a->label(), b->label());
+  }
+
+  bool equiv_block(Block* a, Block* b) {
+    if (!equiv_list(a->parameters(), b->parameters())) return false;
+    return equiv(a->body(), b->body());
+  }
+
+  bool equiv_lambda(Lambda* a, Lambda* b) {
+    if (!equiv_list(a->parameters(), b->parameters())) return false;
+    return equiv(a->body(), b->body());
+  }
+
+  bool equiv_sequence(Sequence* a, Sequence* b) {
+    return equiv_list(a->expressions(), b->expressions());
+  }
+
+  bool equiv_decl_local(DeclarationLocal* a, DeclarationLocal* b) {
+    if (a->kind() != b->kind()) return false;
+    if (!equiv(a->name(), b->name())) return false;
+    if (!equiv_opt(a->type(), b->type())) return false;
+    if (!equiv_opt(a->value(), b->value())) return false;
+    return true;
+  }
+
+  bool equiv_if(If* a, If* b) {
+    if (!equiv(a->expression(), b->expression())) return false;
+    if (!equiv(a->yes(), b->yes())) return false;
+    return equiv_opt(a->no(), b->no());
+  }
+
+  bool equiv_while(While* a, While* b) {
+    if (!equiv(a->condition(), b->condition())) return false;
+    return equiv(a->body(), b->body());
+  }
+
+  bool equiv_for(For* a, For* b) {
+    if (!equiv_opt(a->initializer(), b->initializer())) return false;
+    if (!equiv_opt(a->condition(), b->condition())) return false;
+    if (!equiv_opt(a->update(), b->update())) return false;
+    return equiv(a->body(), b->body());
+  }
+
+  bool equiv_try_finally(TryFinally* a, TryFinally* b) {
+    if (!equiv(a->body(), b->body())) return false;
+    if (!equiv_list(a->handler_parameters(), b->handler_parameters())) return false;
+    return equiv(a->handler(), b->handler());
+  }
+
+  bool equiv_return(Return* a, Return* b) {
+    return equiv_opt(a->value(), b->value());
+  }
+
+  bool equiv_unary(Unary* a, Unary* b) {
+    if (a->kind() != b->kind()) return false;
+    if (a->prefix() != b->prefix()) return false;
+    return equiv(a->expression(), b->expression());
+  }
+
+  bool equiv_binary(Binary* a, Binary* b) {
+    if (a->kind() != b->kind()) return false;
+    if (!equiv(a->left(), b->left())) return false;
+    return equiv(a->right(), b->right());
+  }
+
+  bool equiv_call(Call* a, Call* b) {
+    if (a->is_call_primitive() != b->is_call_primitive()) return false;
+    if (!equiv(a->target(), b->target())) return false;
+    return equiv_list(a->arguments(), b->arguments());
+  }
+
+  // Mirrors the formatter's conservative syntactic approximation of receiver
+  // paths that the resolver may interpret as a class/static/constructor name.
+  bool is_static_receiver_candidate(Expression* e) {
+    int identifiers = 0;
+    while (e != null && e->is_Dot()) {
+      identifiers++;
+      e = e->as_Dot()->receiver();
+    }
+    if (e == null || !e->is_Identifier()) return false;
+    identifiers++;
+    return identifiers <= 3;
+  }
+
+  bool has_semantic_receiver_parens(Expression* e) {
+    if (e == null || !e->is_Parenthesis()) return false;
+    e = e->as_Parenthesis()->expression();
+    while (e != null && e->is_Parenthesis()) {
+      e = e->as_Parenthesis()->expression();
+    }
+    return is_static_receiver_candidate(e);
+  }
+
+  // Parentheses around an identifier path in receiver position are semantic:
+  // `Foo.bar` is a static lookup, while `(Foo).bar` is a member lookup on the
+  // class object. Other receiver parentheses are ordinary grammar and may be
+  // reconstructed canonically by the formatter.
+  bool equiv_receiver(Expression* a, Expression* b) {
+    bool a_parens = has_semantic_receiver_parens(a);
+    bool b_parens = has_semantic_receiver_parens(b);
+    if (a_parens != b_parens) return false;
+    return equiv(a, b);
+  }
+
+  bool equiv_dot(Dot* a, Dot* b) {
+    if (!equiv_receiver(a->receiver(), b->receiver())) return false;
+    return equiv(a->name(), b->name());
+  }
+
+  bool equiv_index(Index* a, Index* b) {
+    if (!equiv_receiver(a->receiver(), b->receiver())) return false;
+    return equiv_list(a->arguments(), b->arguments());
+  }
+
+  bool equiv_index_slice(IndexSlice* a, IndexSlice* b) {
+    if (!equiv_receiver(a->receiver(), b->receiver())) return false;
+    if (!equiv_opt(a->from(), b->from())) return false;
+    return equiv_opt(a->to(), b->to());
+  }
+
+  bool equiv_identifier(Identifier* a, Identifier* b) {
+    return sym_eq(a->data(), b->data());
+  }
+
+  bool equiv_nullable(Nullable* a, Nullable* b) {
+    return equiv(a->type(), b->type());
+  }
+
+  bool equiv_literal_boolean(LiteralBoolean* a, LiteralBoolean* b) {
+    return a->value() == b->value();
+  }
+
+  bool equiv_literal_integer(LiteralInteger* a, LiteralInteger* b) {
+    if (a->is_negated() != b->is_negated()) return false;
+    return sym_eq(a->data(), b->data());
+  }
+
+  bool equiv_literal_character(LiteralCharacter* a, LiteralCharacter* b) {
+    return sym_eq(a->data(), b->data());
+  }
+
+  bool equiv_literal_string(LiteralString* a, LiteralString* b) {
+    if (a->is_multiline() != b->is_multiline()) return false;
+    return sym_eq(a->data(), b->data());
+  }
+
+  bool equiv_literal_string_interp(LiteralStringInterpolation* a,
+                                          LiteralStringInterpolation* b) {
+    if (a->parts().length() != b->parts().length()) return false;
+    if (a->formats().length() != b->formats().length()) return false;
+    for (int i = 0; i < a->parts().length(); i++) {
+      if (!equiv(a->parts()[i], b->parts()[i])) return false;
+    }
+    for (int i = 0; i < a->formats().length(); i++) {
+      LiteralString* af = a->formats()[i];
+      LiteralString* bf = b->formats()[i];
+      if (af == null && bf == null) continue;
+      if (af == null || bf == null) return false;
+      if (!equiv(af, bf)) return false;
+    }
+    return equiv_list(a->expressions(), b->expressions());
+  }
+
+  bool equiv_literal_float(LiteralFloat* a, LiteralFloat* b) {
+    if (a->is_negated() != b->is_negated()) return false;
+    return sym_eq(a->data(), b->data());
+  }
+
+  bool equiv_literal_list(LiteralList* a, LiteralList* b) {
+    return equiv_list(a->elements(), b->elements());
+  }
+
+  bool equiv_literal_byte_array(LiteralByteArray* a, LiteralByteArray* b) {
+    return equiv_list(a->elements(), b->elements());
+  }
+
+  bool equiv_literal_set(LiteralSet* a, LiteralSet* b) {
+    return equiv_list(a->elements(), b->elements());
+  }
+
+  bool equiv_literal_map(LiteralMap* a, LiteralMap* b) {
+    return equiv_list(a->keys(), b->keys())
+        && equiv_list(a->values(), b->values());
+  }
+
+  bool equiv_toitdoc_reference(ToitdocReference* a,
+                                      ToitdocReference* b) {
+    if (a->is_signature_reference() != b->is_signature_reference()) return false;
+    if (a->is_setter() != b->is_setter()) return false;
+    if (!equiv(a->target(), b->target())) return false;
+    if (!a->is_signature_reference()) return true;
+    return equiv_list(a->parameters(), b->parameters());
+  }
+
+  void record_mismatch(Node* a, Node* b) {
+    if (mismatch_recorded_) return;
+    mismatch_recorded_ = true;
+    mismatch_a_ = a;
+    mismatch_b_ = b;
+  }
+
+
+  bool equiv(Node* a, Node* b) {
+    bool result = equiv_no_record(a, b);
+    if (!result) record_mismatch(unwrap(a), unwrap(b));
+    return result;
+  }
+
+  bool equiv_no_record(Node* a, Node* b) {
+    a = unwrap(a);
+    b = unwrap(b);
+    if (a == null && b == null) return true;
+    if (a == null || b == null) return false;
+
+    // Node kinds must match exactly. (LspSelection inherits from Identifier
+    // but is_Identifier() also reports true for LspSelection — we don't treat
+    // them as equivalent unless both are the same concrete kind.)
+    if (strcmp(a->node_type(), b->node_type()) != 0) return false;
+
+    if (a->is_Unit()) return equiv_unit(a->as_Unit(), b->as_Unit());
+    if (a->is_Import()) return equiv_import(a->as_Import(), b->as_Import());
+    if (a->is_Export()) return equiv_export(a->as_Export(), b->as_Export());
+    if (a->is_Class()) return equiv_class(a->as_Class(), b->as_Class());
+    if (a->is_Field()) return equiv_field(a->as_Field(), b->as_Field());
+    if (a->is_Method()) return equiv_method(a->as_Method(), b->as_Method());
+    if (a->is_Parameter()) return equiv_parameter(a->as_Parameter(), b->as_Parameter());
+    if (a->is_NamedArgument()) return equiv_named_arg(a->as_NamedArgument(), b->as_NamedArgument());
+    if (a->is_BreakContinue()) return equiv_break_continue(a->as_BreakContinue(), b->as_BreakContinue());
+    if (a->is_Block()) return equiv_block(a->as_Block(), b->as_Block());
+    if (a->is_Lambda()) return equiv_lambda(a->as_Lambda(), b->as_Lambda());
+    if (a->is_Sequence()) return equiv_sequence(a->as_Sequence(), b->as_Sequence());
+    if (a->is_DeclarationLocal()) return equiv_decl_local(a->as_DeclarationLocal(), b->as_DeclarationLocal());
+    if (a->is_If()) return equiv_if(a->as_If(), b->as_If());
+    if (a->is_While()) return equiv_while(a->as_While(), b->as_While());
+    if (a->is_For()) return equiv_for(a->as_For(), b->as_For());
+    if (a->is_TryFinally()) return equiv_try_finally(a->as_TryFinally(), b->as_TryFinally());
+    if (a->is_Return()) return equiv_return(a->as_Return(), b->as_Return());
+    if (a->is_Unary()) return equiv_unary(a->as_Unary(), b->as_Unary());
+    if (a->is_Binary()) return equiv_binary(a->as_Binary(), b->as_Binary());
+    if (a->is_Call()) return equiv_call(a->as_Call(), b->as_Call());
+    if (a->is_Dot()) return equiv_dot(a->as_Dot(), b->as_Dot());
+    if (a->is_Index()) return equiv_index(a->as_Index(), b->as_Index());
+    if (a->is_IndexSlice()) return equiv_index_slice(a->as_IndexSlice(), b->as_IndexSlice());
+    if (a->is_Identifier()) return equiv_identifier(a->as_Identifier(), b->as_Identifier());
+    if (a->is_Nullable()) return equiv_nullable(a->as_Nullable(), b->as_Nullable());
+    if (a->is_LiteralNull()) return true;
+    if (a->is_LiteralUndefined()) return true;
+    if (a->is_LiteralBoolean()) return equiv_literal_boolean(a->as_LiteralBoolean(), b->as_LiteralBoolean());
+    if (a->is_LiteralInteger()) return equiv_literal_integer(a->as_LiteralInteger(), b->as_LiteralInteger());
+    if (a->is_LiteralCharacter()) return equiv_literal_character(a->as_LiteralCharacter(), b->as_LiteralCharacter());
+    if (a->is_LiteralString()) return equiv_literal_string(a->as_LiteralString(), b->as_LiteralString());
+    if (a->is_LiteralStringInterpolation()) {
+      return equiv_literal_string_interp(a->as_LiteralStringInterpolation(),
+                                         b->as_LiteralStringInterpolation());
+    }
+    if (a->is_LiteralFloat()) return equiv_literal_float(a->as_LiteralFloat(), b->as_LiteralFloat());
+    if (a->is_LiteralList()) return equiv_literal_list(a->as_LiteralList(), b->as_LiteralList());
+    if (a->is_LiteralByteArray()) return equiv_literal_byte_array(a->as_LiteralByteArray(), b->as_LiteralByteArray());
+    if (a->is_LiteralSet()) return equiv_literal_set(a->as_LiteralSet(), b->as_LiteralSet());
+    if (a->is_LiteralMap()) return equiv_literal_map(a->as_LiteralMap(), b->as_LiteralMap());
+    if (a->is_ToitdocReference()) {
+      return equiv_toitdoc_reference(a->as_ToitdocReference(),
+                                     b->as_ToitdocReference());
+    }
+
+    // Parenthesis has already been unwrapped. Error nodes are never safe
+    // formatter input.
+    if (a->is_Error()) return false;
+
+    // Future AST kinds must be added explicitly instead of silently weakening
+    // the verifier.
+    UNREACHABLE();
+  }
+
+};
+
+} // namespace
+
+bool ast_equivalent(Unit* a, Unit* b, Node** mismatch_a, Node** mismatch_b) {
+  return ast_nodes_equivalent(a, b, mismatch_a, mismatch_b);
+}
+
+bool ast_nodes_equivalent(Node* a, Node* b,
+                          Node** mismatch_a, Node** mismatch_b) {
+  AstComparator comparator;
+  bool result = comparator.compare(a, b);
+  if (mismatch_a != null) *mismatch_a = comparator.mismatch_a();
+  if (mismatch_b != null) *mismatch_b = comparator.mismatch_b();
+  return result;
+}
+
+} // namespace toit::compiler
+} // namespace toit

--- a/src/compiler/ast_equivalence.h
+++ b/src/compiler/ast_equivalence.h
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#pragma once
+
+#include "ast.h"
+
+namespace toit {
+namespace compiler {
+
+// Returns true iff the two AST units are semantically equivalent, modulo:
+// - source positions (ranges),
+// - trivia (comments, whitespace),
+// - Parenthesis wrappers (transparent — `(e)` equivalent to `e`).
+//
+// Intended as the formatter's safety net: the formatted output is parsed
+// and compared against the input's AST. A difference means the formatter
+// has changed meaning, not just presentation.
+//
+// On mismatch, `mismatch_a` / `mismatch_b` (when non-null) receive the
+// deepest node pair where the difference was detected (either may be
+// null when one side is missing a node).
+bool ast_equivalent(ast::Unit* a, ast::Unit* b,
+                    ast::Node** mismatch_a = null,
+                    ast::Node** mismatch_b = null);
+
+// Compares arbitrary AST subtrees using the same rules as $ast_equivalent.
+// This is primarily useful for focused pretty-printer tests.
+bool ast_nodes_equivalent(ast::Node* a, ast::Node* b,
+                          ast::Node** mismatch_a = null,
+                          ast::Node** mismatch_b = null);
+
+} // namespace toit::compiler
+} // namespace toit

--- a/src/compiler/format_source.cc
+++ b/src/compiler/format_source.cc
@@ -1,0 +1,176 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#include "format_source.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace toit {
+namespace compiler {
+
+FormatSource::FormatSource(Source* source, List<Scanner::Comment> comments)
+    : source_(source) {
+  ASSERT(source_ != null);
+  build_lines();
+  build_comments(comments);
+}
+
+void FormatSource::build_lines() {
+  const uint8* bytes = source_->text();
+  int size = source_->size();
+  int from = 0;
+  while (from < size) {
+    int content_to = from;
+    while (content_to < size && bytes[content_to] != '\n' &&
+           bytes[content_to] != '\r') {
+      content_to++;
+    }
+    int to = content_to;
+    if (to < size && bytes[to] == '\r') to++;
+    if (to < size && bytes[to] == '\n') to++;
+
+    int indentation = 0;
+    while (from + indentation < content_to) {
+      uint8 c = bytes[from + indentation];
+      if (c != ' ' && c != '\t') break;
+      indentation++;
+    }
+    FormatLine line;
+    line.from = from;
+    line.content_to = content_to;
+    line.to = to;
+    line.indentation = indentation;
+    lines_.push_back(line);
+    from = to;
+  }
+}
+
+int FormatSource::line_index_at(int offset) const {
+  ASSERT(offset >= 0 && offset <= source_->size());
+  if (lines_.empty()) return -1;
+  if (offset == source_->size()) return lines_.size() - 1;
+
+  int low = 0;
+  int high = lines_.size();
+  while (low + 1 < high) {
+    int middle = low + (high - low) / 2;
+    if (lines_[middle].from <= offset) {
+      low = middle;
+    } else {
+      high = middle;
+    }
+  }
+  ASSERT(lines_[low].from <= offset && offset < lines_[low].to);
+  return low;
+}
+
+std::string FormatSource::text(int from, int to) const {
+  ASSERT(from >= 0 && from <= to && to <= source_->size());
+  return std::string(
+      reinterpret_cast<const char*>(source_->text()) + from, to - from);
+}
+
+void FormatSource::build_comments(List<Scanner::Comment> comments) {
+  for (auto comment : comments) {
+    if (!comment.is_valid()) continue;
+    int from = source_->offset_in_source(comment.range().from());
+    int to = source_->offset_in_source(comment.range().to());
+    int start_line = line_index_at(from);
+    int end_line = line_index_at(std::max(from, to - 1));
+    const FormatLine& line = lines_[start_line];
+    bool follows_code = false;
+    for (int offset = line.from; offset < from; offset++) {
+      uint8 c = source_->text()[offset];
+      if (c != ' ' && c != '\t') {
+        follows_code = true;
+        break;
+      }
+    }
+
+    int id = comments_.size();
+    FormatComment fact;
+    fact.id = id;
+    fact.from = from;
+    fact.to = to;
+    fact.start_line = start_line;
+    fact.end_line = end_line;
+    fact.start_column = from - line.from;
+    fact.is_block = comment.is_multiline();
+    fact.is_toitdoc = comment.is_toitdoc();
+    fact.spans_lines = start_line != end_line;
+    fact.follows_code = follows_code;
+    fact.text = text(from, to);
+    comments_.push_back(std::move(fact));
+    if (!comment.is_multiline() && follows_code) {
+      ASSERT(lines_[start_line].trailing_line_comment < 0);
+      lines_[start_line].trailing_line_comment = id;
+    }
+  }
+}
+
+std::string FormatSource::reindent_line(int line_index,
+                                        int new_indentation) const {
+  ASSERT(line_index >= 0 && line_index < static_cast<int>(lines_.size()));
+  ASSERT(new_indentation >= 0);
+  const FormatLine& line = lines_[line_index];
+  return std::string(new_indentation, ' ') +
+      text(line.from + line.indentation, line.to);
+}
+
+std::string FormatSource::shift_multiline_comment(
+    int comment_id, int new_start_column) const {
+  ASSERT(comment_id >= 0 &&
+         comment_id < static_cast<int>(comments_.size()));
+  ASSERT(new_start_column >= 0);
+  const FormatComment& comment = comments_[comment_id];
+  ASSERT(comment.is_block && comment.spans_lines);
+  int delta = new_start_column - comment.start_column;
+
+  std::string result;
+  const std::string& input = comment.text;
+  size_t cursor = 0;
+  while (cursor < input.size()) {
+    size_t newline = input.find_first_of("\r\n", cursor);
+    if (newline == std::string::npos) {
+      result.append(input, cursor, std::string::npos);
+      break;
+    }
+    result.append(input, cursor, newline - cursor);
+    if (input[newline] == '\r' && newline + 1 < input.size() &&
+        input[newline + 1] == '\n') {
+      result.append("\r\n");
+      cursor = newline + 2;
+    } else {
+      result.push_back(input[newline]);
+      cursor = newline + 1;
+    }
+
+    size_t indentation_end = cursor;
+    while (indentation_end < input.size() &&
+           (input[indentation_end] == ' ' ||
+            input[indentation_end] == '\t')) {
+      indentation_end++;
+    }
+    int indentation = indentation_end - cursor;
+    int shifted = std::max(0, indentation + delta);
+    result.append(shifted, ' ');
+    cursor = indentation_end;
+  }
+  return result;
+}
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_source.h
+++ b/src/compiler/format_source.h
@@ -1,0 +1,84 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "scanner.h"
+#include "sources.h"
+
+namespace toit {
+namespace compiler {
+
+struct FormatLine {
+  int from = 0;
+  int content_to = 0;
+  int to = 0;
+  int indentation = 0;
+  int trailing_line_comment = -1;
+
+  bool is_frozen() const { return trailing_line_comment >= 0; }
+};
+
+struct FormatComment {
+  int id = -1;
+  int from = 0;
+  int to = 0;
+  int start_line = -1;
+  int end_line = -1;
+  int start_column = 0;
+  bool is_block = false;
+  bool is_toitdoc = false;
+  bool spans_lines = false;
+  bool follows_code = false;
+  std::string text;
+};
+
+// Immutable physical source facts used while comments are attached to AST
+// pieces. This class does not decide formatting or comment ownership.
+class FormatSource {
+ public:
+  FormatSource(Source* source, List<Scanner::Comment> comments);
+
+  Source* source() const { return source_; }
+  const std::vector<FormatLine>& lines() const { return lines_; }
+  const std::vector<FormatComment>& comments() const { return comments_; }
+
+  int line_index_at(int offset) const;
+  std::string text(int from, int to) const;
+
+  // Reproduces a physical line exactly, except for replacing its leading
+  // indentation with $new_indentation spaces.
+  std::string reindent_line(int line_index, int new_indentation) const;
+
+  // Reproduces a block comment while shifting every continuation line by the
+  // same column delta as the first line. The returned text begins at the
+  // comment delimiter and does not include indentation before its first line.
+  std::string shift_multiline_comment(int comment_id,
+                                      int new_start_column) const;
+
+ private:
+  void build_lines();
+  void build_comments(List<Scanner::Comment> comments);
+
+  Source* source_;
+  std::vector<FormatLine> lines_;
+  std::vector<FormatComment> comments_;
+};
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_verifier.cc
+++ b/src/compiler/format_verifier.cc
@@ -1,0 +1,168 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#include "format_verifier.h"
+
+#include <stdio.h>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "ast_equivalence.h"
+#include "diagnostic.h"
+#include "parser.h"
+#include "scanner.h"
+#include "sources.h"
+#include "symbol_canonicalizer.h"
+
+namespace toit {
+namespace compiler {
+
+namespace {
+
+struct CommentFingerprint {
+  std::string text;
+  bool has_code_before_on_line;
+
+  bool operator==(const CommentFingerprint& other) const {
+    return text == other.text
+        && has_code_before_on_line == other.has_code_before_on_line;
+  }
+};
+
+std::vector<CommentFingerprint> comment_fingerprints(Scanner* scanner,
+                                                     Source* source) {
+  std::vector<CommentFingerprint> result;
+  for (auto comment : scanner->comments()) {
+    if (!comment.is_valid()) continue;
+    int from = source->offset_in_source(comment.range().from());
+    int to = source->offset_in_source(comment.range().to());
+    std::string text(char_cast(source->text()) + from, to - from);
+    std::string normalized;
+    bool at_line_start = false;
+    for (char c : text) {
+      if (at_line_start && (c == ' ' || c == '\t')) continue;
+      at_line_start = c == '\n';
+      normalized.push_back(c);
+    }
+    bool has_code_before_on_line = false;
+    for (int i = from - 1;
+         i >= 0 && source->text()[i] != '\n';
+         i--) {
+      if (source->text()[i] != ' ' && source->text()[i] != '\t') {
+        has_code_before_on_line = true;
+        break;
+      }
+    }
+    result.push_back({std::move(normalized), has_code_before_on_line});
+  }
+  return result;
+}
+
+void print_excerpt(const char* label, Source* source, ast::Node* node) {
+  if (node == null) {
+    fprintf(stderr, "  %s: <missing node>\n", label);
+    return;
+  }
+  int from = source->offset_in_source(node->full_range().from());
+  int to = source->offset_in_source(node->full_range().to());
+  int length = to - from;
+  if (length > 200) length = 200;
+  fprintf(stderr, "  %s %s (offset %d): %.*s\n",
+          label, node->node_type(), from, length,
+          char_cast(source->text()) + from);
+}
+
+} // namespace
+
+bool verify_formatted_output(SourceManager* source_manager,
+                             Source* original_source,
+                             Scanner* original_scanner,
+                             ast::Unit* original_unit,
+                             const uint8* formatted,
+                             int formatted_size,
+                             const char* out_path) {
+  Source* formatted_source = source_manager->load_from_memory(
+      std::string(original_source->absolute_path()) + "<formatted>",
+      formatted,
+      formatted_size);
+  bool show_package_warnings;
+  bool print_diagnostics_on_stdout;
+  AnalysisDiagnostics diagnostics(source_manager,
+                                  show_package_warnings=false,
+                                  print_diagnostics_on_stdout=false);
+  SymbolCanonicalizer symbols;
+  Scanner scanner(formatted_source, &symbols, &diagnostics);
+  Parser parser(formatted_source, &scanner, &diagnostics);
+  ast::Unit* formatted_unit = parser.parse_unit();
+  if (diagnostics.encountered_error()) {
+    fprintf(stderr,
+            "toit format: formatter produced output with parse errors; "
+            "refusing to write %s\n",
+            out_path);
+    return false;
+  }
+
+  ast::Node* mismatch_original = null;
+  ast::Node* mismatch_formatted = null;
+  if (!ast_equivalent(original_unit,
+                      formatted_unit,
+                      &mismatch_original,
+                      &mismatch_formatted)) {
+    fprintf(stderr,
+            "toit format: formatter changed meaning; refusing to write %s\n",
+            out_path);
+    print_excerpt("original ", original_source, mismatch_original);
+    print_excerpt("formatted", formatted_source, mismatch_formatted);
+    return false;
+  }
+
+  // Preserve comment text and whether each comment follows code on its line.
+  // Interior indentation of line-spanning comments belongs to the formatter,
+  // so the comparison normalizes leading whitespace on interior lines.
+  auto original_comments =
+      comment_fingerprints(original_scanner, original_source);
+  auto formatted_comments = comment_fingerprints(&scanner, formatted_source);
+  if (original_comments == formatted_comments) return true;
+
+  fprintf(stderr,
+          "toit format: formatter dropped or changed a comment; "
+          "refusing to write %s\n",
+          out_path);
+  size_t common = 0;
+  while (common < original_comments.size()
+         && common < formatted_comments.size()
+         && original_comments[common] == formatted_comments[common]) {
+    common++;
+  }
+  if (common < original_comments.size()) {
+    fprintf(stderr, "  original : %s (%s)\n",
+            original_comments[common].text.c_str(),
+            original_comments[common].has_code_before_on_line
+                ? "end-of-line"
+                : "own-line");
+  }
+  if (common < formatted_comments.size()) {
+    fprintf(stderr, "  formatted: %s (%s)\n",
+            formatted_comments[common].text.c_str(),
+            formatted_comments[common].has_code_before_on_line
+                ? "end-of-line"
+                : "own-line");
+  }
+  return false;
+}
+
+} // namespace toit::compiler
+} // namespace toit

--- a/src/compiler/format_verifier.h
+++ b/src/compiler/format_verifier.h
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#pragma once
+
+#include "../top.h"
+
+namespace toit {
+namespace compiler {
+
+namespace ast {
+class Unit;
+}
+
+class Scanner;
+class Source;
+class SourceManager;
+
+// Re-parses formatter output and verifies both AST equivalence and comment
+// preservation. Diagnostics name `out_path`; the output buffer remains owned
+// by the caller.
+bool verify_formatted_output(SourceManager* source_manager,
+                             Source* original_source,
+                             Scanner* original_scanner,
+                             ast::Unit* original_unit,
+                             const uint8* formatted,
+                             int formatted_size,
+                             const char* out_path);
+
+} // namespace toit::compiler
+} // namespace toit

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -2854,7 +2854,7 @@ Source::Range Parser::peek_range() {
     }
     return source_->range(state.scanner_state.from, shortened_to);
   }
-  return current_range();
+  return source_->range(state.scanner_state.from, state.scanner_state.to);
 }
 
 Source::Range Parser::current_range_safe() {

--- a/src/compiler/sources.cc
+++ b/src/compiler/sources.cc
@@ -195,6 +195,16 @@ SourceManager::LoadResult SourceManager::load_file(const std::string& path, cons
   };
 }
 
+Source* SourceManager::load_from_memory(const std::string& virtual_path,
+                                        const uint8* bytes,
+                                        int size) {
+  uint8* owned = unvoid_cast<uint8*>(malloc(size + 1));
+  memcpy(owned, bytes, size);
+  owned[size] = 0;
+  return register_source(
+      virtual_path, Package::invalid(), virtual_path, owned, size);
+}
+
 SourceManagerSource* SourceManager::register_source(const std::string& absolute_path,
                                                     const Package& package,
                                                     const std::string& error_path,

--- a/src/compiler/sources.h
+++ b/src/compiler/sources.h
@@ -267,6 +267,14 @@ class SourceManager {
   bool is_loaded(const char* path);
   bool is_loaded(const std::string& path);
 
+  /// Registers an in-memory source under $virtual_path.
+  ///
+  /// The source manager copies $bytes and owns the resulting buffer. This is
+  /// useful for parsing generated output without first writing it to disk.
+  Source* load_from_memory(const std::string& virtual_path,
+                           const uint8* bytes,
+                           int size);
+
  private:
   Filesystem* filesystem_;
 

--- a/src/file_writer.cc
+++ b/src/file_writer.cc
@@ -1,0 +1,243 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#include "file_writer.h"
+
+#include <atomic>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <limits>
+#include <stdio.h>
+#include <string>
+#include <sys/stat.h>
+
+#ifdef TOIT_WINDOWS
+#include <io.h>
+#include <process.h>
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
+namespace toit {
+
+namespace {
+
+std::atomic<unsigned int> next_temporary_id(0);
+
+#ifdef TOIT_WINDOWS
+
+std::wstring wide_path(const char *path) {
+  int length =
+      MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, null, 0);
+  if (length <= 0)
+    return std::wstring();
+  std::wstring result(length, L'\0');
+  if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, &result[0],
+                          length) == 0) {
+    return std::wstring();
+  }
+  result.resize(length - 1);
+  return result;
+}
+
+bool replace_file(const std::string &temporary, const std::string &path) {
+  std::wstring temporary_w = wide_path(temporary.c_str());
+  std::wstring path_w = wide_path(path.c_str());
+  if (temporary_w.empty() || path_w.empty()) {
+    errno = EINVAL;
+    return false;
+  }
+  if (MoveFileExW(temporary_w.c_str(), path_w.c_str(),
+                  MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) != 0) {
+    return true;
+  }
+  errno = EIO;
+  return false;
+}
+
+int process_id() { return _getpid(); }
+
+#else
+
+bool replace_file(const std::string &temporary, const std::string &path) {
+  return rename(temporary.c_str(), path.c_str()) == 0;
+}
+
+int process_id() { return getpid(); }
+
+#endif
+
+std::string temporary_path(const std::string &path) {
+  // The caller reserves this predictable candidate with O_EXCL (or the
+  // Windows equivalent) before writing. A shared generator keeps the POSIX
+  // and Windows implementations identical; collisions simply try a new id.
+  unsigned int id = next_temporary_id.fetch_add(1);
+  return path + ".tmp." + std::to_string(process_id()) + "." +
+         std::to_string(id);
+}
+
+} // namespace
+
+bool write_file_atomically(const char *path, const uint8 *content, size_t size,
+                           int create_mode) {
+  if (path == null || path[0] == '\0') {
+    errno = EINVAL;
+    return false;
+  }
+  if (content == null && size != 0) {
+    errno = EINVAL;
+    return false;
+  }
+
+  std::string destination(path);
+  int existing_mode = -1;
+
+#ifdef TOIT_WINDOWS
+  std::wstring destination_w = wide_path(path);
+  if (destination_w.empty()) {
+    errno = EINVAL;
+    return false;
+  }
+  struct _stat64 destination_stat;
+  if (_wstat64(destination_w.c_str(), &destination_stat) == 0) {
+    if ((destination_stat.st_mode & _S_IFMT) != _S_IFREG) {
+      errno = EINVAL;
+      return false;
+    }
+    if ((destination_stat.st_mode & _S_IWRITE) == 0 ||
+        _waccess(destination_w.c_str(), 2) != 0) {
+      errno = EACCES;
+      return false;
+    }
+    existing_mode = destination_stat.st_mode & (_S_IREAD | _S_IWRITE);
+  } else if (errno != ENOENT) {
+    return false;
+  }
+#else
+  struct stat destination_stat;
+#ifdef TOIT_ESP32
+  if (stat(path, &destination_stat) == 0) {
+#else
+  if (lstat(path, &destination_stat) == 0) {
+    if (S_ISLNK(destination_stat.st_mode)) {
+      char resolved[PATH_MAX];
+      if (realpath(path, resolved) == null)
+        return false;
+      return write_file_atomically(resolved, content, size, create_mode);
+    }
+#endif
+    if (!S_ISREG(destination_stat.st_mode)) {
+      errno = EINVAL;
+      return false;
+    }
+    if ((destination_stat.st_mode & 0222) == 0 || access(path, W_OK) != 0) {
+      errno = EACCES;
+      return false;
+    }
+    existing_mode = destination_stat.st_mode & 07777;
+  } else if (errno != ENOENT) {
+    return false;
+  }
+#endif
+
+  std::string temporary;
+  int fd = -1;
+  for (int attempt = 0; attempt < 100 && fd < 0; attempt++) {
+    temporary = temporary_path(destination);
+#ifdef TOIT_WINDOWS
+    std::wstring temporary_w = wide_path(temporary.c_str());
+    if (temporary_w.empty()) {
+      errno = EINVAL;
+      return false;
+    }
+    fd = _wopen(temporary_w.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_BINARY,
+                create_mode);
+#else
+    fd = open(temporary.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_BINARY,
+              create_mode);
+#endif
+    if (fd < 0 && errno != EEXIST)
+      return false;
+  }
+  if (fd < 0)
+    return false;
+
+  bool succeeded = true;
+  size_t written = 0;
+  while (written < size) {
+#ifdef TOIT_WINDOWS
+    size_t remaining = size - written;
+    unsigned int chunk =
+        remaining > INT_MAX ? INT_MAX : static_cast<unsigned int>(remaining);
+    int result = _write(fd, content + written, chunk);
+#else
+    size_t remaining = size - written;
+    size_t maximum = std::numeric_limits<ssize_t>::max();
+    size_t chunk = remaining > maximum ? maximum : remaining;
+    ssize_t result = write(fd, content + written, chunk);
+#endif
+    if (result < 0 && errno == EINTR)
+      continue;
+    if (result <= 0) {
+      succeeded = false;
+      break;
+    }
+    written += result;
+  }
+
+  if (succeeded && existing_mode >= 0) {
+#ifdef TOIT_WINDOWS
+    std::wstring temporary_w = wide_path(temporary.c_str());
+    succeeded = !temporary_w.empty() &&
+                _wchmod(temporary_w.c_str(), existing_mode) == 0;
+#else
+    succeeded = fchmod(fd, existing_mode) == 0;
+#endif
+  }
+#ifdef TOIT_WINDOWS
+  if (succeeded)
+    succeeded = _commit(fd) == 0;
+  if (_close(fd) != 0)
+    succeeded = false;
+#else
+  if (succeeded)
+    succeeded = fsync(fd) == 0;
+  if (close(fd) != 0)
+    succeeded = false;
+#endif
+
+  if (succeeded)
+    succeeded = replace_file(temporary, destination);
+  if (!succeeded) {
+    int failure_errno = errno;
+#ifdef TOIT_WINDOWS
+    std::wstring temporary_w = wide_path(temporary.c_str());
+    if (!temporary_w.empty())
+      _wunlink(temporary_w.c_str());
+#else
+    unlink(temporary.c_str());
+#endif
+    errno = failure_errno;
+  }
+  return succeeded;
+}
+
+} // namespace toit

--- a/src/file_writer.h
+++ b/src/file_writer.h
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#pragma once
+
+#include <stddef.h>
+
+#include "top.h"
+
+namespace toit {
+
+// Writes a complete file through a temporary file in the destination
+// directory, then atomically replaces the destination. Existing permission
+// bits are preserved. As with any rename-based replacement, inode identity,
+// hard-link relationships, and other platform-specific metadata are not
+// preserved. `create_mode` is used only for a new file and is filtered by the
+// process umask.
+//
+// Returns false without modifying the destination on any failure before the
+// final rename.
+bool write_file_atomically(const char* path,
+                           const uint8* content,
+                           size_t size,
+                           int create_mode = 0666);
+
+} // namespace toit

--- a/tests/ctest/ast-equivalence-input.toit
+++ b/tests/ctest/ast-equivalence-input.toit
@@ -1,0 +1,6 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+main:
+  null

--- a/tests/ctest/ast-equivalence-test.cc
+++ b/tests/ctest/ast-equivalence-test.cc
@@ -1,0 +1,100 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <memory>
+#include <string>
+
+#include "../../src/compiler/ast_equivalence.h"
+#include "../../src/compiler/diagnostic.h"
+#include "../../src/compiler/filesystem_local.h"
+#include "../../src/compiler/parser.h"
+#include "../../src/compiler/scanner.h"
+#include "../../src/compiler/sources.h"
+#include "../../src/compiler/symbol_canonicalizer.h"
+#include "../../src/top.h"
+
+namespace toit {
+namespace compiler {
+
+struct ParsedUnit {
+  std::unique_ptr<SymbolCanonicalizer> symbols;
+  ast::Unit* unit = null;
+};
+
+static ParsedUnit parse(SourceManager* sources,
+                        const char* path,
+                        const std::string& text) {
+  static int next_source_id = 0;
+  ParsedUnit result;
+  result.symbols.reset(new SymbolCanonicalizer());
+  std::string unique_path = std::string(path) + std::to_string(next_source_id++);
+  Source* source = sources->load_from_memory(
+      unique_path,
+      reinterpret_cast<const uint8*>(text.data()),
+      text.size());
+  NullDiagnostics diagnostics(sources);
+  Scanner scanner(source, result.symbols.get(), &diagnostics);
+  Parser parser(source, &scanner, &diagnostics);
+  result.unit = parser.parse_unit();
+  ASSERT(!diagnostics.encountered_error());
+  return result;
+}
+
+static void expect_equivalent(SourceManager* sources,
+                              const std::string& left,
+                              const std::string& right) {
+  ParsedUnit left_unit = parse(sources, "///<ast-equivalence-left>", left);
+  ParsedUnit right_unit = parse(sources, "///<ast-equivalence-right>", right);
+  ASSERT(ast_equivalent(left_unit.unit, right_unit.unit));
+}
+
+static void expect_different(SourceManager* sources,
+                             const std::string& left,
+                             const std::string& right) {
+  ParsedUnit left_unit = parse(sources, "///<ast-difference-left>", left);
+  ParsedUnit right_unit = parse(sources, "///<ast-difference-right>", right);
+  ast::Node* mismatch_left = null;
+  ast::Node* mismatch_right = null;
+  ASSERT(!ast_equivalent(left_unit.unit,
+                         right_unit.unit,
+                         &mismatch_left,
+                         &mismatch_right));
+  ASSERT(mismatch_left != null || mismatch_right != null);
+}
+
+static void test_ast_equivalence(SourceManager* sources) {
+  expect_equivalent(
+      sources,
+      "main: return ((1 + 2))\n",
+      "main:\n  return 1 + 2\n");
+
+  expect_equivalent(
+      sources,
+      "compute first second -> int: return first + second\n",
+      "compute -> int\n    first\n    second\n:\n  return first + second\n");
+
+  expect_different(
+      sources,
+      "main: return 1 + 2\n",
+      "main: return 1 * 2\n");
+
+  // Parentheses around a possible static receiver are resolver-sensitive.
+  expect_different(
+      sources,
+      "main: return Foo.bar\n",
+      "main: return (Foo).bar\n");
+}
+
+} // namespace compiler
+} // namespace toit
+
+int main(int argc, char** argv) {
+  toit::throwing_new_allowed = true;
+  ASSERT(argc == 2);
+
+  toit::compiler::FilesystemLocal filesystem;
+  toit::compiler::SourceManager sources(&filesystem);
+  toit::compiler::test_ast_equivalence(&sources);
+  return 0;
+}

--- a/tests/ctest/file-writer-input.toit
+++ b/tests/ctest/file-writer-input.toit
@@ -1,0 +1,6 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+main:
+  null

--- a/tests/ctest/file-writer-test.cc
+++ b/tests/ctest/file-writer-test.cc
@@ -1,0 +1,88 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include <string>
+
+#ifdef TOIT_WINDOWS
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+#include "../../src/file_writer.h"
+#include "../../src/top.h"
+
+namespace toit {
+
+static std::string read_file(const std::string& path) {
+  FILE* file = fopen(path.c_str(), "rb");
+  ASSERT(file != null);
+  ASSERT(fseek(file, 0, SEEK_END) == 0);
+  long size = ftell(file);
+  ASSERT(size >= 0);
+  ASSERT(fseek(file, 0, SEEK_SET) == 0);
+  std::string result(size, '\0');
+  ASSERT(size == 0 || fread(&result[0], 1, size, file) == size);
+  ASSERT(fclose(file) == 0);
+  return result;
+}
+
+static void remove_file(const std::string& path) {
+#ifdef TOIT_WINDOWS
+  _unlink(path.c_str());
+#else
+  unlink(path.c_str());
+#endif
+}
+
+static void set_mode(const std::string& path, int mode) {
+#ifdef TOIT_WINDOWS
+  ASSERT(_chmod(path.c_str(), mode) == 0);
+#else
+  ASSERT(chmod(path.c_str(), mode) == 0);
+#endif
+}
+
+static void test_atomic_file_writer(const char* executable_path) {
+  std::string path = std::string(executable_path) + ".atomic-output";
+  remove_file(path);
+
+  const char* first = "first contents\n";
+  ASSERT(write_file_atomically(
+      path.c_str(), reinterpret_cast<const uint8*>(first), strlen(first), 0600));
+  ASSERT(read_file(path) == first);
+
+  set_mode(path, 0640);
+  const char* second = "replacement contents\n";
+  ASSERT(write_file_atomically(
+      path.c_str(), reinterpret_cast<const uint8*>(second), strlen(second)));
+  ASSERT(read_file(path) == second);
+
+#ifndef TOIT_WINDOWS
+  struct stat status;
+  ASSERT(stat(path.c_str(), &status) == 0);
+  ASSERT((status.st_mode & 0777) == 0640);
+#endif
+
+  set_mode(path, 0440);
+  ASSERT(!write_file_atomically(
+      path.c_str(), reinterpret_cast<const uint8*>(first), strlen(first)));
+  ASSERT(read_file(path) == second);
+
+  set_mode(path, 0600);
+  remove_file(path);
+}
+
+} // namespace toit
+
+int main(int argc, char** argv) {
+  toit::throwing_new_allowed = true;
+  ASSERT(argc == 2);
+  toit::test_atomic_file_writer(argv[0]);
+  return 0;
+}

--- a/tests/ctest/format-source-input.toit
+++ b/tests/ctest/format-source-input.toit
@@ -1,0 +1,11 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+sample:
+  value := 1  // Keep   every byte.
+  // This comment is on its own line.
+  value := /* Attached
+               alignment. */ 2
+  /* Standalone
+     block. */

--- a/tests/ctest/format-source-test.cc
+++ b/tests/ctest/format-source-test.cc
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <string>
+
+#include "../../src/compiler/diagnostic.h"
+#include "../../src/compiler/filesystem_local.h"
+#include "../../src/compiler/format_source.h"
+#include "../../src/compiler/scanner.h"
+#include "../../src/compiler/sources.h"
+#include "../../src/compiler/symbol_canonicalizer.h"
+#include "../../src/top.h"
+
+namespace toit {
+namespace compiler {
+
+static int comment_containing(const FormatSource& source, const char* needle) {
+  for (const auto& comment : source.comments()) {
+    if (comment.text.find(needle) != std::string::npos) return comment.id;
+  }
+  return -1;
+}
+
+static int line_containing(const FormatSource& source, const char* needle) {
+  for (int i = 0; i < static_cast<int>(source.lines().size()); i++) {
+    const FormatLine& line = source.lines()[i];
+    if (source.text(line.from, line.content_to).find(needle) !=
+        std::string::npos) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+static void expect(const char* expected, const std::string& actual) {
+  if (actual == expected) return;
+  fprintf(stderr, "Expected:\n---\n%s---\nActual:\n---\n%s---\n",
+          expected, actual.c_str());
+  exit(1);
+}
+
+static void test_format_source(Source* source,
+                               List<Scanner::Comment> comments) {
+  FormatSource facts(source, comments);
+
+  int frozen_line = line_containing(facts, "value := 1");
+  ASSERT(frozen_line >= 0);
+  ASSERT(facts.lines()[frozen_line].is_frozen());
+  expect("    value := 1  // Keep   every byte.\n",
+         facts.reindent_line(frozen_line, 4));
+
+  int own_line_id = comment_containing(facts, "on its own line");
+  ASSERT(own_line_id >= 0);
+  ASSERT(!facts.comments()[own_line_id].follows_code);
+  ASSERT(!facts.lines()[facts.comments()[own_line_id].start_line].is_frozen());
+
+  int attached_id = comment_containing(facts, "Attached");
+  ASSERT(attached_id >= 0);
+  ASSERT(facts.comments()[attached_id].follows_code);
+  ASSERT(facts.comments()[attached_id].spans_lines);
+  expect("/* Attached\n                 alignment. */",
+         facts.shift_multiline_comment(
+             attached_id, facts.comments()[attached_id].start_column + 2));
+
+  int standalone_id = comment_containing(facts, "Standalone");
+  ASSERT(standalone_id >= 0);
+  ASSERT(!facts.comments()[standalone_id].follows_code);
+  expect("/* Standalone\n       block. */",
+         facts.shift_multiline_comment(
+             standalone_id,
+             facts.comments()[standalone_id].start_column + 2));
+}
+
+} // namespace compiler
+} // namespace toit
+
+int main(int argc, char** argv) {
+  toit::throwing_new_allowed = true;
+  ASSERT(argc == 2);
+
+  toit::compiler::FilesystemLocal filesystem;
+  toit::compiler::SourceManager sources(&filesystem);
+  toit::compiler::NullDiagnostics diagnostics(&sources);
+  auto loaded = sources.load_file(
+      argv[1], toit::compiler::Package::invalid());
+  ASSERT(loaded.status ==
+         toit::compiler::SourceManager::LoadResult::OK);
+  toit::compiler::SymbolCanonicalizer symbols;
+  toit::compiler::Scanner scanner(loaded.source, &symbols, &diagnostics);
+  while (scanner.next().token() != toit::compiler::Token::EOS) {}
+  toit::compiler::test_format_source(
+      loaded.source, scanner.comments());
+  return 0;
+}

--- a/tests/ctest/format-verifier-input.toit
+++ b/tests/ctest/format-verifier-input.toit
@@ -1,0 +1,6 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+main:
+  null

--- a/tests/ctest/format-verifier-test.cc
+++ b/tests/ctest/format-verifier-test.cc
@@ -1,0 +1,73 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <string>
+
+#include "../../src/compiler/diagnostic.h"
+#include "../../src/compiler/filesystem_local.h"
+#include "../../src/compiler/format_verifier.h"
+#include "../../src/compiler/parser.h"
+#include "../../src/compiler/scanner.h"
+#include "../../src/compiler/sources.h"
+#include "../../src/compiler/symbol_canonicalizer.h"
+#include "../../src/top.h"
+
+namespace toit {
+namespace compiler {
+
+static bool verify(const std::string& original,
+                   const std::string& formatted) {
+  FilesystemLocal filesystem;
+  SourceManager sources(&filesystem);
+  Source* source = sources.load_from_memory(
+      "///<format-verifier-original>",
+      reinterpret_cast<const uint8*>(original.data()),
+      original.size());
+  SymbolCanonicalizer symbols;
+  NullDiagnostics diagnostics(&sources);
+  Scanner scanner(source, &symbols, &diagnostics);
+  Parser parser(source, &scanner, &diagnostics);
+  ast::Unit* unit = parser.parse_unit();
+  ASSERT(!diagnostics.encountered_error());
+
+  return verify_formatted_output(
+      &sources,
+      source,
+      &scanner,
+      unit,
+      reinterpret_cast<const uint8*>(formatted.data()),
+      formatted.size(),
+      "<format-verifier-test>");
+}
+
+static void test_format_verifier() {
+  ASSERT(verify(
+      "main: return ((1 + 2))  // Keep this.\n",
+      "main:\n  return 1 + 2  // Keep this.\n"));
+
+  ASSERT(verify(
+      "main:\n  /* First line.\n     Second line. */\n  return 1\n",
+      "main:\n    /* First line.\n       Second line. */\n    return 1\n"));
+
+  ASSERT(!verify(
+      "main: return 1  // Keep this.\n",
+      "main: return 1\n"));
+
+  ASSERT(!verify(
+      "main: return 1  // Keep this.\n",
+      "main:\n  // Keep this.\n  return 1\n"));
+
+  ASSERT(!verify("main: return 1 + 2\n", "main: return 1 * 2\n"));
+  ASSERT(!verify("main: return Foo.bar\n", "main: return (Foo).bar\n"));
+}
+
+} // namespace compiler
+} // namespace toit
+
+int main(int argc, char** argv) {
+  toit::throwing_new_allowed = true;
+  ASSERT(argc == 2);
+  toit::compiler::test_format_verifier();
+  return 0;
+}


### PR DESCRIPTION
Part 1 of 10 in the AST-driven Toit pretty-printer stack.

## Summary

- specify the formatter contract and implementation roadmap
- add structural AST-equivalence and comment-preservation verification
- add atomic source-file replacement
- model source comments, frozen trailing-comment lines, and multiline comments

This layer establishes safety and source facts without exposing the formatter command.

## Verification

- AST-equivalence, atomic-writer, and source-fact CTests pass
- the complete stack formats and verifies all 269 Toit files under lib, tools, and examples

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>