### PR TITLE
compiler: add direct layout decisions and expression printing

### DIFF
--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -1,0 +1,421 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#include "format_expression.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "token.h"
+
+namespace toit {
+namespace compiler {
+
+using namespace ast;
+
+namespace {
+
+Expression* peel_parentheses(Expression* expression) {
+  while (expression != null && expression->is_Parenthesis()) {
+    expression = expression->as_Parenthesis()->expression();
+  }
+  return expression;
+}
+
+bool is_right_associative(Token::Kind kind) {
+  int precedence = Token::precedence(kind);
+  return precedence == PRECEDENCE_AND || precedence == PRECEDENCE_OR ||
+      precedence == PRECEDENCE_ASSIGNMENT;
+}
+
+bool is_logical(Token::Kind kind) {
+  int precedence = Token::precedence(kind);
+  return precedence == PRECEDENCE_AND || precedence == PRECEDENCE_OR;
+}
+
+bool is_bitwise(Token::Kind kind) {
+  int precedence = Token::precedence(kind);
+  return precedence == PRECEDENCE_BIT_SHIFT ||
+      precedence == PRECEDENCE_BIT_AND ||
+      precedence == PRECEDENCE_BIT_OR ||
+      precedence == PRECEDENCE_BIT_XOR;
+}
+
+bool is_static_receiver_candidate(Expression* expression) {
+  int identifiers = 0;
+  while (expression != null && expression->is_Dot()) {
+    identifiers++;
+    expression = expression->as_Dot()->receiver();
+  }
+  if (expression == null || !expression->is_Identifier()) return false;
+  return ++identifiers <= 3;
+}
+
+class ExpressionPrinter {
+ public:
+  ExpressionPrinter(Source* source,
+                    int base_indentation,
+                    const FormatStyle& style,
+                    const FormatExpressionOptions& options)
+      : source_(source)
+      , base_indentation_(base_indentation)
+      , style_(style)
+      , options_(options) {}
+
+  bool run(Expression* expression, FormatOutput* result) {
+    ASSERT(expression != null && result != null);
+    return format(expression, PRECEDENCE_NONE, result);
+  }
+
+ private:
+  Source* source_;
+  int base_indentation_;
+  const FormatStyle& style_;
+  const FormatExpressionOptions& options_;
+  bool supported_ = true;
+
+  int start(Node* node) const {
+    return source_->offset_in_source(node->full_range().from());
+  }
+
+  int end(Node* node) const {
+    return source_->offset_in_source(node->full_range().to());
+  }
+
+  std::string source_text(Node* node) const {
+    int from = start(node);
+    int to = end(node);
+    return std::string(
+        reinterpret_cast<const char*>(source_->text()) + from, to - from);
+  }
+
+  int estimated_flat_width(Expression* expression) {
+    if (expression == null) return -1;
+    expression = peel_parentheses(expression);
+    int from = start(expression);
+    int to = end(expression);
+    int width = 0;
+    bool pending_space = false;
+    bool after_opener = false;
+    uint8 quote = 0;
+    bool escaped = false;
+    for (int offset = from; offset < to; offset++) {
+      uint8 c = source_->text()[offset];
+      if (quote != 0) {
+        if ((c & 0xc0) != 0x80) width++;
+        if (escaped) {
+          escaped = false;
+        } else if (c == '\\') {
+          escaped = true;
+        } else if (c == quote) {
+          quote = 0;
+        }
+        continue;
+      }
+      if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+        if (!after_opener && width > 0) pending_space = true;
+        continue;
+      }
+      // These tokens may be added or removed by the printer. They are useful
+      // for rendering, but deliberately irrelevant to the rough measurement.
+      if (c == ',') {
+        pending_space = width > 0;
+        after_opener = false;
+        continue;
+      }
+      if (c == '(') {
+        after_opener = true;
+        continue;
+      }
+      if (c == ')' || c == '\\') {
+        after_opener = false;
+        continue;
+      }
+      if (c == ']' || c == '}') pending_space = false;
+      if (pending_space) {
+        width++;
+        pending_space = false;
+      }
+      if ((c & 0xc0) != 0x80) width++;
+      if (c == '\'' || c == '"') quote = c;
+      after_opener = c == '[' || c == '{';
+    }
+    return width;
+  }
+
+  std::string receiver(Expression* expression) {
+    bool had_parentheses = expression->is_Parenthesis();
+    Expression* inner = peel_parentheses(expression);
+    std::string result = flat(inner, PRECEDENCE_POSTFIX);
+    if (had_parentheses && is_static_receiver_candidate(inner)) {
+      return "(" + flat(inner, PRECEDENCE_NONE) + ")";
+    }
+    return result;
+  }
+
+  bool needs_bitwise_parentheses(Token::Kind parent,
+                                 Token::Kind child) const {
+    if (!options_.parenthesize_mixed_bitwise) return false;
+    if (!is_bitwise(parent) && !is_bitwise(child)) return false;
+    if (Token::precedence(parent) == PRECEDENCE_ASSIGNMENT) return false;
+    return parent != child;
+  }
+
+  std::string binary_operand(Expression* expression,
+                             int outer_precedence,
+                             Token::Kind parent_kind) {
+    Expression* inner = peel_parentheses(expression);
+    if (inner != null && inner->is_Binary() &&
+        needs_bitwise_parentheses(
+            parent_kind, inner->as_Binary()->kind())) {
+      return "(" + flat(inner, PRECEDENCE_NONE) + ")";
+    }
+    return flat(expression, outer_precedence);
+  }
+
+  std::string flat_binary(Binary* binary, int outer_precedence) {
+    Token::Kind kind = binary->kind();
+    int precedence = Token::precedence(kind);
+    bool parentheses =
+        outer_precedence != PRECEDENCE_NONE && precedence <= outer_precedence;
+    bool right_associative = is_right_associative(kind);
+    int left_precedence = right_associative ? precedence : precedence - 1;
+    int right_precedence = right_associative ? precedence - 1 : precedence;
+    if (precedence == PRECEDENCE_ASSIGNMENT || is_logical(kind)) {
+      right_precedence = PRECEDENCE_NONE;
+    }
+    if (is_logical(kind)) left_precedence = PRECEDENCE_NONE;
+
+    std::string result =
+        binary_operand(binary->left(), left_precedence, kind) + " " +
+        Token::symbol(kind).c_str() + " " +
+        binary_operand(binary->right(), right_precedence, kind);
+    return parentheses ? "(" + result + ")" : result;
+  }
+
+  std::string flat_ternary(If* expression, int outer_precedence) {
+    std::string result = flat(expression->expression(), PRECEDENCE_CONDITIONAL) +
+        " ? " + flat(expression->yes(), PRECEDENCE_NONE) + " : " +
+        flat(expression->no(), PRECEDENCE_NONE);
+    return outer_precedence == PRECEDENCE_NONE
+        ? result
+        : "(" + result + ")";
+  }
+
+  std::string flat(Expression* expression, int outer_precedence) {
+    if (!supported_ || expression == null) return std::string();
+    expression = peel_parentheses(expression);
+    if (expression->is_Binary()) {
+      return flat_binary(expression->as_Binary(), outer_precedence);
+    }
+    if (expression->is_Unary()) {
+      Unary* unary = expression->as_Unary();
+      std::string operation = Token::symbol(unary->kind()).c_str();
+      if (!unary->prefix()) {
+        return flat(unary->expression(), PRECEDENCE_POSTFIX) + operation;
+      }
+      Expression* operand = peel_parentheses(unary->expression());
+      std::string operand_text;
+      if (unary->kind() == Token::NOT && operand->is_Binary()) {
+        operand_text = "(" + flat(operand, PRECEDENCE_NONE) + ")";
+      } else {
+        operand_text = flat(operand, PRECEDENCE_POSTFIX);
+      }
+      std::string result = operation +
+          (unary->kind() == Token::NOT ? " " : "") + operand_text;
+      return unary->kind() == Token::NOT &&
+              outer_precedence != PRECEDENCE_NONE
+          ? "(" + result + ")"
+          : result;
+    }
+    if (expression->is_Dot()) {
+      Dot* dot = expression->as_Dot();
+      return receiver(dot->receiver()) + "." + source_text(dot->name());
+    }
+    if (expression->is_Index()) {
+      Index* index = expression->as_Index();
+      std::string result = receiver(index->receiver()) + "[";
+      for (int i = 0; i < index->arguments().length(); i++) {
+        if (i > 0) result += ", ";
+        result += flat(index->arguments()[i], PRECEDENCE_NONE);
+      }
+      return result + "]";
+    }
+    if (expression->is_IndexSlice()) {
+      IndexSlice* slice = expression->as_IndexSlice();
+      std::string result = receiver(slice->receiver()) + "[";
+      if (slice->from() != null) {
+        result += flat(slice->from(), PRECEDENCE_NONE);
+      }
+      result += "..";
+      if (slice->to() != null) result += flat(slice->to(), PRECEDENCE_NONE);
+      return result + "]";
+    }
+    if (expression->is_Nullable()) {
+      return flat(expression->as_Nullable()->type(), PRECEDENCE_POSTFIX) + "?";
+    }
+    if (expression->is_If()) {
+      If* conditional = expression->as_If();
+      if (conditional->yes() != null && conditional->yes()->is_Sequence()) {
+        supported_ = false;
+        return std::string();
+      }
+      return flat_ternary(conditional, outer_precedence);
+    }
+    if (expression->is_Identifier() || expression->is_LiteralNull() ||
+        expression->is_LiteralUndefined() ||
+        expression->is_LiteralBoolean() ||
+        expression->is_LiteralInteger() ||
+        expression->is_LiteralCharacter() ||
+        expression->is_LiteralString() ||
+        expression->is_LiteralStringInterpolation() ||
+        expression->is_LiteralFloat()) {
+      std::string result = source_text(expression);
+      if (result.find('\n') != std::string::npos ||
+          result.find('\r') != std::string::npos) {
+        supported_ = false;
+        return std::string();
+      }
+      return result;
+    }
+    supported_ = false;
+    return std::string();
+  }
+
+  void flatten_chain(Binary* binary,
+                     Token::Kind kind,
+                     std::vector<Expression*>* operands) {
+    if (is_right_associative(kind)) {
+      operands->push_back(binary->left());
+      Expression* right = binary->right();
+      if (!right->is_Parenthesis() && right->is_Binary() &&
+          right->as_Binary()->kind() == kind) {
+        flatten_chain(right->as_Binary(), kind, operands);
+      } else {
+        operands->push_back(right);
+      }
+      return;
+    }
+
+    Expression* left = binary->left();
+    if (!left->is_Parenthesis() && left->is_Binary() &&
+        left->as_Binary()->kind() == kind) {
+      flatten_chain(left->as_Binary(), kind, operands);
+    } else {
+      operands->push_back(left);
+    }
+    operands->push_back(binary->right());
+  }
+
+  FormatOutput broken_binary(Binary* binary, int outer_precedence) {
+    Token::Kind kind = binary->kind();
+    int precedence = Token::precedence(kind);
+    bool parentheses =
+        outer_precedence != PRECEDENCE_NONE && precedence <= outer_precedence;
+    std::vector<Expression*> operands;
+    flatten_chain(binary, kind, &operands);
+    std::string operation = Token::symbol(kind).c_str();
+
+    FormatOutput result = FormatOutput::single_line(
+        (parentheses ? "(" : "") + flat(operands[0], precedence));
+    bool trailing = is_logical(kind);
+    if (trailing && operands.size() > 1) result.append(" " + operation);
+    for (int i = 1; i < static_cast<int>(operands.size()); i++) {
+      bool last = i + 1 == static_cast<int>(operands.size());
+      std::string operand = flat(operands[i], precedence);
+      result.add_line(
+          style_.continuation_step,
+          trailing ? operand + (last ? "" : " " + operation)
+                   : operation + " " + operand);
+    }
+    if (parentheses) result.append(")");
+    return result;
+  }
+
+  bool render_flat(Expression* expression,
+                   int outer_precedence,
+                   FormatOutput* result) {
+    std::string text = flat(expression, outer_precedence);
+    if (!supported_) return false;
+    *result = FormatOutput::single_line(text);
+    return true;
+  }
+
+  bool format(Expression* expression,
+              int outer_precedence,
+              FormatOutput* result) {
+    Expression* inner = peel_parentheses(expression);
+    int flat_width = estimated_flat_width(expression);
+    if (flat_width < 0) return render_flat(expression, outer_precedence, result);
+
+    if (inner->is_Binary() &&
+        Token::precedence(inner->as_Binary()->kind()) !=
+            PRECEDENCE_ASSIGNMENT) {
+      Binary* binary = inner->as_Binary();
+      std::vector<Expression*> operands;
+      flatten_chain(binary, binary->kind(), &operands);
+      int splits = std::max(1, static_cast<int>(operands.size()) - 1);
+      if (!is_flat_acceptable(flat_width,
+                              base_indentation_,
+                              splits,
+                              splits,
+                              0,
+                              style_)) {
+        *result = broken_binary(binary, outer_precedence);
+        return supported_;
+      }
+    } else if (inner->is_If()) {
+      If* conditional = inner->as_If();
+      if (conditional->yes() == null ||
+          !conditional->yes()->is_Sequence()) {
+        if (!is_flat_acceptable(flat_width,
+                                base_indentation_,
+                                2,
+                                2,
+                                0,
+                                style_)) {
+          *result = FormatOutput::single_line(
+              flat(conditional->expression(), PRECEDENCE_CONDITIONAL));
+          result->add_line(
+              style_.continuation_step,
+              "? " + flat(conditional->yes(), PRECEDENCE_NONE));
+          result->add_line(
+              style_.continuation_step,
+              ": " + flat(conditional->no(), PRECEDENCE_NONE));
+          return supported_;
+        }
+      }
+    }
+    return render_flat(expression, outer_precedence, result);
+  }
+};
+
+} // namespace
+
+bool format_expression(Expression* expression,
+                       Source* source,
+                       int base_indentation,
+                       FormatOutput* result,
+                       const FormatStyle& style,
+                       const FormatExpressionOptions& options) {
+  ASSERT(source != null);
+  ASSERT(base_indentation >= 0);
+  ExpressionPrinter printer(source, base_indentation, style, options);
+  return printer.run(expression, result);
+}
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_expression.h
+++ b/src/compiler/format_expression.h
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#pragma once
+
+#include "ast.h"
+#include "format_output.h"
+#include "sources.h"
+
+namespace toit {
+namespace compiler {
+
+struct FormatExpressionOptions {
+  // Development switch used to measure the readability/churn tradeoff. It is
+  // not intended to become a user-facing formatter option.
+  bool parenthesize_mixed_bitwise = true;
+};
+
+// Formats one expression directly from its AST. Returns false for expression
+// kinds not implemented by the current review slice.
+bool format_expression(ast::Expression* expression,
+                       Source* source,
+                       int base_indentation,
+                       FormatOutput* result,
+                       const FormatStyle& style = FormatStyle(),
+                       const FormatExpressionOptions& options =
+                           FormatExpressionOptions());
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_output.cc
+++ b/src/compiler/format_output.cc
@@ -1,0 +1,105 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#include "format_output.h"
+
+#include <algorithm>
+
+#include "../top.h"
+
+namespace toit {
+namespace compiler {
+
+static void check_single_line(const std::string& text) {
+  ASSERT(text.find('\n') == std::string::npos);
+  ASSERT(text.find('\r') == std::string::npos);
+}
+
+FormatOutput FormatOutput::single_line(const std::string& text) {
+  check_single_line(text);
+  FormatOutput result;
+  result.add_line(0, text);
+  return result;
+}
+
+void FormatOutput::append(const std::string& text) {
+  check_single_line(text);
+  ASSERT(!lines_.empty());
+  lines_.back().text += text;
+}
+
+void FormatOutput::add_line(int indentation, const std::string& text) {
+  ASSERT(indentation >= 0);
+  check_single_line(text);
+  FormatOutputLine line;
+  line.indentation = indentation;
+  line.text = text;
+  lines_.push_back(line);
+}
+
+std::string FormatOutput::render(int base_indentation,
+                                 bool final_newline) const {
+  ASSERT(base_indentation >= 0);
+  std::string result;
+  for (int i = 0; i < static_cast<int>(lines_.size()); i++) {
+    if (i > 0) result.push_back('\n');
+    result.append(base_indentation + lines_[i].indentation, ' ');
+    result += lines_[i].text;
+  }
+  if (final_newline) result.push_back('\n');
+  return result;
+}
+
+int utf8_code_point_width(const std::string& text) {
+  int result = 0;
+  for (unsigned char c : text) {
+    if ((c & 0xc0) != 0x80) result++;
+  }
+  return result;
+}
+
+int preferred_extent_at(int base_indentation, const FormatStyle& style) {
+  ASSERT(base_indentation >= 0);
+  ASSERT(style.preferred_extent >= 0);
+  int pressure = style.indentation_pressure_divisor <= 0
+      ? 0
+      : base_indentation / style.indentation_pressure_divisor;
+  return std::max(0, style.preferred_extent - pressure);
+}
+
+bool is_flat_acceptable(int estimated_width, int base_indentation,
+                        int broken_lines, int split_items, int broken_penalty,
+                        const FormatStyle& style) {
+  ASSERT(estimated_width >= 0);
+  ASSERT(base_indentation >= 0);
+  ASSERT(broken_lines >= 0);
+  ASSERT(split_items >= 0);
+  ASSERT(broken_penalty >= 0);
+  ASSERT(style.width_penalty >= 0);
+  ASSERT(style.line_penalty >= 0);
+  ASSERT(style.split_item_penalty >= 0);
+  int overflow = estimated_width - preferred_extent_at(base_indentation, style);
+  if (overflow <= 0) return true;
+  int64_t flat_cost = static_cast<int64_t>(overflow) * overflow *
+      style.width_penalty;
+  int64_t break_cost = static_cast<int64_t>(broken_lines) *
+          style.line_penalty +
+      static_cast<int64_t>(split_items) * style.split_item_penalty +
+      broken_penalty;
+  return flat_cost <= break_cost;
+}
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_output.h
+++ b/src/compiler/format_output.h
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+#pragma once
+
+#include <stdint.h>
+
+#include <string>
+#include <vector>
+
+namespace toit {
+namespace compiler {
+
+struct FormatStyle {
+  int indentation_step = 2;
+  int continuation_step = 4;
+
+  // These values define a soft flat-layout preference, not an output limit.
+  int preferred_extent = 100;
+  int indentation_pressure_divisor = 4;
+  int width_penalty = 1;
+  int line_penalty = 20;
+  int split_item_penalty = 5;
+  int backslash_penalty = 10;
+
+  int max_blank_lines = 2;
+  int trailing_comment_gap = 2;
+};
+
+struct FormatOutputLine {
+  int indentation = 0;
+  std::string text;
+};
+
+// The selected, grammar-legal output of an AST printer. Speculative layouts
+// are never stored here. Lines carry indentation relative to the AST node's
+// enclosing indentation.
+class FormatOutput {
+ public:
+  static FormatOutput single_line(const std::string& text);
+
+  void append(const std::string& text);
+  void add_line(int indentation, const std::string& text);
+
+  const std::vector<FormatOutputLine>& lines() const { return lines_; }
+
+  std::string render(int base_indentation, bool final_newline = false) const;
+
+ private:
+  std::vector<FormatOutputLine> lines_;
+};
+
+int utf8_code_point_width(const std::string& text);
+
+// Returns whether a construct's flat spelling is acceptable. $broken_lines,
+// $split_items, and $broken_penalty are deliberately rough estimates of the
+// alternative's readability cost; no broken output is built or measured.
+bool is_flat_acceptable(int estimated_width, int base_indentation,
+                        int broken_lines, int split_items,
+                        int broken_penalty = 0,
+                        const FormatStyle& style = FormatStyle());
+
+// Returns the preferred local extent after applying the slight pressure from
+// the enclosing indentation. This is useful for greedy row packing after a
+// construct has already decided to break.
+int preferred_extent_at(int base_indentation,
+                        const FormatStyle& style = FormatStyle());
+
+} // namespace compiler
+} // namespace toit

--- a/tests/ctest/format-expression-input.toit
+++ b/tests/ctest/format-expression-input.toit
@@ -1,0 +1,3 @@
+// This file is intentionally only an input anchor for the C++ test.
+main:
+  return 0

--- a/tests/ctest/format-expression-test.cc
+++ b/tests/ctest/format-expression-test.cc
@@ -1,0 +1,122 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <memory>
+#include <string>
+
+#include "../../src/compiler/ast_equivalence.h"
+#include "../../src/compiler/diagnostic.h"
+#include "../../src/compiler/filesystem_local.h"
+#include "../../src/compiler/format_expression.h"
+#include "../../src/compiler/parser.h"
+#include "../../src/compiler/scanner.h"
+#include "../../src/compiler/sources.h"
+#include "../../src/compiler/symbol_canonicalizer.h"
+#include "../../src/top.h"
+
+namespace toit {
+namespace compiler {
+
+struct ParsedExpression {
+  std::unique_ptr<SymbolCanonicalizer> symbols;
+  Source* source = null;
+  ast::Expression* expression = null;
+};
+
+static ParsedExpression parse_expression(SourceManager* sources,
+                                         const std::string& text) {
+  static int next_source_id = 0;
+  ParsedExpression result;
+  result.symbols.reset(new SymbolCanonicalizer());
+  std::string program = "sample:\n  return " + text + "\n";
+  std::string path = "///<format-expression-" +
+      std::to_string(next_source_id++) + ">";
+  result.source = sources->load_from_memory(
+      path,
+      reinterpret_cast<const uint8*>(program.data()),
+      program.size());
+  NullDiagnostics diagnostics(sources);
+  Scanner scanner(result.source, result.symbols.get(), &diagnostics);
+  Parser parser(result.source, &scanner, &diagnostics);
+  ast::Unit* unit = parser.parse_unit();
+  ASSERT(!diagnostics.encountered_error());
+  ASSERT(unit->declarations().length() == 1);
+  ast::Method* method = unit->declarations()[0]->as_Method();
+  ASSERT(method != null && method->body() != null);
+  ASSERT(method->body()->expressions().length() == 1);
+  ast::Return* return_expression =
+      method->body()->expressions()[0]->as_Return();
+  ASSERT(return_expression != null);
+  result.expression = return_expression->value();
+  ASSERT(result.expression != null);
+  return result;
+}
+
+static std::string format(SourceManager* sources,
+                          const std::string& input,
+                          int preferred_extent = 100,
+                          bool parenthesize_mixed_bitwise = true) {
+  ParsedExpression parsed = parse_expression(sources, input);
+  FormatStyle style;
+  style.preferred_extent = preferred_extent;
+  style.indentation_pressure_divisor = 0;
+  FormatExpressionOptions options;
+  options.parenthesize_mixed_bitwise = parenthesize_mixed_bitwise;
+  FormatOutput output_lines;
+  ASSERT(format_expression(
+      parsed.expression, parsed.source, 0, &output_lines, style, options));
+  std::string output = output_lines.render(0);
+
+  ParsedExpression reparsed = parse_expression(sources, output);
+  ASSERT(ast_nodes_equivalent(parsed.expression, reparsed.expression));
+
+  FormatOutput second_output;
+  ASSERT(format_expression(
+      reparsed.expression,
+      reparsed.source,
+      0,
+      &second_output,
+      style,
+      options));
+  ASSERT(second_output.render(0) == output);
+  return output;
+}
+
+static void test_format_expression(SourceManager* sources) {
+  ASSERT(format(sources, "(a + b) * c") == "(a + b) * c");
+  ASSERT(format(sources, "((z))") == "z");
+  ASSERT(format(sources, "foo and (bar or gee)") ==
+      "foo and (bar or gee)");
+  ASSERT(format(sources, "not (foo or bar)") == "not (foo or bar)");
+
+  ASSERT(format(sources, "byte >> 4 & 0xf") ==
+      "(byte >> 4) & 0xf");
+  ASSERT(format(sources, "byte >> 4 & 0xf", 100, false) ==
+      "byte >> 4 & 0xf");
+
+  ASSERT(format(sources, "Foo.bar") == "Foo.bar");
+  ASSERT(format(sources, "(Foo).bar") == "(Foo).bar");
+  ASSERT(format(sources, "values[1]") == "values[1]");
+  ASSERT(format(sources, "values[1..4]") == "values[1..4]");
+
+  ASSERT(format(sources, "alpha-long + beta-long + gamma-long", 15) ==
+      "alpha-long\n    + beta-long\n    + gamma-long");
+  ASSERT(format(sources, "foo or bar or gee", 8) ==
+      "foo or\n    bar or\n    gee");
+  ASSERT(format(sources, "condition ? yes : no", 8) ==
+      "condition\n    ? yes\n    : no");
+}
+
+} // namespace compiler
+} // namespace toit
+
+int main(int argc, char** argv) {
+  toit::throwing_new_allowed = true;
+  ASSERT(argc == 2);
+
+  toit::compiler::FilesystemLocal filesystem;
+  toit::compiler::SourceManager sources(&filesystem);
+  toit::compiler::test_format_expression(&sources);
+  return 0;
+}

--- a/tests/ctest/format-output-input.toit
+++ b/tests/ctest/format-output-input.toit
@@ -1,0 +1,6 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+main:
+  null

--- a/tests/ctest/format-output-test.cc
+++ b/tests/ctest/format-output-test.cc
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <string>
+
+#include "../../src/compiler/format_output.h"
+#include "../../src/top.h"
+
+namespace toit {
+namespace compiler {
+
+static void test_soft_width_and_item_pressure() {
+  FormatStyle style;
+  ASSERT(is_flat_acceptable(110, 0, 9, 9, 0, style));
+  ASSERT(!is_flat_acceptable(180, 0, 3, 3, 0, style));
+}
+
+static void test_indentation_pressure() {
+  FormatStyle style;
+  ASSERT(is_flat_acceptable(101, 0, 1, 1, 0, style));
+  ASSERT(!is_flat_acceptable(101, 40, 1, 1, 0, style));
+
+  style.indentation_pressure_divisor = 0;
+  ASSERT(is_flat_acceptable(101, 40, 1, 1, 0, style));
+}
+
+static void test_rendering_and_break_preference() {
+  FormatOutput output = FormatOutput::single_line("first \\");
+  output.add_line(4, "second");
+  ASSERT(output.render(2, true) == "  first \\\n      second\n");
+
+  FormatStyle style;
+  ASSERT(!is_flat_acceptable(107, 0, 1, 1, 0, style));
+  ASSERT(is_flat_acceptable(107, 0, 1, 1, style.backslash_penalty * 3, style));
+}
+
+static void test_utf8_width() {
+  ASSERT(utf8_code_point_width("plain") == 5);
+  ASSERT(utf8_code_point_width("h\xc3\xa9j") == 3);
+}
+
+} // namespace compiler
+} // namespace toit
+
+int main(int argc, char** argv) {
+  toit::throwing_new_allowed = true;
+  ASSERT(argc == 2);
+  toit::compiler::test_soft_width_and_item_pressure();
+  toit::compiler::test_indentation_pressure();
+  toit::compiler::test_rendering_and_break_preference();
+  toit::compiler::test_utf8_width();
+  return 0;
+}


### PR DESCRIPTION
Part 2 of 10 in the AST-driven Toit pretty-printer stack. Depends on #3186.

## Summary

- add a line-oriented output builder that stores only the selected result
- estimate flat width without constructing a speculative flat rendering
- decide whether flat output is acceptable using a soft preferred region, line cost, and item pressure
- render a grammar-legal broken policy directly after rejecting flat output
- pretty-print literals, unary and binary expressions, access, indexing, slices, and conditionals from the AST
- reconstruct precedence-sensitive parentheses

There is no fixed maximum width and no general layout-combinator IR. The measurement is intentionally approximate and may differ slightly from the rendered spelling.

## Verification

- mechanism tests cover soft width, item pressure, indentation pressure, UTF-8 width, and output rendering
- expression behavior is exercised through the public-command gold tests at the top of the stack

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
