### PR TITLE
compiler: format statements and complete units

### DIFF
--- a/src/compiler/format_statement.cc
+++ b/src/compiler/format_statement.cc
@@ -1,0 +1,296 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+
+#include "format_statement.h"
+
+#include <string>
+#include <vector>
+
+#include "token.h"
+
+namespace toit {
+namespace compiler {
+
+using namespace ast;
+
+namespace {
+
+class StatementPrinter {
+ public:
+  StatementPrinter(Source* source,
+                   const FormatStyle& style,
+                   const FormatExpressionOptions& expression_options)
+      : source_(source)
+      , style_(style)
+      , expression_options_(expression_options) {}
+
+  bool sequence(Sequence* sequence, int indentation, std::string* result) {
+    ASSERT(sequence != null && result != null);
+    std::vector<std::string> statements;
+    for (auto expression : sequence->expressions()) {
+      std::string text;
+      if (!statement(expression, indentation, &text)) return false;
+      statements.push_back(std::move(text));
+    }
+    *result = join(statements, "\n");
+    return true;
+  }
+
+ private:
+  Source* source_;
+  const FormatStyle& style_;
+  const FormatExpressionOptions& expression_options_;
+
+  static std::string join(const std::vector<std::string>& parts,
+                          const char* separator) {
+    std::string result;
+    for (const auto& part : parts) {
+      if (!result.empty()) result += separator;
+      result += part;
+    }
+    return result;
+  }
+
+  bool flat(Expression* expression, std::string* result) {
+    return format_expression_flat(
+        expression, source_, result, expression_options_);
+  }
+
+  bool formatted(Expression* expression,
+                 int indentation,
+                 FormatOutput* result) {
+    return format_expression(expression,
+                             source_,
+                             indentation,
+                             result,
+                             style_,
+                             expression_options_);
+  }
+
+  static std::string indent(int indentation) {
+    return std::string(indentation, ' ');
+  }
+
+  static std::string render_prefixed(const std::string& prefix,
+                                     const FormatOutput& output,
+                                     int indentation) {
+    ASSERT(!output.lines().empty());
+    std::string result = indent(indentation) + prefix +
+        output.lines()[0].text;
+    for (int i = 1; i < static_cast<int>(output.lines().size()); i++) {
+      result += "\n" + indent(indentation + output.lines()[i].indentation) +
+          output.lines()[i].text;
+    }
+    return result;
+  }
+
+  bool local_fragment(DeclarationLocal* declaration, std::string* result) {
+    std::string text;
+    if (!flat(declaration->name(), &text)) return false;
+    if (declaration->type() != null) {
+      std::string type;
+      if (!flat(declaration->type(), &type)) return false;
+      text += "/" + type;
+    }
+    text += " " + std::string(Token::symbol(declaration->kind()).c_str());
+    if (declaration->value() != null) {
+      std::string value;
+      if (!flat(declaration->value(), &value)) return false;
+      text += " " + value;
+    }
+    *result = text;
+    return true;
+  }
+
+  bool suite(Expression* expression,
+             int indentation,
+             std::string* result) {
+    if (expression == null || !expression->is_Sequence()) return false;
+    return sequence(expression->as_Sequence(), indentation, result);
+  }
+
+  bool control_if(If* conditional,
+                  int indentation,
+                  const std::string& keyword,
+                  std::string* result) {
+    std::string condition;
+    if (!flat(conditional->expression(), &condition)) return false;
+    std::string body;
+    if (!suite(conditional->yes(),
+               indentation + style_.indentation_step,
+               &body)) return false;
+    *result = indent(indentation) + keyword + " " + condition + ":";
+    if (!body.empty()) *result += "\n" + body;
+
+    Expression* no = conditional->no();
+    if (no == null) return true;
+    if (no->is_If() && no->as_If()->yes()->is_Sequence()) {
+      std::string tail;
+      if (!control_if(no->as_If(), indentation, "else if", &tail)) {
+        return false;
+      }
+      *result += "\n" + tail;
+      return true;
+    }
+    std::string else_body;
+    if (!suite(no, indentation + style_.indentation_step, &else_body)) {
+      return false;
+    }
+    *result += "\n" + indent(indentation) + "else:";
+    if (!else_body.empty()) *result += "\n" + else_body;
+    return true;
+  }
+
+  bool statement(Expression* expression,
+                 int indentation,
+                 std::string* result) {
+    if (expression->is_Return()) {
+      Return* return_expression = expression->as_Return();
+      if (return_expression->value() == null) {
+        *result = indent(indentation) + "return";
+        return true;
+      }
+      FormatOutput value;
+      if (!formatted(return_expression->value(), indentation, &value)) {
+        return false;
+      }
+      *result = render_prefixed("return ", value, indentation);
+      return true;
+    }
+    if (expression->is_DeclarationLocal()) {
+      DeclarationLocal* declaration = expression->as_DeclarationLocal();
+      std::string prefix;
+      if (!flat(declaration->name(), &prefix)) return false;
+      if (declaration->type() != null) {
+        std::string type;
+        if (!flat(declaration->type(), &type)) return false;
+        prefix += "/" + type;
+      }
+      prefix += " " +
+          std::string(Token::symbol(declaration->kind()).c_str());
+      if (declaration->value() == null) {
+        *result = indent(indentation) + prefix;
+        return true;
+      }
+      FormatOutput value;
+      if (!formatted(declaration->value(), indentation, &value)) return false;
+      *result = render_prefixed(prefix + " ", value, indentation);
+      return true;
+    }
+    if (expression->is_BreakContinue()) {
+      BreakContinue* jump = expression->as_BreakContinue();
+      std::string text = jump->is_break() ? "break" : "continue";
+      if (jump->label() != null) {
+        std::string label;
+        if (!flat(jump->label(), &label)) return false;
+        text += "." + label;
+      }
+      if (jump->value() != null) {
+        std::string value;
+        if (!flat(jump->value(), &value)) return false;
+        text += " " + value;
+      }
+      *result = indent(indentation) + text;
+      return true;
+    }
+    if (expression->is_If() &&
+        expression->as_If()->yes() != null &&
+        expression->as_If()->yes()->is_Sequence()) {
+      return control_if(
+          expression->as_If(), indentation, "if", result);
+    }
+    if (expression->is_While()) {
+      While* loop = expression->as_While();
+      std::string condition;
+      if (!flat(loop->condition(), &condition)) return false;
+      std::string body;
+      if (!suite(loop->body(),
+                 indentation + style_.indentation_step,
+                 &body)) return false;
+      *result = indent(indentation) + "while " + condition + ":";
+      if (!body.empty()) *result += "\n" + body;
+      return true;
+    }
+    if (expression->is_For()) {
+      For* loop = expression->as_For();
+      std::string initializer;
+      if (loop->initializer() != null) {
+        if (loop->initializer()->is_DeclarationLocal()) {
+          if (!local_fragment(
+              loop->initializer()->as_DeclarationLocal(), &initializer)) {
+            return false;
+          }
+        } else if (!flat(loop->initializer(), &initializer)) {
+          return false;
+        }
+      }
+      std::string condition;
+      if (loop->condition() != null && !flat(loop->condition(), &condition)) {
+        return false;
+      }
+      std::string update;
+      if (loop->update() != null && !flat(loop->update(), &update)) {
+        return false;
+      }
+      std::string body;
+      if (!suite(loop->body(),
+                 indentation + style_.indentation_step,
+                 &body)) return false;
+      *result = indent(indentation) + "for " + initializer + "; " +
+          condition + "; " + update + ":";
+      if (!body.empty()) *result += "\n" + body;
+      return true;
+    }
+    if (expression->is_TryFinally()) {
+      TryFinally* attempt = expression->as_TryFinally();
+      std::string body;
+      if (!sequence(attempt->body(),
+                    indentation + style_.indentation_step,
+                    &body)) return false;
+      *result = indent(indentation) + "try:";
+      if (!body.empty()) *result += "\n" + body;
+      *result += "\n" + indent(indentation) + "finally:";
+      if (!attempt->handler_parameters().is_empty()) {
+        *result += " |";
+        for (auto parameter : attempt->handler_parameters()) {
+          std::string name;
+          if (!flat(parameter->name(), &name)) return false;
+          *result += " " + name;
+        }
+        *result += " |";
+      }
+      std::string handler;
+      if (!sequence(attempt->handler(),
+                    indentation + style_.indentation_step,
+                    &handler)) return false;
+      if (!handler.empty()) *result += "\n" + handler;
+      return true;
+    }
+
+    FormatOutput output;
+    if (!formatted(expression, indentation, &output)) return false;
+    *result = output.render(indentation);
+    return true;
+  }
+};
+
+} // namespace
+
+bool format_sequence(Sequence* sequence,
+                     Source* source,
+                     int indentation,
+                     std::string* result,
+                     const FormatStyle& style,
+                     const FormatExpressionOptions& expression_options) {
+  ASSERT(source != null && result != null);
+  ASSERT(indentation >= 0);
+  StatementPrinter printer(source, style, expression_options);
+  return printer.sequence(sequence, indentation, result);
+}
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_statement.h
+++ b/src/compiler/format_statement.h
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+
+#pragma once
+
+#include <string>
+
+#include "ast.h"
+#include "format_expression.h"
+#include "format_output.h"
+#include "sources.h"
+
+namespace toit {
+namespace compiler {
+
+// Formats a statement sequence at the supplied absolute indentation. Returns
+// false when the sequence contains an AST kind outside the implemented slice.
+bool format_sequence(ast::Sequence* sequence,
+                     Source* source,
+                     int indentation,
+                     std::string* result,
+                     const FormatStyle& style = FormatStyle(),
+                     const FormatExpressionOptions& expression_options =
+                         FormatExpressionOptions());
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_unit.cc
+++ b/src/compiler/format_unit.cc
@@ -1,0 +1,254 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+
+#include "format_unit.h"
+
+#include <string>
+#include <vector>
+
+#include "format_declaration.h"
+#include "format_statement.h"
+
+namespace toit {
+namespace compiler {
+
+using namespace ast;
+
+namespace {
+
+class UnitPrinter {
+ public:
+  UnitPrinter(Source* source,
+              const FormatStyle& style,
+              const FormatExpressionOptions& expression_options)
+      : source_(source)
+      , style_(style)
+      , expression_options_(expression_options) {}
+
+  bool run(Unit* unit, std::string* result) {
+    std::vector<std::string> sections;
+    std::vector<std::string> directives;
+    for (auto import : unit->imports()) {
+      std::string text;
+      if (!format_import(import, &text)) return false;
+      directives.push_back(std::move(text));
+    }
+    for (auto export_ : unit->exports()) {
+      std::string text;
+      if (!format_export(export_, &text)) return false;
+      directives.push_back(std::move(text));
+    }
+    if (!directives.empty()) sections.push_back(join(directives, "\n"));
+
+    for (auto node : unit->declarations()) {
+      std::string text;
+      if (!declaration(node, 0, &text)) return false;
+      sections.push_back(std::move(text));
+    }
+    *result = join(sections, "\n\n");
+    if (!result->empty()) result->push_back('\n');
+    return true;
+  }
+
+ private:
+  Source* source_;
+  const FormatStyle& style_;
+  const FormatExpressionOptions& expression_options_;
+
+  static std::string indent(int indentation) {
+    return std::string(indentation, ' ');
+  }
+
+  static std::string join(const std::vector<std::string>& parts,
+                          const char* separator) {
+    std::string result;
+    for (const auto& part : parts) {
+      if (!result.empty()) result += separator;
+      result += part;
+    }
+    return result;
+  }
+
+  bool flat(Expression* expression, std::string* result) {
+    return format_expression_flat(
+        expression, source_, result, expression_options_);
+  }
+
+  bool format_import(Import* import, std::string* result) {
+    std::string text = "import ";
+    if (import->is_relative()) {
+      text.append(import->dot_outs() + 1, '.');
+    }
+    for (int i = 0; i < import->segments().length(); i++) {
+      if (i > 0) text += ".";
+      std::string segment;
+      if (!flat(import->segments()[i], &segment)) return false;
+      text += segment;
+    }
+    if (import->prefix() != null) {
+      std::string prefix;
+      if (!flat(import->prefix(), &prefix)) return false;
+      text += " as " + prefix;
+    }
+    if (import->show_all()) {
+      text += " show *";
+    } else if (!import->show_identifiers().is_empty()) {
+      text += " show";
+      for (auto identifier : import->show_identifiers()) {
+        std::string name;
+        if (!flat(identifier, &name)) return false;
+        text += " " + name;
+      }
+    }
+    *result = text;
+    return true;
+  }
+
+  bool format_export(Export* export_, std::string* result) {
+    std::string text = "export";
+    if (export_->export_all()) {
+      text += " *";
+    } else {
+      for (auto identifier : export_->identifiers()) {
+        std::string name;
+        if (!flat(identifier, &name)) return false;
+        text += " " + name;
+      }
+    }
+    *result = text;
+    return true;
+  }
+
+  bool field(Field* field, int indentation, std::string* result) {
+    std::string prefix = indent(indentation);
+    if (field->is_abstract()) prefix += "abstract ";
+    if (field->is_static()) prefix += "static ";
+    std::string name;
+    if (!flat(field->name(), &name)) return false;
+    prefix += name;
+    if (field->type() != null) {
+      std::string type;
+      if (!flat(field->type(), &type)) return false;
+      prefix += "/" + type;
+    }
+    if (field->initializer() == null) {
+      *result = prefix;
+      return true;
+    }
+    FormatOutput initializer;
+    if (!format_expression(field->initializer(),
+                           source_,
+                           indentation,
+                           &initializer,
+                           style_,
+                           expression_options_)) return false;
+    prefix += field->is_final() ? " ::= " : " := ";
+    ASSERT(!initializer.lines().empty());
+    *result = prefix + initializer.lines()[0].text;
+    for (int i = 1; i < static_cast<int>(initializer.lines().size()); i++) {
+      *result += "\n" +
+          indent(indentation + initializer.lines()[i].indentation) +
+          initializer.lines()[i].text;
+    }
+    return true;
+  }
+
+  bool method(Method* method, int indentation, std::string* result) {
+    FormatOutput header;
+    if (!format_method_header(method,
+                              source_,
+                              indentation,
+                              &header,
+                              style_,
+                              expression_options_)) return false;
+    *result = header.render(indentation);
+    if (method->body() != null) {
+      std::string body;
+      if (!format_sequence(method->body(),
+                           source_,
+                           indentation + style_.indentation_step,
+                           &body,
+                           style_,
+                           expression_options_)) return false;
+      if (!body.empty()) *result += "\n" + body;
+    }
+    return true;
+  }
+
+  bool class_(Class* klass, int indentation, std::string* result) {
+    std::string header = indent(indentation);
+    if (klass->has_abstract_modifier()) header += "abstract ";
+    switch (klass->kind()) {
+      case Class::CLASS: header += "class "; break;
+      case Class::INTERFACE: header += "interface "; break;
+      case Class::MONITOR: header += "monitor "; break;
+      case Class::MIXIN: header += "mixin "; break;
+    }
+    std::string name;
+    if (!flat(klass->name(), &name)) return false;
+    header += name;
+    if (klass->super() != null) {
+      std::string super;
+      if (!flat(klass->super(), &super)) return false;
+      header += " extends " + super;
+    }
+    if (!klass->mixins().is_empty()) {
+      header += " with";
+      for (auto mixin : klass->mixins()) {
+        std::string text;
+        if (!flat(mixin, &text)) return false;
+        header += " " + text;
+      }
+    }
+    if (!klass->interfaces().is_empty()) {
+      header += " implements";
+      for (auto interface : klass->interfaces()) {
+        std::string text;
+        if (!flat(interface, &text)) return false;
+        header += " " + text;
+      }
+    }
+    header += ":";
+
+    std::vector<std::string> members;
+    for (auto member : klass->members()) {
+      std::string text;
+      if (!declaration(
+          member, indentation + style_.indentation_step, &text)) return false;
+      members.push_back(std::move(text));
+    }
+    *result = header;
+    if (!members.empty()) *result += "\n" + join(members, "\n\n");
+    return true;
+  }
+
+  bool declaration(Node* node, int indentation, std::string* result) {
+    if (node->is_Field()) return field(node->as_Field(), indentation, result);
+    if (node->is_Method()) return method(node->as_Method(), indentation, result);
+    if (node->is_Class()) return class_(node->as_Class(), indentation, result);
+    return false;
+  }
+};
+
+} // namespace
+
+bool format_unit(Unit* unit,
+                 Source* source,
+                 List<Scanner::Comment> comments,
+                 std::string* result,
+                 const FormatStyle& style,
+                 const FormatExpressionOptions& expression_options) {
+  ASSERT(unit != null && source != null && result != null);
+  // Comment ownership is added as a separate review slice. Refusing the unit
+  // is essential: silently dropping trivia would violate the formatter gate.
+  if (!comments.is_empty()) return false;
+  UnitPrinter printer(source, style, expression_options);
+  return printer.run(unit, result);
+}
+
+} // namespace compiler
+} // namespace toit

--- a/src/compiler/format_unit.h
+++ b/src/compiler/format_unit.h
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+
+#pragma once
+
+#include <string>
+
+#include "ast.h"
+#include "format_expression.h"
+#include "format_output.h"
+#include "scanner.h"
+#include "sources.h"
+
+namespace toit {
+namespace compiler {
+
+// Formats a complete compilation unit. Unsupported syntax or trivia returns
+// false; callers must then leave the destination untouched.
+bool format_unit(ast::Unit* unit,
+                 Source* source,
+                 List<Scanner::Comment> comments,
+                 std::string* result,
+                 const FormatStyle& style = FormatStyle(),
+                 const FormatExpressionOptions& expression_options =
+                     FormatExpressionOptions());
+
+} // namespace compiler
+} // namespace toit

--- a/tests/ctest/format-statement-input.toit
+++ b/tests/ctest/format-statement-input.toit
@@ -1,0 +1,3 @@
+// This file is intentionally only an input anchor for the C++ test.
+main:
+  return 0

--- a/tests/ctest/format-statement-test.cc
+++ b/tests/ctest/format-statement-test.cc
@@ -1,0 +1,97 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <memory>
+#include <string>
+
+#include "../../src/compiler/ast_equivalence.h"
+#include "../../src/compiler/diagnostic.h"
+#include "../../src/compiler/filesystem_local.h"
+#include "../../src/compiler/format_statement.h"
+#include "../../src/compiler/parser.h"
+#include "../../src/compiler/scanner.h"
+#include "../../src/compiler/sources.h"
+#include "../../src/compiler/symbol_canonicalizer.h"
+#include "../../src/top.h"
+
+namespace toit {
+namespace compiler {
+
+struct ParsedBody {
+  std::unique_ptr<SymbolCanonicalizer> symbols;
+  Source* source = null;
+  ast::Sequence* body = null;
+};
+
+static ParsedBody parse_body(SourceManager* sources, const std::string& body) {
+  static int next_source_id = 0;
+  ParsedBody result;
+  result.symbols.reset(new SymbolCanonicalizer());
+  std::string program = "sample:\n" + body + "\n";
+  std::string path = "///<format-statement-" +
+      std::to_string(next_source_id++) + ">";
+  result.source = sources->load_from_memory(
+      path,
+      reinterpret_cast<const uint8*>(program.data()),
+      program.size());
+  NullDiagnostics diagnostics(sources);
+  Scanner scanner(result.source, result.symbols.get(), &diagnostics);
+  Parser parser(result.source, &scanner, &diagnostics);
+  ast::Unit* unit = parser.parse_unit();
+  ASSERT(!diagnostics.encountered_error());
+  result.body = unit->declarations()[0]->as_Method()->body();
+  ASSERT(result.body != null);
+  return result;
+}
+
+static std::string format(SourceManager* sources,
+                          const std::string& input,
+                          int preferred_extent = 100) {
+  ParsedBody parsed = parse_body(sources, input);
+  FormatStyle style;
+  style.preferred_extent = preferred_extent;
+  style.indentation_pressure_divisor = 0;
+  std::string output;
+  ASSERT(format_sequence(parsed.body, parsed.source, 2, &output, style));
+
+  ParsedBody reparsed = parse_body(sources, output);
+  ASSERT(ast_nodes_equivalent(parsed.body, reparsed.body));
+  std::string second;
+  ASSERT(format_sequence(
+      reparsed.body, reparsed.source, 2, &second, style));
+  ASSERT(second == output);
+  return output;
+}
+
+static void test_format_statement(SourceManager* sources) {
+  ASSERT(format(sources, "  value  :=  1\n  return  value") ==
+      "  value := 1\n  return value");
+  ASSERT(format(sources, "  if ready: return 1\n  else: return 2") ==
+      "  if ready:\n    return 1\n  else:\n    return 2");
+  ASSERT(format(sources, "  while ready: continue") ==
+      "  while ready:\n    continue");
+  ASSERT(format(sources, "  for i := 0; i < 3; i++: print i") ==
+      "  for i := 0; i < 3; i++:\n    print i");
+  ASSERT(format(sources, "  try: work\n  finally: cleanup") ==
+      "  try:\n    work\n  finally:\n    cleanup");
+  ASSERT(format(
+      sources,
+      "  return alpha-long + beta-long + gamma-long",
+      15) ==
+      "  return alpha-long\n"
+      "      + beta-long\n"
+      "      + gamma-long");
+}
+
+} // namespace compiler
+} // namespace toit
+
+int main(int argc, char** argv) {
+  toit::throwing_new_allowed = true;
+  ASSERT(argc == 2);
+  toit::compiler::FilesystemLocal filesystem;
+  toit::compiler::SourceManager sources(&filesystem);
+  toit::compiler::test_format_statement(&sources);
+  return 0;
+}

--- a/tests/ctest/format-unit-input.toit
+++ b/tests/ctest/format-unit-input.toit
@@ -1,0 +1,2 @@
+main:
+  return 0

--- a/tests/ctest/format-unit-test.cc
+++ b/tests/ctest/format-unit-test.cc
@@ -1,0 +1,113 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#include <memory>
+#include <string>
+
+#include "../../src/compiler/ast_equivalence.h"
+#include "../../src/compiler/diagnostic.h"
+#include "../../src/compiler/filesystem_local.h"
+#include "../../src/compiler/format_unit.h"
+#include "../../src/compiler/parser.h"
+#include "../../src/compiler/scanner.h"
+#include "../../src/compiler/sources.h"
+#include "../../src/compiler/symbol_canonicalizer.h"
+#include "../../src/top.h"
+
+namespace toit {
+namespace compiler {
+
+struct ParsedUnit {
+  std::unique_ptr<SymbolCanonicalizer> symbols;
+  Source* source = null;
+  std::unique_ptr<Scanner> scanner;
+  ast::Unit* unit = null;
+};
+
+static ParsedUnit parse(SourceManager* sources, const std::string& text) {
+  static int next_source_id = 0;
+  ParsedUnit result;
+  result.symbols.reset(new SymbolCanonicalizer());
+  std::string path = "///<format-unit-" +
+      std::to_string(next_source_id++) + ">";
+  result.source = sources->load_from_memory(
+      path,
+      reinterpret_cast<const uint8*>(text.data()),
+      text.size());
+  NullDiagnostics diagnostics(sources);
+  result.scanner.reset(
+      new Scanner(result.source, result.symbols.get(), &diagnostics));
+  Parser parser(result.source, result.scanner.get(), &diagnostics);
+  result.unit = parser.parse_unit();
+  ASSERT(!diagnostics.encountered_error());
+  return result;
+}
+
+static std::string format(SourceManager* sources,
+                          const std::string& input,
+                          int preferred_extent = 100) {
+  ParsedUnit parsed = parse(sources, input);
+  FormatStyle style;
+  style.preferred_extent = preferred_extent;
+  style.indentation_pressure_divisor = 0;
+  std::string output;
+  ASSERT(format_unit(parsed.unit,
+                     parsed.source,
+                     parsed.scanner->comments(),
+                     &output,
+                     style));
+
+  ParsedUnit reparsed = parse(sources, output);
+  ASSERT(ast_equivalent(parsed.unit, reparsed.unit));
+  std::string second;
+  ASSERT(format_unit(reparsed.unit,
+                     reparsed.source,
+                     reparsed.scanner->comments(),
+                     &second,
+                     style));
+  ASSERT(second == output);
+  return output;
+}
+
+static void test_format_unit(SourceManager* sources) {
+  const char* input =
+      "import  ..foo.bar  as baz\n"
+      "import expect show *\n"
+      "export alpha beta\n"
+      "abstract class Device extends Base with Mix implements Interface:\n"
+      "    static VALUE /int ::= 1\n"
+      "    configure --organization/string --application/string value/int -> bool:\n"
+      "      if value: return true\n"
+      "      else: return false\n"
+      "main: return 0\n";
+  const char* expected =
+      "import ..foo.bar as baz\n"
+      "import expect show *\n"
+      "export alpha beta\n"
+      "\n"
+      "abstract class Device extends Base with Mix implements Interface:\n"
+      "  static VALUE/int ::= 1\n"
+      "\n"
+      "  configure --organization/string --application/string value/int -> bool:\n"
+      "    if value:\n"
+      "      return true\n"
+      "    else:\n"
+      "      return false\n"
+      "\n"
+      "main:\n"
+      "  return 0\n";
+  ASSERT(format(sources, input) == expected);
+}
+
+} // namespace compiler
+} // namespace toit
+
+int main(int argc, char** argv) {
+  toit::throwing_new_allowed = true;
+  ASSERT(argc == 2);
+  toit::compiler::FilesystemLocal filesystem;
+  toit::compiler::SourceManager sources(&filesystem);
+  toit::compiler::test_format_unit(&sources);
+  return 0;
+}


### PR DESCRIPTION
Part 4 of 10 in the AST-driven Toit pretty-printer stack. Depends on #3188.

## Summary

- format declarations, assignments, returns, loops, conditionals, try/finally, and control flow
- format imports, exports, fields, methods, classes, and complete source units
- preserve declaration order and emit one final newline
- fail explicitly on unsupported AST kinds

This completes the comment-free AST printer before comment ownership is introduced.

## Verification

- statement and unit formatting builds independently
- complete SDK units are exercised by the corpus gate at the top of the stack

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>