### PR TITLE
compiler: preserve comments exactly once

### DIFF
--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -254,10 +254,9 @@ class ExpressionPrinter {
     bool right_associative = is_right_associative(kind);
     int left_precedence = right_associative ? precedence : precedence - 1;
     int right_precedence = right_associative ? precedence - 1 : precedence;
-    if (precedence == PRECEDENCE_ASSIGNMENT || is_logical(kind)) {
+    if (precedence == PRECEDENCE_ASSIGNMENT) {
       right_precedence = PRECEDENCE_NONE;
     }
-    if (is_logical(kind)) left_precedence = PRECEDENCE_NONE;
 
     std::string result =
         binary_operand(binary->left(), left_precedence, kind) + " " +

--- a/src/compiler/format_source.cc
+++ b/src/compiler/format_source.cc
@@ -83,6 +83,18 @@ std::string FormatSource::text(int from, int to) const {
       reinterpret_cast<const char*>(source_->text()) + from, to - from);
 }
 
+std::vector<int> FormatSource::comments_in(int from, int to) const {
+  ASSERT(from >= 0 && from <= to && to <= source_->size());
+  std::vector<int> result;
+  for (const auto& comment : comments_) {
+    if (from <= comment.from && comment.to <= to) result.push_back(comment.id);
+  }
+  std::sort(result.begin(), result.end(), [this](int left, int right) {
+    return comments_[left].from < comments_[right].from;
+  });
+  return result;
+}
+
 void FormatSource::build_comments(List<Scanner::Comment> comments) {
   for (auto comment : comments) {
     if (!comment.is_valid()) continue;
@@ -168,6 +180,97 @@ std::string FormatSource::shift_multiline_comment(
     int shifted = std::max(0, indentation + delta);
     result.append(shifted, ' ');
     cursor = indentation_end;
+  }
+  return result;
+}
+
+std::string FormatSource::reindent_region(
+    int first_line, int last_line, int new_first_indentation) const {
+  ASSERT(first_line >= 0 && first_line <= last_line &&
+         last_line < static_cast<int>(lines_.size()));
+  ASSERT(new_first_indentation >= 0);
+  int delta = new_first_indentation - lines_[first_line].indentation;
+  std::string result;
+  for (int line_index = first_line; line_index <= last_line; line_index++) {
+    const FormatLine& line = lines_[line_index];
+    int shifted = std::max(0, line.indentation + delta);
+    result += std::string(shifted, ' ') +
+        text(line.from + line.indentation, line.to);
+  }
+  return result;
+}
+
+FormatCommentState::FormatCommentState(const FormatSource* source)
+    : source_(source)
+    , consumed_(source == null ? 0 : source->comments().size(), false) {
+  ASSERT(source_ != null);
+}
+
+void FormatCommentState::consume(int id) {
+  ASSERT(id >= 0 && id < static_cast<int>(consumed_.size()));
+  ASSERT(!consumed_[id]);
+  consumed_[id] = true;
+}
+
+std::vector<int> FormatCommentState::unconsumed_in(int from, int to) const {
+  std::vector<int> result;
+  for (int id : source_->comments_in(from, to)) {
+    if (!consumed_[id]) result.push_back(id);
+  }
+  return result;
+}
+
+bool FormatCommentState::has_unconsumed_in(int from, int to) const {
+  return !unconsumed_in(from, to).empty();
+}
+
+bool FormatCommentState::all_consumed() const {
+  for (bool value : consumed_) {
+    if (!value) return false;
+  }
+  return true;
+}
+
+bool FormatCommentState::render_own_line(int from,
+                                         int to,
+                                         int indentation_delta,
+                                         std::string* result) {
+  ASSERT(result != null);
+  std::vector<std::string> rendered;
+  for (int id : unconsumed_in(from, to)) {
+    const FormatComment& comment = source_->comments()[id];
+    if (comment.follows_code) return false;
+    int column = std::max(0, comment.start_column + indentation_delta);
+    std::string text = std::string(column, ' ');
+    if (comment.spans_lines) {
+      text += source_->shift_multiline_comment(id, column);
+    } else {
+      text += comment.text;
+    }
+    rendered.push_back(std::move(text));
+    consume(id);
+  }
+  result->clear();
+  for (const auto& text : rendered) {
+    if (!result->empty()) *result += "\n";
+    *result += text;
+  }
+  return true;
+}
+
+std::string FormatCommentState::render_verbatim(
+    int first_line, int last_line, int new_first_indentation) {
+  const auto& lines = source_->lines();
+  ASSERT(first_line >= 0 && first_line <= last_line &&
+         last_line < static_cast<int>(lines.size()));
+  int from = lines[first_line].from;
+  int to = lines[last_line].to;
+  for (int id : unconsumed_in(from, to)) consume(id);
+  std::string result = source_->reindent_region(
+      first_line, last_line, new_first_indentation);
+  while (!result.empty() &&
+         (result.back() == '\n' || result.back() == '\r')) {
+    result.pop_back();
   }
   return result;
 }

--- a/src/compiler/format_source.h
+++ b/src/compiler/format_source.h
@@ -60,6 +60,7 @@ class FormatSource {
 
   int line_index_at(int offset) const;
   std::string text(int from, int to) const;
+  std::vector<int> comments_in(int from, int to) const;
 
   // Reproduces a physical line exactly, except for replacing its leading
   // indentation with $new_indentation spaces.
@@ -71,6 +72,12 @@ class FormatSource {
   std::string shift_multiline_comment(int comment_id,
                                       int new_start_column) const;
 
+  // Reproduces complete physical lines while shifting every line by the same
+  // indentation delta.
+  std::string reindent_region(int first_line,
+                              int last_line,
+                              int new_first_indentation) const;
+
  private:
   void build_lines();
   void build_comments(List<Scanner::Comment> comments);
@@ -78,6 +85,37 @@ class FormatSource {
   Source* source_;
   std::vector<FormatLine> lines_;
   std::vector<FormatComment> comments_;
+};
+
+// Shared exactly-once consumption state for one formatting run.
+class FormatCommentState {
+ public:
+  explicit FormatCommentState(const FormatSource* source);
+
+  const FormatSource* source() const { return source_; }
+  bool consumed(int id) const { return consumed_[id]; }
+  void consume(int id);
+
+  std::vector<int> unconsumed_in(int from, int to) const;
+  bool has_unconsumed_in(int from, int to) const;
+  bool all_consumed() const;
+
+  // Renders own-line comments in source order, shifting their original
+  // columns by $indentation_delta. Inline comments belong to their syntax and
+  // make this operation fail.
+  bool render_own_line(int from,
+                       int to,
+                       int indentation_delta,
+                       std::string* result);
+
+  // Reproduces and consumes a closed physical-line region.
+  std::string render_verbatim(int first_line,
+                              int last_line,
+                              int new_first_indentation);
+
+ private:
+  const FormatSource* source_;
+  std::vector<bool> consumed_;
 };
 
 } // namespace compiler

--- a/src/compiler/format_statement.cc
+++ b/src/compiler/format_statement.cc
@@ -23,18 +23,45 @@ class StatementPrinter {
  public:
   StatementPrinter(Source* source,
                    const FormatStyle& style,
-                   const FormatExpressionOptions& expression_options)
+                   const FormatExpressionOptions& expression_options,
+                   FormatCommentState* comments)
       : source_(source)
       , style_(style)
-      , expression_options_(expression_options) {}
+      , expression_options_(expression_options)
+      , comments_(comments) {}
 
   bool sequence(Sequence* sequence, int indentation, std::string* result) {
     ASSERT(sequence != null && result != null);
     std::vector<std::string> statements;
+    // Earlier container printers have already consumed their comments. Using
+    // zero here lets the first statement claim own-line comments immediately
+    // after a suite's colon even though Sequence's AST range starts at its
+    // first expression.
+    int cursor = 0;
     for (auto expression : sequence->expressions()) {
+      int expression_start = start(expression);
+      if (comments_ != null) {
+        int original_indentation = line(expression_start).indentation;
+        std::string leading;
+        if (!comments_->render_own_line(
+            cursor,
+            expression_start,
+            indentation - original_indentation,
+            &leading)) return false;
+        if (!leading.empty()) statements.push_back(std::move(leading));
+      }
       std::string text;
-      if (!statement(expression, indentation, &text)) return false;
+      if (comments_ != null && should_render_verbatim(expression)) {
+        int first_line = facts()->line_index_at(expression_start);
+        int last_line = facts()->line_index_at(
+            std::max(expression_start, end(expression) - 1));
+        text = comments_->render_verbatim(
+            first_line, last_line, indentation);
+      } else if (!statement(expression, indentation, &text)) {
+        return false;
+      }
       statements.push_back(std::move(text));
+      cursor = end(expression);
     }
     *result = join(statements, "\n");
     return true;
@@ -44,6 +71,43 @@ class StatementPrinter {
   Source* source_;
   const FormatStyle& style_;
   const FormatExpressionOptions& expression_options_;
+  FormatCommentState* comments_;
+
+  FormatSource* facts() const {
+    return const_cast<FormatSource*>(comments_->source());
+  }
+
+  int start(Node* node) const {
+    return source_->offset_in_source(node->full_range().from());
+  }
+
+  int end(Node* node) const {
+    return source_->offset_in_source(node->full_range().to());
+  }
+
+  const FormatLine& line(int offset) const {
+    return facts()->lines()[facts()->line_index_at(offset)];
+  }
+
+  bool is_control(Expression* expression) const {
+    return (expression->is_If() && expression->as_If()->yes() != null &&
+            expression->as_If()->yes()->is_Sequence()) ||
+        expression->is_While() || expression->is_For() ||
+        expression->is_TryFinally();
+  }
+
+  bool should_render_verbatim(Expression* expression) const {
+    int from = start(expression);
+    int first_line = facts()->line_index_at(from);
+    int header_to = facts()->lines()[first_line].to;
+    if (comments_->has_unconsumed_in(from, header_to)) return true;
+    if (is_control(expression)) return false;
+    int last_line = facts()->line_index_at(
+        std::max(from, end(expression) - 1));
+    return comments_->has_unconsumed_in(
+        facts()->lines()[first_line].from,
+        facts()->lines()[last_line].to);
+  }
 
   static std::string join(const std::vector<std::string>& parts,
                           const char* separator) {
@@ -285,10 +349,11 @@ bool format_sequence(Sequence* sequence,
                      int indentation,
                      std::string* result,
                      const FormatStyle& style,
-                     const FormatExpressionOptions& expression_options) {
+                     const FormatExpressionOptions& expression_options,
+                     FormatCommentState* comments) {
   ASSERT(source != null && result != null);
   ASSERT(indentation >= 0);
-  StatementPrinter printer(source, style, expression_options);
+  StatementPrinter printer(source, style, expression_options, comments);
   return printer.sequence(sequence, indentation, result);
 }
 

--- a/src/compiler/format_statement.h
+++ b/src/compiler/format_statement.h
@@ -12,6 +12,7 @@
 #include "ast.h"
 #include "format_expression.h"
 #include "format_output.h"
+#include "format_source.h"
 #include "sources.h"
 
 namespace toit {
@@ -25,7 +26,8 @@ bool format_sequence(ast::Sequence* sequence,
                      std::string* result,
                      const FormatStyle& style = FormatStyle(),
                      const FormatExpressionOptions& expression_options =
-                         FormatExpressionOptions());
+                         FormatExpressionOptions(),
+                     FormatCommentState* comments = null);
 
 } // namespace compiler
 } // namespace toit

--- a/src/compiler/format_unit.cc
+++ b/src/compiler/format_unit.cc
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "format_declaration.h"
+#include "format_source.h"
 #include "format_statement.h"
 
 namespace toit {
@@ -24,31 +25,60 @@ class UnitPrinter {
  public:
   UnitPrinter(Source* source,
               const FormatStyle& style,
-              const FormatExpressionOptions& expression_options)
+              const FormatExpressionOptions& expression_options,
+              FormatCommentState* comments)
       : source_(source)
       , style_(style)
-      , expression_options_(expression_options) {}
+      , expression_options_(expression_options)
+      , comments_(comments) {}
 
   bool run(Unit* unit, std::string* result) {
     std::vector<std::string> sections;
     std::vector<std::string> directives;
+    int cursor = 0;
     for (auto import : unit->imports()) {
       std::string text;
-      if (!format_import(import, &text)) return false;
+      if (!leading(import, 0, cursor, &text)) return false;
+      std::string directive;
+      if (has_comment_on_first_line(import)) {
+        directive = verbatim(import, 0);
+      } else if (!format_import(import, &directive)) {
+        return false;
+      }
+      if (!text.empty()) text += "\n";
+      text += directive;
       directives.push_back(std::move(text));
+      cursor = end(import);
     }
     for (auto export_ : unit->exports()) {
       std::string text;
-      if (!format_export(export_, &text)) return false;
+      if (!leading(export_, 0, cursor, &text)) return false;
+      std::string directive;
+      if (has_comment_on_first_line(export_)) {
+        directive = verbatim(export_, 0);
+      } else if (!format_export(export_, &directive)) {
+        return false;
+      }
+      if (!text.empty()) text += "\n";
+      text += directive;
       directives.push_back(std::move(text));
+      cursor = end(export_);
     }
     if (!directives.empty()) sections.push_back(join(directives, "\n"));
 
     for (auto node : unit->declarations()) {
       std::string text;
+      std::string prefix;
+      if (!leading(node, 0, cursor, &prefix)) return false;
       if (!declaration(node, 0, &text)) return false;
+      if (!prefix.empty()) text = prefix + "\n" + text;
       sections.push_back(std::move(text));
+      cursor = end(node);
     }
+    std::string trailing;
+    if (!comments_->render_own_line(
+        cursor, source_->size(), 0, &trailing)) return false;
+    if (!trailing.empty()) sections.push_back(std::move(trailing));
     *result = join(sections, "\n\n");
     if (!result->empty()) result->push_back('\n');
     return true;
@@ -58,6 +88,67 @@ class UnitPrinter {
   Source* source_;
   const FormatStyle& style_;
   const FormatExpressionOptions& expression_options_;
+  FormatCommentState* comments_;
+
+  const FormatSource* facts() const { return comments_->source(); }
+
+  int start(Node* node) const {
+    return source_->offset_in_source(node->full_range().from());
+  }
+
+  int end(Node* node) const {
+    return source_->offset_in_source(node->full_range().to());
+  }
+
+  int original_indentation(Node* node) const {
+    return facts()->lines()[facts()->line_index_at(start(node))].indentation;
+  }
+
+  bool leading(Node* node,
+               int indentation,
+               int cursor,
+               std::string* result) {
+    return comments_->render_own_line(
+        cursor,
+        start(node),
+        indentation - original_indentation(node),
+        result);
+  }
+
+  bool has_comment_on_first_line(Node* node) const {
+    int node_start = start(node);
+    int line = facts()->line_index_at(node_start);
+    return comments_->has_unconsumed_in(
+        node_start, facts()->lines()[line].to);
+  }
+
+  bool offset_is_in_comment(int offset) const {
+    for (const auto& comment : facts()->comments()) {
+      if (comment.from <= offset && offset < comment.to) return true;
+    }
+    return false;
+  }
+
+  int method_header_end(Method* method) const {
+    if (method->body() == null) return end(method);
+    int body_start = method->body()->expressions().is_empty()
+        ? end(method)
+        : start(method->body()->expressions().first());
+    const uint8* bytes = source_->text();
+    for (int offset = body_start - 1; offset >= start(method); offset--) {
+      if (bytes[offset] == ':' && !offset_is_in_comment(offset)) {
+        int line = facts()->line_index_at(offset);
+        return facts()->lines()[line].to;
+      }
+    }
+    return body_start;
+  }
+
+  std::string verbatim(Node* node, int indentation) {
+    int first = facts()->line_index_at(start(node));
+    int last = facts()->line_index_at(std::max(start(node), end(node) - 1));
+    return comments_->render_verbatim(first, last, indentation);
+  }
 
   static std::string indent(int indentation) {
     return std::string(indentation, ' ');
@@ -124,6 +215,12 @@ class UnitPrinter {
   }
 
   bool field(Field* field, int indentation, std::string* result) {
+    if (comments_->has_unconsumed_in(
+        start(field),
+        facts()->lines()[facts()->line_index_at(end(field))].to)) {
+      *result = verbatim(field, indentation);
+      return true;
+    }
     std::string prefix = indent(indentation);
     if (field->is_abstract()) prefix += "abstract ";
     if (field->is_static()) prefix += "static ";
@@ -158,6 +255,11 @@ class UnitPrinter {
   }
 
   bool method(Method* method, int indentation, std::string* result) {
+    int header_to = method_header_end(method);
+    if (comments_->has_unconsumed_in(start(method), header_to)) {
+      *result = verbatim(method, indentation);
+      return true;
+    }
     FormatOutput header;
     if (!format_method_header(method,
                               source_,
@@ -173,13 +275,18 @@ class UnitPrinter {
                            indentation + style_.indentation_step,
                            &body,
                            style_,
-                           expression_options_)) return false;
+                           expression_options_,
+                           comments_)) return false;
       if (!body.empty()) *result += "\n" + body;
     }
     return true;
   }
 
   bool class_(Class* klass, int indentation, std::string* result) {
+    if (has_comment_on_first_line(klass)) {
+      *result = verbatim(klass, indentation);
+      return true;
+    }
     std::string header = indent(indentation);
     if (klass->has_abstract_modifier()) header += "abstract ";
     switch (klass->kind()) {
@@ -215,11 +322,19 @@ class UnitPrinter {
     header += ":";
 
     std::vector<std::string> members;
+    int cursor = facts()->lines()[facts()->line_index_at(start(klass))].to;
     for (auto member : klass->members()) {
       std::string text;
+      std::string prefix;
+      if (!leading(member,
+                   indentation + style_.indentation_step,
+                   cursor,
+                   &prefix)) return false;
       if (!declaration(
           member, indentation + style_.indentation_step, &text)) return false;
+      if (!prefix.empty()) text = prefix + "\n" + text;
       members.push_back(std::move(text));
+      cursor = end(member);
     }
     *result = header;
     if (!members.empty()) *result += "\n" + join(members, "\n\n");
@@ -243,11 +358,11 @@ bool format_unit(Unit* unit,
                  const FormatStyle& style,
                  const FormatExpressionOptions& expression_options) {
   ASSERT(unit != null && source != null && result != null);
-  // Comment ownership is added as a separate review slice. Refusing the unit
-  // is essential: silently dropping trivia would violate the formatter gate.
-  if (!comments.is_empty()) return false;
-  UnitPrinter printer(source, style, expression_options);
-  return printer.run(unit, result);
+  FormatSource facts(source, comments);
+  FormatCommentState comment_state(&facts);
+  UnitPrinter printer(source, style, expression_options, &comment_state);
+  if (!printer.run(unit, result)) return false;
+  return comment_state.all_consumed();
 }
 
 } // namespace compiler

--- a/tests/ctest/ast-equivalence-test.cc
+++ b/tests/ctest/ast-equivalence-test.cc
@@ -13,6 +13,7 @@
 #include "../../src/compiler/sources.h"
 #include "../../src/compiler/symbol_canonicalizer.h"
 #include "../../src/top.h"
+#include "format-test-support.h"
 
 namespace toit {
 namespace compiler {

--- a/tests/ctest/file-writer-test.cc
+++ b/tests/ctest/file-writer-test.cc
@@ -16,6 +16,7 @@
 
 #include "../../src/file_writer.h"
 #include "../../src/top.h"
+#include "format-test-support.h"
 
 namespace toit {
 

--- a/tests/ctest/format-declaration-test.cc
+++ b/tests/ctest/format-declaration-test.cc
@@ -14,6 +14,7 @@
 #include "../../src/compiler/sources.h"
 #include "../../src/compiler/symbol_canonicalizer.h"
 #include "../../src/top.h"
+#include "format-test-support.h"
 
 namespace toit {
 namespace compiler {

--- a/tests/ctest/format-expression-test.cc
+++ b/tests/ctest/format-expression-test.cc
@@ -14,6 +14,7 @@
 #include "../../src/compiler/sources.h"
 #include "../../src/compiler/symbol_canonicalizer.h"
 #include "../../src/top.h"
+#include "format-test-support.h"
 
 namespace toit {
 namespace compiler {
@@ -29,7 +30,12 @@ static ParsedExpression parse_expression(SourceManager* sources,
   static int next_source_id = 0;
   ParsedExpression result;
   result.symbols.reset(new SymbolCanonicalizer());
-  std::string program = "sample:\n  return " + text + "\n";
+  std::string indented_text;
+  for (char c : text) {
+    indented_text.push_back(c);
+    if (c == '\n') indented_text += "  ";
+  }
+  std::string program = "sample:\n  return " + indented_text + "\n";
   std::string path = "///<format-expression-" +
       std::to_string(next_source_id++) + ">";
   result.source = sources->load_from_memory(
@@ -40,7 +46,10 @@ static ParsedExpression parse_expression(SourceManager* sources,
   Scanner scanner(result.source, result.symbols.get(), &diagnostics);
   Parser parser(result.source, &scanner, &diagnostics);
   ast::Unit* unit = parser.parse_unit();
-  ASSERT(!diagnostics.encountered_error());
+  if (diagnostics.encountered_error()) {
+    fprintf(stderr, "Failed to parse expression fixture:\n%s", program.c_str());
+    exit(1);
+  }
   ASSERT(unit->declarations().length() == 1);
   ast::Method* method = unit->declarations()[0]->as_Method();
   ASSERT(method != null && method->body() != null);
@@ -69,7 +78,13 @@ static std::string format(SourceManager* sources,
   std::string output = output_lines.render(0);
 
   ParsedExpression reparsed = parse_expression(sources, output);
-  ASSERT(ast_nodes_equivalent(parsed.expression, reparsed.expression));
+  if (!ast_nodes_equivalent(parsed.expression, reparsed.expression)) {
+    fprintf(stderr,
+            "Expression changed AST:\ninput:  %s\noutput: %s\n",
+            input.c_str(),
+            output.c_str());
+    exit(1);
+  }
 
   FormatOutput second_output;
   ASSERT(format_expression(
@@ -111,7 +126,7 @@ static void test_format_expression(SourceManager* sources) {
   ASSERT(format(
       sources,
       "consume arg01 arg02 arg03 arg04 arg05 arg06 arg07 arg08 arg09 arg10",
-      40) ==
+      65) ==
       "consume arg01 arg02 arg03 arg04 arg05 arg06 arg07 arg08 arg09 arg10");
   ASSERT(format(
       sources,
@@ -123,7 +138,7 @@ static void test_format_expression(SourceManager* sources) {
   ASSERT(format(
       sources,
       "send first-moderately-long second-moderately-long third-moderately-long",
-      36) ==
+      43) ==
       "send first-moderately-long \\\n"
       "    second-moderately-long third-moderately-long");
   ASSERT(format(sources, "consume (build x y)") == "consume (build x y)");
@@ -140,7 +155,7 @@ static void test_format_expression(SourceManager* sources) {
   ASSERT(format(
       sources,
       "[aaaaaaaaaa, bbbbbbbbbb, cccccccccc, dddddddddd]",
-      24) ==
+      25) ==
       "[\n"
       "  aaaaaaaaaa, bbbbbbbbbb,\n"
       "  cccccccccc, dddddddddd,\n"

--- a/tests/ctest/format-output-test.cc
+++ b/tests/ctest/format-output-test.cc
@@ -6,6 +6,7 @@
 
 #include "../../src/compiler/format_output.h"
 #include "../../src/top.h"
+#include "format-test-support.h"
 
 namespace toit {
 namespace compiler {

--- a/tests/ctest/format-source-test.cc
+++ b/tests/ctest/format-source-test.cc
@@ -14,6 +14,7 @@
 #include "../../src/compiler/sources.h"
 #include "../../src/compiler/symbol_canonicalizer.h"
 #include "../../src/top.h"
+#include "format-test-support.h"
 
 namespace toit {
 namespace compiler {
@@ -73,6 +74,26 @@ static void test_format_source(Source* source,
          facts.shift_multiline_comment(
              standalone_id,
              facts.comments()[standalone_id].start_column + 2));
+
+  FormatCommentState state(&facts);
+  std::string own_line;
+  const FormatComment& own_line_comment = facts.comments()[own_line_id];
+  bool rendered = state.render_own_line(
+      own_line_comment.from, own_line_comment.to, 2, &own_line);
+  ASSERT(rendered);
+  expect("    // This comment is on its own line.", own_line);
+  ASSERT(state.consumed(own_line_id));
+
+  const FormatComment& standalone = facts.comments()[standalone_id];
+  rendered = state.render_own_line(
+      standalone.from, standalone.to, 2, &own_line);
+  ASSERT(rendered);
+  expect("    /* Standalone\n       block. */", own_line);
+  ASSERT(state.consumed(standalone_id));
+
+  expect("    value := 1  // Keep   every byte.",
+         state.render_verbatim(frozen_line, frozen_line, 4));
+  ASSERT(state.consumed(facts.lines()[frozen_line].trailing_line_comment));
 }
 
 } // namespace compiler

--- a/tests/ctest/format-statement-test.cc
+++ b/tests/ctest/format-statement-test.cc
@@ -14,6 +14,7 @@
 #include "../../src/compiler/sources.h"
 #include "../../src/compiler/symbol_canonicalizer.h"
 #include "../../src/top.h"
+#include "format-test-support.h"
 
 namespace toit {
 namespace compiler {

--- a/tests/ctest/format-test-support.h
+++ b/tests/ctest/format-test-support.h
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+
+// The compiler's ASSERT is intentionally compiled out in release builds.
+// Formatter tests must retain their checks in every build configuration.
+#undef ASSERT
+#define ASSERT(condition) do {                                                \
+  if (!(condition)) {                                                         \
+    fprintf(stderr, "%s:%d: formatter test assertion failed: %s\n",          \
+            __FILE__, __LINE__, #condition);                                  \
+    exit(1);                                                                  \
+  }                                                                           \
+} while (false)

--- a/tests/ctest/format-unit-test.cc
+++ b/tests/ctest/format-unit-test.cc
@@ -14,6 +14,7 @@
 #include "../../src/compiler/sources.h"
 #include "../../src/compiler/symbol_canonicalizer.h"
 #include "../../src/top.h"
+#include "format-test-support.h"
 
 namespace toit {
 namespace compiler {

--- a/tests/ctest/format-verifier-test.cc
+++ b/tests/ctest/format-verifier-test.cc
@@ -12,6 +12,7 @@
 #include "../../src/compiler/sources.h"
 #include "../../src/compiler/symbol_canonicalizer.h"
 #include "../../src/top.h"
+#include "format-test-support.h"
 
 namespace toit {
 namespace compiler {


### PR DESCRIPTION
Part 5 of 10 in the AST-driven Toit pretty-printer stack. Depends on #3189.

## Summary

- add explicit comment-consumption state
- preserve every comment exactly once and in source order
- keep trailing line comments frozen with their physical code line
- retain opaque multiline-comment spacing and line breaks while shifting enclosing indentation
- keep formatter test assertions active in release builds

## Verification

- source/comment ownership CTests pass
- public-command comment gold cases cover frozen lines, multiline comments, blank-line caps, and comments in class and control-flow contexts

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>