### PR TITLE
compiler: format declarations, calls, and collections

### DIFF
--- a/src/compiler/format_declaration.cc
+++ b/src/compiler/format_declaration.cc
@@ -1,0 +1,205 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+
+#include "format_declaration.h"
+
+#include <string>
+#include <vector>
+
+namespace toit {
+namespace compiler {
+
+using namespace ast;
+
+namespace {
+
+class MethodHeaderPrinter {
+ public:
+  MethodHeaderPrinter(Method* method,
+                      Source* source,
+                      int base_indentation,
+                      const FormatStyle& style,
+                      const FormatExpressionOptions& expression_options)
+      : method_(method)
+      , source_(source)
+      , base_indentation_(base_indentation)
+      , style_(style)
+      , expression_options_(expression_options) {}
+
+  bool run(FormatOutput* result) {
+    if (!prepare()) return false;
+    if (parameters_.empty()) {
+      *result = flat_output();
+      return true;
+    }
+
+    int flat_width = utf8_code_point_width(prefix_) +
+        utf8_code_point_width(return_suffix()) +
+        utf8_code_point_width(colon_suffix());
+    for (const auto& parameter : parameters_) {
+      flat_width += 1 + utf8_code_point_width(parameter);
+    }
+    int split_at = first_named_ < 0 ? 0 : first_named_;
+    int broken_lines = parameters_.size() - split_at;
+    if (is_flat_acceptable(flat_width,
+                           base_indentation_,
+                           broken_lines,
+                           broken_lines,
+                           0,
+                           style_)) {
+      *result = flat_output();
+      return true;
+    }
+
+    if (first_named_ >= 0) {
+      int prefix_width = utf8_code_point_width(prefix_) +
+          utf8_code_point_width(return_suffix());
+      for (int i = 0; i < first_named_; i++) {
+        prefix_width += 1 + utf8_code_point_width(parameters_[i]);
+      }
+      if (is_flat_acceptable(prefix_width,
+                             base_indentation_,
+                             1,
+                             1,
+                             0,
+                             style_)) {
+        *result = named_suffix_output();
+        return true;
+      }
+    }
+    *result = fully_broken_output();
+    return true;
+  }
+
+ private:
+  Method* method_;
+  Source* source_;
+  int base_indentation_;
+  const FormatStyle& style_;
+  const FormatExpressionOptions& expression_options_;
+  std::string prefix_;
+  std::string return_type_;
+  std::vector<std::string> parameters_;
+  int first_named_ = -1;
+
+  bool expression(Expression* node, std::string* result) {
+    return format_expression_flat(
+        node, source_, result, expression_options_);
+  }
+
+  bool prepare_parameter(Parameter* parameter, std::string* result) {
+    std::string text;
+    if (parameter->is_block()) text += "[";
+    if (parameter->is_named()) text += "--";
+    if (parameter->is_field_storing()) text += ".";
+
+    std::string name;
+    if (!expression(parameter->name(), &name)) return false;
+    text += name;
+    if (parameter->type() != null) {
+      std::string type;
+      if (!expression(parameter->type(), &type)) return false;
+      text += "/" + type;
+    }
+    if (parameter->default_value() != null) {
+      std::string value;
+      if (!expression(parameter->default_value(), &value)) return false;
+      text += "=" + value;
+    }
+    if (parameter->is_block()) text += "]";
+    *result = text;
+    return true;
+  }
+
+  bool prepare() {
+    if (method_->is_abstract()) prefix_ += "abstract ";
+    if (method_->is_static()) prefix_ += "static ";
+
+    std::string name;
+    if (!expression(method_->name_or_dot(), &name)) return false;
+    prefix_ += name;
+    if (method_->is_setter()) prefix_ += "=";
+
+    if (method_->return_type() != null) {
+      if (!expression(method_->return_type(), &return_type_)) return false;
+    }
+    auto ast_parameters = method_->parameters();
+    for (int i = 0; i < ast_parameters.length(); i++) {
+      Parameter* parameter = ast_parameters[i];
+      std::string text;
+      if (!prepare_parameter(parameter, &text)) return false;
+      if (first_named_ < 0 && parameter->is_named()) first_named_ = i;
+      parameters_.push_back(text);
+    }
+    return true;
+  }
+
+  std::string return_suffix() const {
+    return return_type_.empty() ? std::string() : " -> " + return_type_;
+  }
+
+  std::string colon_suffix() const {
+    return method_->body() == null ? std::string() : ":";
+  }
+
+  FormatOutput flat_output() const {
+    std::string text = prefix_;
+    for (const auto& parameter : parameters_) text += " " + parameter;
+    text += return_suffix();
+    text += colon_suffix();
+    return FormatOutput::single_line(text);
+  }
+
+  FormatOutput named_suffix_output() const {
+    int split_at = first_named_ < 0
+        ? static_cast<int>(parameters_.size())
+        : first_named_;
+    std::string first = prefix_;
+    for (int i = 0; i < split_at; i++) first += " " + parameters_[i];
+    first += return_suffix();
+
+    FormatOutput result = FormatOutput::single_line(first);
+    for (int i = split_at; i < static_cast<int>(parameters_.size()); i++) {
+      result.add_line(style_.continuation_step, parameters_[i]);
+    }
+    if (method_->body() != null) {
+      if (split_at == static_cast<int>(parameters_.size())) {
+        result.append(":");
+      } else {
+        result.add_line(0, ":");
+      }
+    }
+    return result;
+  }
+
+  FormatOutput fully_broken_output() const {
+    FormatOutput result = FormatOutput::single_line(prefix_ + return_suffix());
+    for (const auto& parameter : parameters_) {
+      result.add_line(style_.continuation_step, parameter);
+    }
+    if (method_->body() != null) result.add_line(0, ":");
+    return result;
+  }
+};
+
+} // namespace
+
+bool format_method_header(Method* method,
+                          Source* source,
+                          int base_indentation,
+                          FormatOutput* result,
+                          const FormatStyle& style,
+                          const FormatExpressionOptions& expression_options) {
+  ASSERT(method != null && source != null && result != null);
+  ASSERT(base_indentation >= 0);
+  MethodHeaderPrinter printer(
+      method, source, base_indentation, style, expression_options);
+  return printer.run(result);
+}
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_declaration.h
+++ b/src/compiler/format_declaration.h
@@ -1,0 +1,30 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+
+#pragma once
+
+#include "ast.h"
+#include "format_expression.h"
+#include "format_output.h"
+#include "sources.h"
+
+namespace toit {
+namespace compiler {
+
+// Formats a method header, including its body-introducing colon when present.
+// The body itself is deliberately outside this review slice. Returns false if
+// a parameter or type contains an expression not yet supported by the printer.
+bool format_method_header(ast::Method* method,
+                          Source* source,
+                          int base_indentation,
+                          FormatOutput* result,
+                          const FormatStyle& style = FormatStyle(),
+                          const FormatExpressionOptions& expression_options =
+                              FormatExpressionOptions());
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -80,6 +80,14 @@ class ExpressionPrinter {
     return format(expression, PRECEDENCE_NONE, result);
   }
 
+  bool run_flat(Expression* expression, std::string* result) {
+    ASSERT(expression != null && result != null);
+    std::string text = flat(expression, PRECEDENCE_NONE);
+    if (!supported_) return false;
+    *result = text;
+    return true;
+  }
+
  private:
   Source* source_;
   int base_indentation_;
@@ -404,6 +412,15 @@ class ExpressionPrinter {
 };
 
 } // namespace
+
+bool format_expression_flat(Expression* expression,
+                            Source* source,
+                            std::string* result,
+                            const FormatExpressionOptions& options) {
+  ASSERT(source != null);
+  ExpressionPrinter printer(source, 0, FormatStyle(), options);
+  return printer.run_flat(expression, result);
+}
 
 bool format_expression(Expression* expression,
                        Source* source,

--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -16,6 +16,7 @@
 #include "format_expression.h"
 
 #include <algorithm>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -168,10 +169,38 @@ class ExpressionPrinter {
     bool had_parentheses = expression->is_Parenthesis();
     Expression* inner = peel_parentheses(expression);
     std::string result = flat(inner, PRECEDENCE_POSTFIX);
-    if (had_parentheses && is_static_receiver_candidate(inner)) {
+    if (had_parentheses &&
+        (is_static_receiver_candidate(inner) || inner->is_Call())) {
       return "(" + flat(inner, PRECEDENCE_NONE) + ")";
     }
     return result;
+  }
+
+  std::string flat_named_argument(NamedArgument* argument) {
+    std::string result = "--";
+    if (argument->inverted()) result += "no-";
+    result += source_text(argument->name());
+    if (argument->expression() != null) {
+      result += "=" + flat(argument->expression(), PRECEDENCE_NONE);
+    }
+    return result;
+  }
+
+  std::string flat_call(Call* call, int outer_precedence) {
+    std::string result = flat(call->target(), PRECEDENCE_POSTFIX);
+    for (auto argument : call->arguments()) {
+      result += " ";
+      if (argument->is_NamedArgument()) {
+        result += flat_named_argument(argument->as_NamedArgument());
+      } else if (peel_parentheses(argument)->is_Call()) {
+        result += "(" + flat(peel_parentheses(argument), PRECEDENCE_NONE) + ")";
+      } else {
+        result += flat(argument, PRECEDENCE_NONE);
+      }
+    }
+    return outer_precedence == PRECEDENCE_NONE
+        ? result
+        : "(" + result + ")";
   }
 
   bool needs_bitwise_parentheses(Token::Kind parent,
@@ -228,6 +257,12 @@ class ExpressionPrinter {
     expression = peel_parentheses(expression);
     if (expression->is_Binary()) {
       return flat_binary(expression->as_Binary(), outer_precedence);
+    }
+    if (expression->is_Call()) {
+      return flat_call(expression->as_Call(), outer_precedence);
+    }
+    if (expression->is_NamedArgument()) {
+      return flat_named_argument(expression->as_NamedArgument());
     }
     if (expression->is_Unary()) {
       Unary* unary = expression->as_Unary();
@@ -353,6 +388,100 @@ class ExpressionPrinter {
     return result;
   }
 
+  std::string call_argument(Expression* argument) {
+    if (argument->is_NamedArgument()) {
+      return flat_named_argument(argument->as_NamedArgument());
+    }
+    return flat(argument, PRECEDENCE_NONE);
+  }
+
+  FormatOutput broken_call(Call* call) {
+    FormatOutput result = FormatOutput::single_line(
+        flat(call->target(), PRECEDENCE_POSTFIX));
+    for (auto argument : call->arguments()) {
+      result.add_line(style_.continuation_step, call_argument(argument));
+    }
+    return result;
+  }
+
+  FormatOutput named_suffix_call(Call* call, int first_named) {
+    std::string first = flat(call->target(), PRECEDENCE_POSTFIX);
+    for (int i = 0; i < first_named; i++) {
+      first += " " + call_argument(call->arguments()[i]);
+    }
+    FormatOutput result = FormatOutput::single_line(first);
+    for (int i = first_named; i < call->arguments().length(); i++) {
+      result.add_line(
+          style_.continuation_step, call_argument(call->arguments()[i]));
+    }
+    return result;
+  }
+
+  FormatOutput backslash_call(Call* call, int split_at) {
+    std::string first = flat(call->target(), PRECEDENCE_POSTFIX);
+    for (int i = 0; i < split_at; i++) {
+      first += " " + call_argument(call->arguments()[i]);
+    }
+    first += " \\";
+    std::string second;
+    for (int i = split_at; i < call->arguments().length(); i++) {
+      if (!second.empty()) second += " ";
+      second += call_argument(call->arguments()[i]);
+    }
+    FormatOutput result = FormatOutput::single_line(first);
+    result.add_line(style_.continuation_step, second);
+    return result;
+  }
+
+  int first_named_argument(Call* call) {
+    for (int i = 0; i < call->arguments().length(); i++) {
+      if (call->arguments()[i]->is_NamedArgument()) return i;
+    }
+    return -1;
+  }
+
+  int estimated_call_argument_width(Expression* argument) {
+    return estimated_flat_width(argument);
+  }
+
+  int best_backslash_split(Call* call) {
+    if (call->arguments().length() < 2 || first_named_argument(call) >= 0) {
+      return -1;
+    }
+    int target = estimated_flat_width(call->target());
+    if (target < 0) return -1;
+    std::vector<int> arguments;
+    for (auto argument : call->arguments()) {
+      int width = estimated_call_argument_width(argument);
+      if (width < 0) return -1;
+      arguments.push_back(width);
+    }
+
+    int best_split = -1;
+    int best_extent = std::numeric_limits<int>::max();
+    for (int split = 1; split < static_cast<int>(arguments.size()); split++) {
+      int first = target + 2;
+      for (int i = 0; i < split; i++) first += 1 + arguments[i];
+      int second = style_.continuation_step;
+      for (int i = split; i < static_cast<int>(arguments.size()); i++) {
+        second += (i == split ? 0 : 1) + arguments[i];
+      }
+      int extent = std::max(first, second);
+      if (extent < best_extent) {
+        best_extent = extent;
+        best_split = split;
+      }
+    }
+    return is_flat_acceptable(best_extent,
+                              base_indentation_,
+                              1,
+                              1,
+                              style_.backslash_penalty,
+                              style_)
+        ? best_split
+        : -1;
+  }
+
   bool render_flat(Expression* expression,
                    int outer_precedence,
                    FormatOutput* result) {
@@ -384,6 +513,45 @@ class ExpressionPrinter {
                               style_)) {
         *result = broken_binary(binary, outer_precedence);
         return supported_;
+      }
+    } else if (inner->is_Call() && outer_precedence == PRECEDENCE_NONE) {
+      Call* call = inner->as_Call();
+      if (!call->arguments().is_empty()) {
+        int first_named = first_named_argument(call);
+        int backslash_split = best_backslash_split(call);
+        int broken_lines = first_named >= 0
+            ? call->arguments().length() - first_named
+            : backslash_split >= 0 ? 1 : call->arguments().length();
+        int broken_penalty = backslash_split >= 0
+            ? style_.backslash_penalty
+            : 0;
+        if (!is_flat_acceptable(flat_width,
+                                base_indentation_,
+                                broken_lines,
+                                broken_lines,
+                                broken_penalty,
+                                style_)) {
+          if (first_named >= 0) {
+            int prefix_width = estimated_flat_width(call->target());
+            for (int i = 0; i < first_named; i++) {
+              prefix_width += 1 +
+                  estimated_call_argument_width(call->arguments()[i]);
+            }
+            *result = is_flat_acceptable(prefix_width,
+                                         base_indentation_,
+                                         1,
+                                         1,
+                                         0,
+                                         style_)
+                ? named_suffix_call(call, first_named)
+                : broken_call(call);
+          } else if (backslash_split >= 0) {
+            *result = backslash_call(call, backslash_split);
+          } else {
+            *result = broken_call(call);
+          }
+          return supported_;
+        }
       }
     } else if (inner->is_If()) {
       If* conditional = inner->as_If();

--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -203,6 +203,29 @@ class ExpressionPrinter {
         : "(" + result + ")";
   }
 
+  template<typename T>
+  std::string flat_elements(const char* opening,
+                            const char* closing,
+                            T elements) {
+    std::string result = opening;
+    for (int i = 0; i < elements.length(); i++) {
+      if (i > 0) result += ", ";
+      result += flat(elements[i], PRECEDENCE_NONE);
+    }
+    return result + closing;
+  }
+
+  std::string flat_map(LiteralMap* map) {
+    if (map->keys().is_empty()) return "{:}";
+    std::string result = "{";
+    for (int i = 0; i < map->keys().length(); i++) {
+      if (i > 0) result += ", ";
+      result += flat(map->keys()[i], PRECEDENCE_NONE) + ": " +
+          flat(map->values()[i], PRECEDENCE_NONE);
+    }
+    return result + "}";
+  }
+
   bool needs_bitwise_parentheses(Token::Kind parent,
                                  Token::Kind child) const {
     if (!options_.parenthesize_mixed_bitwise) return false;
@@ -263,6 +286,21 @@ class ExpressionPrinter {
     }
     if (expression->is_NamedArgument()) {
       return flat_named_argument(expression->as_NamedArgument());
+    }
+    if (expression->is_LiteralList()) {
+      return flat_elements(
+          "[", "]", expression->as_LiteralList()->elements());
+    }
+    if (expression->is_LiteralByteArray()) {
+      return flat_elements(
+          "#[", "]", expression->as_LiteralByteArray()->elements());
+    }
+    if (expression->is_LiteralSet()) {
+      return flat_elements(
+          "{", "}", expression->as_LiteralSet()->elements());
+    }
+    if (expression->is_LiteralMap()) {
+      return flat_map(expression->as_LiteralMap());
     }
     if (expression->is_Unary()) {
       Unary* unary = expression->as_Unary();
@@ -482,6 +520,105 @@ class ExpressionPrinter {
         : -1;
   }
 
+  FormatOutput broken_collection(const std::string& opening,
+                                 const std::string& closing,
+                                 const std::vector<std::string>& items) {
+    FormatOutput result = FormatOutput::single_line(opening);
+    std::string row;
+    int available = preferred_extent_at(base_indentation_, style_) -
+        style_.indentation_step;
+    for (const auto& item : items) {
+      std::string addition = item + ",";
+      int addition_width = utf8_code_point_width(addition);
+      int row_width = utf8_code_point_width(row);
+      if (!row.empty() && row_width + 1 + addition_width > available) {
+        result.add_line(style_.indentation_step, row);
+        row.clear();
+      }
+      if (!row.empty()) row += " ";
+      row += addition;
+    }
+    if (!row.empty()) result.add_line(style_.indentation_step, row);
+    result.add_line(0, closing);
+    return result;
+  }
+
+  std::vector<std::string> collection_items(Expression* expression) {
+    std::vector<std::string> result;
+    if (expression->is_LiteralList()) {
+      for (auto element : expression->as_LiteralList()->elements()) {
+        result.push_back(flat(element, PRECEDENCE_NONE));
+      }
+    } else if (expression->is_LiteralByteArray()) {
+      for (auto element : expression->as_LiteralByteArray()->elements()) {
+        result.push_back(flat(element, PRECEDENCE_NONE));
+      }
+    } else if (expression->is_LiteralSet()) {
+      for (auto element : expression->as_LiteralSet()->elements()) {
+        result.push_back(flat(element, PRECEDENCE_NONE));
+      }
+    } else {
+      LiteralMap* map = expression->as_LiteralMap();
+      for (int i = 0; i < map->keys().length(); i++) {
+        result.push_back(flat(map->keys()[i], PRECEDENCE_NONE) + ": " +
+            flat(map->values()[i], PRECEDENCE_NONE));
+      }
+    }
+    return result;
+  }
+
+  std::vector<int> collection_item_widths(Expression* expression) {
+    std::vector<int> result;
+    if (expression->is_LiteralList()) {
+      for (auto element : expression->as_LiteralList()->elements()) {
+        result.push_back(estimated_flat_width(element));
+      }
+    } else if (expression->is_LiteralByteArray()) {
+      for (auto element : expression->as_LiteralByteArray()->elements()) {
+        result.push_back(estimated_flat_width(element));
+      }
+    } else if (expression->is_LiteralSet()) {
+      for (auto element : expression->as_LiteralSet()->elements()) {
+        result.push_back(estimated_flat_width(element));
+      }
+    } else {
+      LiteralMap* map = expression->as_LiteralMap();
+      for (int i = 0; i < map->keys().length(); i++) {
+        int key = estimated_flat_width(map->keys()[i]);
+        int value = estimated_flat_width(map->values()[i]);
+        result.push_back(key < 0 || value < 0 ? -1 : key + 2 + value);
+      }
+    }
+    return result;
+  }
+
+  int estimated_collection_rows(const std::vector<int>& widths) {
+    int available = preferred_extent_at(base_indentation_, style_) -
+        style_.indentation_step;
+    int rows = 0;
+    int row_width = 0;
+    for (int width : widths) {
+      if (width < 0) return widths.size();
+      int addition = width + 1;
+      if (row_width > 0 && row_width + 1 + addition > available) {
+        rows++;
+        row_width = 0;
+      }
+      row_width += (row_width == 0 ? 0 : 1) + addition;
+    }
+    return rows + (row_width == 0 ? 0 : 1);
+  }
+
+  int estimated_collection_width(Expression* expression,
+                                 const std::vector<int>& widths) {
+    int result = expression->is_LiteralByteArray() ? 3 : 2;
+    for (int i = 0; i < static_cast<int>(widths.size()); i++) {
+      if (widths[i] < 0) return -1;
+      result += widths[i] + (i == 0 ? 0 : 2);
+    }
+    return result;
+  }
+
   bool render_flat(Expression* expression,
                    int outer_precedence,
                    FormatOutput* result) {
@@ -550,6 +687,32 @@ class ExpressionPrinter {
           } else {
             *result = broken_call(call);
           }
+          return supported_;
+        }
+      }
+    } else if (inner->is_LiteralList() ||
+               inner->is_LiteralByteArray() ||
+               inner->is_LiteralSet() ||
+               inner->is_LiteralMap()) {
+      std::vector<int> widths = collection_item_widths(inner);
+      if (!widths.empty()) {
+        int collection_width = estimated_collection_width(inner, widths);
+        int rows = estimated_collection_rows(widths);
+        if (!is_flat_acceptable(collection_width,
+                                base_indentation_,
+                                rows + 1,
+                                widths.size(),
+                                0,
+                                style_)) {
+          std::vector<std::string> items = collection_items(inner);
+          std::string opening = inner->is_LiteralList()
+              ? "["
+              : inner->is_LiteralByteArray() ? "#[" : "{";
+          std::string closing = inner->is_LiteralList() ||
+                  inner->is_LiteralByteArray()
+              ? "]"
+              : "}";
+          *result = broken_collection(opening, closing, items);
           return supported_;
         }
       }

--- a/src/compiler/format_expression.h
+++ b/src/compiler/format_expression.h
@@ -28,6 +28,14 @@ struct FormatExpressionOptions {
   bool parenthesize_mixed_bitwise = true;
 };
 
+// Produces the canonical one-line spelling for an expression. Returns false
+// when the expression kind is not implemented or inherently spans lines.
+bool format_expression_flat(ast::Expression* expression,
+                            Source* source,
+                            std::string* result,
+                            const FormatExpressionOptions& options =
+                                FormatExpressionOptions());
+
 // Formats one expression directly from its AST. Returns false for expression
 // kinds not implemented by the current review slice.
 bool format_expression(ast::Expression* expression,

--- a/tests/ctest/format-declaration-input.toit
+++ b/tests/ctest/format-declaration-input.toit
@@ -1,0 +1,3 @@
+// This file is intentionally only an input anchor for the C++ test.
+main:
+  return 0

--- a/tests/ctest/format-declaration-test.cc
+++ b/tests/ctest/format-declaration-test.cc
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <memory>
+#include <string>
+
+#include "../../src/compiler/ast_equivalence.h"
+#include "../../src/compiler/diagnostic.h"
+#include "../../src/compiler/filesystem_local.h"
+#include "../../src/compiler/format_declaration.h"
+#include "../../src/compiler/parser.h"
+#include "../../src/compiler/scanner.h"
+#include "../../src/compiler/sources.h"
+#include "../../src/compiler/symbol_canonicalizer.h"
+#include "../../src/top.h"
+
+namespace toit {
+namespace compiler {
+
+struct ParsedMethod {
+  std::unique_ptr<SymbolCanonicalizer> symbols;
+  Source* source = null;
+  ast::Method* method = null;
+};
+
+static ParsedMethod parse_method(SourceManager* sources,
+                                 const std::string& header) {
+  static int next_source_id = 0;
+  ParsedMethod result;
+  result.symbols.reset(new SymbolCanonicalizer());
+  std::string program = header + "\n  return 0\n";
+  std::string path = "///<format-declaration-" +
+      std::to_string(next_source_id++) + ">";
+  result.source = sources->load_from_memory(
+      path,
+      reinterpret_cast<const uint8*>(program.data()),
+      program.size());
+  NullDiagnostics diagnostics(sources);
+  Scanner scanner(result.source, result.symbols.get(), &diagnostics);
+  Parser parser(result.source, &scanner, &diagnostics);
+  ast::Unit* unit = parser.parse_unit();
+  ASSERT(!diagnostics.encountered_error());
+  ASSERT(unit->declarations().length() == 1);
+  result.method = unit->declarations()[0]->as_Method();
+  ASSERT(result.method != null);
+  return result;
+}
+
+static std::string format(SourceManager* sources,
+                          const std::string& input,
+                          int preferred_extent = 100) {
+  ParsedMethod parsed = parse_method(sources, input);
+  FormatStyle style;
+  style.preferred_extent = preferred_extent;
+  style.indentation_pressure_divisor = 0;
+  FormatOutput output_lines;
+  ASSERT(format_method_header(
+      parsed.method, parsed.source, 0, &output_lines, style));
+  std::string output = output_lines.render(0);
+
+  ParsedMethod reparsed = parse_method(sources, output);
+  ASSERT(ast_nodes_equivalent(parsed.method, reparsed.method));
+  FormatOutput second_output;
+  ASSERT(format_method_header(
+      reparsed.method, reparsed.source, 0, &second_output, style));
+  ASSERT(second_output.render(0) == output);
+  return output;
+}
+
+static void test_format_method_header(SourceManager* sources) {
+  ASSERT(format(sources, "short x/int y/int -> int:") ==
+      "short x/int y/int -> int:");
+  ASSERT(format(
+      sources,
+      "configure --organization/string --application/string value/int -> bool:",
+      30) ==
+      "configure -> bool\n"
+      "    --organization/string\n"
+      "    --application/string\n"
+      "    value/int\n"
+      ":");
+  ASSERT(format(
+      sources,
+      "other x/int y/int --extra/int=0 -> int:",
+      26) ==
+      "other x/int y/int -> int\n"
+      "    --extra/int=0\n"
+      ":");
+  ASSERT(format(sources, "each items/List [--handler] -> none:") ==
+      "each items/List [--handler] -> none:");
+  ASSERT(format(sources, "static set-value= value/int -> none:") ==
+      "static set-value= value/int -> none:");
+}
+
+} // namespace compiler
+} // namespace toit
+
+int main(int argc, char** argv) {
+  toit::throwing_new_allowed = true;
+  ASSERT(argc == 2);
+  toit::compiler::FilesystemLocal filesystem;
+  toit::compiler::SourceManager sources(&filesystem);
+  toit::compiler::test_format_method_header(&sources);
+  return 0;
+}

--- a/tests/ctest/format-expression-test.cc
+++ b/tests/ctest/format-expression-test.cc
@@ -106,6 +106,31 @@ static void test_format_expression(SourceManager* sources) {
       "foo or\n    bar or\n    gee");
   ASSERT(format(sources, "condition ? yes : no", 8) ==
       "condition\n    ? yes\n    : no");
+
+  ASSERT(format(sources, "print  \"hello\"") == "print \"hello\"");
+  ASSERT(format(
+      sources,
+      "consume arg01 arg02 arg03 arg04 arg05 arg06 arg07 arg08 arg09 arg10",
+      40) ==
+      "consume arg01 arg02 arg03 arg04 arg05 arg06 arg07 arg08 arg09 arg10");
+  ASSERT(format(
+      sources,
+      "http-client.post-request encoded --host=server-host --port=server-port",
+      38) ==
+      "http-client.post-request encoded\n"
+      "    --host=server-host\n"
+      "    --port=server-port");
+  ASSERT(format(
+      sources,
+      "send first-moderately-long second-moderately-long third-moderately-long",
+      36) ==
+      "send first-moderately-long \\\n"
+      "    second-moderately-long third-moderately-long");
+  ASSERT(format(sources, "consume (build x y)") == "consume (build x y)");
+  ASSERT(format(sources, "(build x).field") == "(build x).field");
+  ASSERT(format(sources, "1 + (compute x)") == "1 + (compute x)");
+  ASSERT(format(sources, "configure --no-cache") ==
+      "configure --no-cache");
 }
 
 } // namespace compiler

--- a/tests/ctest/format-expression-test.cc
+++ b/tests/ctest/format-expression-test.cc
@@ -131,6 +131,28 @@ static void test_format_expression(SourceManager* sources) {
   ASSERT(format(sources, "1 + (compute x)") == "1 + (compute x)");
   ASSERT(format(sources, "configure --no-cache") ==
       "configure --no-cache");
+
+  ASSERT(format(sources, "[]") == "[]");
+  ASSERT(format(sources, "{}") == "{}");
+  ASSERT(format(sources, "{:}") == "{:}");
+  ASSERT(format(sources, "#[1,2,  3]") == "#[1, 2, 3]");
+  ASSERT(format(sources, "{one:1,two: 2}") == "{one: 1, two: 2}");
+  ASSERT(format(
+      sources,
+      "[aaaaaaaaaa, bbbbbbbbbb, cccccccccc, dddddddddd]",
+      24) ==
+      "[\n"
+      "  aaaaaaaaaa, bbbbbbbbbb,\n"
+      "  cccccccccc, dddddddddd,\n"
+      "]");
+  ASSERT(format(
+      sources,
+      "{first-long: one-long, second-long: two-long}",
+      24) ==
+      "{\n"
+      "  first-long: one-long,\n"
+      "  second-long: two-long,\n"
+      "}");
 }
 
 } // namespace compiler


### PR DESCRIPTION
Part 3 of 10 in the AST-driven Toit pretty-printer stack. Depends on #3187.

## Summary

- print method headers directly from AST declarations
- keep return types on the first method-header line
- use rough widths and item pressure to accept or reject flat calls and collections
- render named-suffix, fully broken, and backslash call policies directly
- render packed collection rows directly after rejecting flat output
- avoid constructing complete broken alternatives before making the flat decision

## Verification

- each review commit builds independently
- the final gold corpus covers return-type movement, many-argument calls, backslash continuations, and packed collections

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
