### PR TITLE
compiler: handle grammar-sensitive suites and calls

### DIFF
--- a/src/compiler/format_declaration.cc
+++ b/src/compiler/format_declaration.cc
@@ -108,7 +108,9 @@ class MethodHeaderPrinter {
     if (parameter->default_value() != null) {
       std::string value;
       if (!expression(parameter->default_value(), &value)) return false;
-      text += "=" + value;
+      text += "=" + (parameter->default_value()->is_Parenthesis()
+          ? "(" + value + ")"
+          : value);
     }
     if (parameter->is_block()) text += "]";
     *result = text;

--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -66,6 +66,11 @@ bool is_static_receiver_candidate(Expression* expression) {
   return ++identifiers <= 3;
 }
 
+bool needs_call_argument_parentheses(Expression* expression) {
+  return expression->is_Call() || expression->is_Binary() ||
+      expression->is_If() || expression->is_DeclarationLocal();
+}
+
 class ExpressionPrinter {
  public:
   ExpressionPrinter(Source* source,
@@ -196,7 +201,12 @@ class ExpressionPrinter {
       result += "/" + flat(parameter->type(), PRECEDENCE_NONE);
     }
     if (parameter->default_value() != null) {
-      result += "=" + flat(parameter->default_value(), PRECEDENCE_NONE);
+      Expression* value = parameter->default_value();
+      bool preserve_parentheses = value->is_Parenthesis();
+      std::string value_text = flat(value, PRECEDENCE_NONE);
+      result += "=" + (preserve_parentheses
+          ? "(" + value_text + ")"
+          : value_text);
     }
     return result;
   }
@@ -277,7 +287,7 @@ class ExpressionPrinter {
         result += " (" + flat_suite(inner) + ")";
       } else if (argument->is_Block() || argument->is_Lambda()) {
         result += flat_suite(argument);
-      } else if (inner->is_Call()) {
+      } else if (needs_call_argument_parentheses(inner)) {
         result += " (" + flat(inner, PRECEDENCE_NONE) + ")";
       } else {
         result += " " + flat(argument, PRECEDENCE_NONE);
@@ -525,7 +535,7 @@ class ExpressionPrinter {
         (inner->is_Block() || inner->is_Lambda())) {
       return "(" + flat_suite(inner) + ")";
     }
-    if (inner->is_Call()) {
+    if (needs_call_argument_parentheses(inner)) {
       return "(" + flat(inner, PRECEDENCE_NONE) + ")";
     }
     return flat(argument, PRECEDENCE_NONE);
@@ -550,6 +560,17 @@ class ExpressionPrinter {
           : suite->as_Lambda()->body();
       if (body->expressions().length() != 1 ||
           i + 1 != call->arguments().length()) return true;
+      std::string body_text;
+      if (!format_sequence(body,
+                           source_,
+                           0,
+                           &body_text,
+                           style_,
+                           options_)) {
+        supported_ = false;
+        return true;
+      }
+      if (body_text.find('\n') != std::string::npos) return true;
     }
     return false;
   }

--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "format_statement.h"
 #include "token.h"
 
 namespace toit {
@@ -186,16 +187,85 @@ class ExpressionPrinter {
     return result;
   }
 
+  std::string flat_parameter(Parameter* parameter) {
+    std::string result;
+    if (parameter->is_named()) result += "--";
+    if (parameter->is_field_storing()) result += ".";
+    result += source_text(parameter->name());
+    if (parameter->type() != null) {
+      result += "/" + flat(parameter->type(), PRECEDENCE_NONE);
+    }
+    if (parameter->default_value() != null) {
+      result += "=" + flat(parameter->default_value(), PRECEDENCE_NONE);
+    }
+    return result;
+  }
+
+  Expression* suite_value(Expression* argument) {
+    if (argument->is_Block() || argument->is_Lambda()) return argument;
+    if (!argument->is_NamedArgument()) return null;
+    Expression* value = argument->as_NamedArgument()->expression();
+    return value != null && (value->is_Block() || value->is_Lambda())
+        ? value
+        : null;
+  }
+
+  std::string suite_introduction(Expression* suite) {
+    bool is_block = suite->is_Block();
+    List<Parameter*> parameters = is_block
+        ? suite->as_Block()->parameters()
+        : suite->as_Lambda()->parameters();
+    std::string result = is_block ? ":" : "::";
+    if (!parameters.is_empty()) {
+      result += " |";
+      for (auto parameter : parameters) {
+        result += " " + flat_parameter(parameter);
+      }
+      result += " |";
+    }
+    return result;
+  }
+
+  std::string flat_suite(Expression* expression) {
+    bool is_block = expression->is_Block();
+    Sequence* body = is_block
+        ? expression->as_Block()->body()
+        : expression->as_Lambda()->body();
+    if (body->expressions().length() != 1) {
+      supported_ = false;
+      return std::string();
+    }
+    std::string body_text;
+    if (!format_sequence(body,
+                         source_,
+                         0,
+                         &body_text,
+                         style_,
+                         options_)) {
+      supported_ = false;
+      return std::string();
+    }
+    if (body_text.find('\n') != std::string::npos) {
+      supported_ = false;
+      return std::string();
+    }
+    std::string result = suite_introduction(expression);
+    if (!body_text.empty()) result += " " + body_text;
+    return result;
+  }
+
   std::string flat_call(Call* call, int outer_precedence) {
     std::string result = flat(call->target(), PRECEDENCE_POSTFIX);
     for (auto argument : call->arguments()) {
-      result += " ";
       if (argument->is_NamedArgument()) {
-        result += flat_named_argument(argument->as_NamedArgument());
+        result += " " + flat_named_argument(argument->as_NamedArgument());
+      } else if (argument->is_Block() || argument->is_Lambda()) {
+        result += flat_suite(argument);
       } else if (peel_parentheses(argument)->is_Call()) {
-        result += "(" + flat(peel_parentheses(argument), PRECEDENCE_NONE) + ")";
+        result += " (" + flat(
+            peel_parentheses(argument), PRECEDENCE_NONE) + ")";
       } else {
-        result += flat(argument, PRECEDENCE_NONE);
+        result += " " + flat(argument, PRECEDENCE_NONE);
       }
     }
     return outer_precedence == PRECEDENCE_NONE
@@ -285,6 +355,9 @@ class ExpressionPrinter {
     }
     if (expression->is_NamedArgument()) {
       return flat_named_argument(expression->as_NamedArgument());
+    }
+    if (expression->is_Block() || expression->is_Lambda()) {
+      return flat_suite(expression);
     }
     if (expression->is_LiteralList()) {
       return flat_elements(
@@ -439,6 +512,70 @@ class ExpressionPrinter {
       result.add_line(style_.continuation_step, call_argument(argument));
     }
     return result;
+  }
+
+  bool call_has_multiline_suite(Call* call) {
+    for (auto argument : call->arguments()) {
+      Expression* suite = suite_value(argument);
+      if (suite == null) continue;
+      Sequence* body = suite->is_Block()
+          ? suite->as_Block()->body()
+          : suite->as_Lambda()->body();
+      if (body->expressions().length() != 1) return true;
+    }
+    return false;
+  }
+
+  bool suite_call(Call* call, FormatOutput* result) {
+    std::string first = flat(call->target(), PRECEDENCE_POSTFIX);
+    Expression* suite = null;
+    for (int i = 0; i < call->arguments().length(); i++) {
+      Expression* argument = call->arguments()[i];
+      Expression* candidate = suite_value(argument);
+      if (candidate == null) {
+        first += " " + call_argument(argument);
+        continue;
+      }
+      // A suite owns the remainder of its indentation level. The parser does
+      // not normally produce later arguments, but refusing this shape keeps
+      // the formatter conservative if the grammar grows.
+      if (suite != null || i + 1 != call->arguments().length()) return false;
+      suite = candidate;
+      if (argument->is_NamedArgument()) {
+        NamedArgument* named = argument->as_NamedArgument();
+        first += " --";
+        if (named->inverted()) first += "no-";
+        first += source_text(named->name()) + "=";
+      }
+      first += suite_introduction(suite);
+    }
+    if (suite == null) return false;
+
+    Sequence* body = suite->is_Block()
+        ? suite->as_Block()->body()
+        : suite->as_Lambda()->body();
+    std::string body_text;
+    if (!format_sequence(body,
+                         source_,
+                         0,
+                         &body_text,
+                         style_,
+                         options_)) return false;
+
+    *result = FormatOutput::single_line(first);
+    size_t line_start = 0;
+    while (line_start < body_text.size()) {
+      size_t line_end = body_text.find('\n', line_start);
+      if (line_end == std::string::npos) line_end = body_text.size();
+      size_t non_space = line_start;
+      while (non_space < line_end && body_text[non_space] == ' ') non_space++;
+      result->add_line(
+          style_.indentation_step +
+              static_cast<int>(non_space - line_start),
+          body_text.substr(non_space, line_end - non_space));
+      line_start = line_end + 1;
+    }
+    return true;
   }
 
   FormatOutput named_suffix_call(Call* call, int first_named) {
@@ -631,6 +768,17 @@ class ExpressionPrinter {
               int outer_precedence,
               FormatOutput* result) {
     Expression* inner = peel_parentheses(expression);
+    if (inner->is_Call() && outer_precedence == PRECEDENCE_NONE &&
+        call_has_multiline_suite(inner->as_Call())) {
+      FormatOutput suite_output;
+      if (suite_call(inner->as_Call(), &suite_output)) {
+        *result = std::move(suite_output);
+      } else {
+        supported_ = false;
+      }
+      return supported_;
+    }
+
     int flat_width = estimated_flat_width(expression);
     if (flat_width < 0) return render_flat(expression, outer_precedence, result);
 

--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -68,7 +68,9 @@ bool is_static_receiver_candidate(Expression* expression) {
 
 bool needs_call_argument_parentheses(Expression* expression) {
   return expression->is_Call() || expression->is_Binary() ||
-      expression->is_If() || expression->is_DeclarationLocal();
+      expression->is_If() || expression->is_DeclarationLocal() ||
+      (expression->is_Unary() &&
+       expression->as_Unary()->kind() == Token::NOT);
 }
 
 class ExpressionPrinter {
@@ -187,7 +189,14 @@ class ExpressionPrinter {
     if (argument->inverted()) result += "no-";
     result += source_text(argument->name());
     if (argument->expression() != null) {
-      result += "=" + flat(argument->expression(), PRECEDENCE_NONE);
+      Expression* value = argument->expression();
+      Expression* inner = peel_parentheses(value);
+      std::string value_text = flat(inner, PRECEDENCE_NONE);
+      if (value->is_Parenthesis() ||
+          needs_call_argument_parentheses(inner)) {
+        value_text = "(" + value_text + ")";
+      }
+      result += "=" + value_text;
     }
     return result;
   }

--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -269,13 +269,16 @@ class ExpressionPrinter {
   std::string flat_call(Call* call, int outer_precedence) {
     std::string result = flat(call->target(), PRECEDENCE_POSTFIX);
     for (auto argument : call->arguments()) {
+      Expression* inner = peel_parentheses(argument);
       if (argument->is_NamedArgument()) {
         result += " " + flat_named_argument(argument->as_NamedArgument());
+      } else if (argument->is_Parenthesis() &&
+                 (inner->is_Block() || inner->is_Lambda())) {
+        result += " (" + flat_suite(inner) + ")";
       } else if (argument->is_Block() || argument->is_Lambda()) {
         result += flat_suite(argument);
-      } else if (peel_parentheses(argument)->is_Call()) {
-        result += " (" + flat(
-            peel_parentheses(argument), PRECEDENCE_NONE) + ")";
+      } else if (inner->is_Call()) {
+        result += " (" + flat(inner, PRECEDENCE_NONE) + ")";
       } else {
         result += " " + flat(argument, PRECEDENCE_NONE);
       }
@@ -517,6 +520,14 @@ class ExpressionPrinter {
     if (argument->is_NamedArgument()) {
       return flat_named_argument(argument->as_NamedArgument());
     }
+    Expression* inner = peel_parentheses(argument);
+    if (argument->is_Parenthesis() &&
+        (inner->is_Block() || inner->is_Lambda())) {
+      return "(" + flat_suite(inner) + ")";
+    }
+    if (inner->is_Call()) {
+      return "(" + flat(inner, PRECEDENCE_NONE) + ")";
+    }
     return flat(argument, PRECEDENCE_NONE);
   }
 
@@ -529,16 +540,91 @@ class ExpressionPrinter {
     return result;
   }
 
-  bool call_has_multiline_suite(Call* call) {
-    for (auto argument : call->arguments()) {
+  bool call_requires_suite_shape(Call* call) {
+    for (int i = 0; i < call->arguments().length(); i++) {
+      Expression* argument = call->arguments()[i];
       Expression* suite = suite_value(argument);
       if (suite == null) continue;
       Sequence* body = suite->is_Block()
           ? suite->as_Block()->body()
           : suite->as_Lambda()->body();
-      if (body->expressions().length() != 1) return true;
+      if (body->expressions().length() != 1 ||
+          i + 1 != call->arguments().length()) return true;
     }
     return false;
+  }
+
+  std::string named_suite_prefix(NamedArgument* named) {
+    std::string result = "--";
+    if (named->inverted()) result += "no-";
+    return result + source_text(named->name()) + "=";
+  }
+
+  void append_suite_body(FormatOutput* result,
+                         int header_indentation,
+                         int body_indentation,
+                         const std::string& header,
+                         const std::string& body_text) {
+    size_t first_newline = body_text.find('\n');
+    if (first_newline == std::string::npos) {
+      result->add_line(header_indentation,
+                       header + (body_text.empty() ? "" : " " + body_text));
+      return;
+    }
+    result->add_line(header_indentation, header);
+    size_t line_start = 0;
+    while (line_start < body_text.size()) {
+      size_t line_end = body_text.find('\n', line_start);
+      if (line_end == std::string::npos) line_end = body_text.size();
+      size_t non_space = line_start;
+      while (non_space < line_end && body_text[non_space] == ' ') non_space++;
+      result->add_line(
+          body_indentation + static_cast<int>(non_space - line_start),
+          body_text.substr(non_space, line_end - non_space));
+      line_start = line_end + 1;
+    }
+  }
+
+  bool segmented_suite_call(Call* call, FormatOutput* result) {
+    std::string first = flat(call->target(), PRECEDENCE_POSTFIX);
+    int first_suite = -1;
+    for (int i = 0; i < call->arguments().length(); i++) {
+      if (suite_value(call->arguments()[i]) != null) {
+        first_suite = i;
+        break;
+      }
+      first += " " + call_argument(call->arguments()[i]);
+    }
+    if (first_suite < 0) return false;
+    *result = FormatOutput::single_line(first);
+
+    for (int i = first_suite; i < call->arguments().length(); i++) {
+      Expression* argument = call->arguments()[i];
+      Expression* suite = suite_value(argument);
+      if (suite == null) {
+        result->add_line(style_.continuation_step, call_argument(argument));
+        continue;
+      }
+      if (!argument->is_NamedArgument()) return false;
+      Sequence* body = suite->is_Block()
+          ? suite->as_Block()->body()
+          : suite->as_Lambda()->body();
+      std::string body_text;
+      if (!format_sequence(body,
+                           source_,
+                           0,
+                           &body_text,
+                           style_,
+                           options_)) return false;
+      append_suite_body(
+          result,
+          style_.continuation_step,
+          style_.continuation_step + style_.indentation_step,
+          named_suite_prefix(argument->as_NamedArgument()) +
+              suite_introduction(suite),
+          body_text);
+    }
+    return true;
   }
 
   bool suite_call(Call* call, FormatOutput* result) {
@@ -557,10 +643,7 @@ class ExpressionPrinter {
       if (suite != null || i + 1 != call->arguments().length()) return false;
       suite = candidate;
       if (argument->is_NamedArgument()) {
-        NamedArgument* named = argument->as_NamedArgument();
-        first += " --";
-        if (named->inverted()) first += "no-";
-        first += source_text(named->name()) + "=";
+        first += " " + named_suite_prefix(argument->as_NamedArgument());
       }
       first += suite_introduction(suite);
     }
@@ -642,7 +725,7 @@ class ExpressionPrinter {
     std::vector<int> arguments;
     for (auto argument : call->arguments()) {
       int width = estimated_call_argument_width(argument);
-      if (width < 0) return -1;
+      if (width < 0 || suite_value(argument) != null) return -1;
       arguments.push_back(width);
     }
 
@@ -784,14 +867,25 @@ class ExpressionPrinter {
               FormatOutput* result) {
     Expression* inner = peel_parentheses(expression);
     if (inner->is_Call() && outer_precedence == PRECEDENCE_NONE &&
-        call_has_multiline_suite(inner->as_Call())) {
+        call_requires_suite_shape(inner->as_Call())) {
       FormatOutput suite_output;
-      if (suite_call(inner->as_Call(), &suite_output)) {
+      Call* call = inner->as_Call();
+      bool has_nonfinal_suite = false;
+      for (int i = 0; i + 1 < call->arguments().length(); i++) {
+        if (suite_value(call->arguments()[i]) != null) {
+          has_nonfinal_suite = true;
+          break;
+        }
+      }
+      bool formatted = has_nonfinal_suite
+          ? segmented_suite_call(call, &suite_output)
+          : suite_call(call, &suite_output);
+      if (formatted) {
         *result = std::move(suite_output);
       } else {
         supported_ = false;
       }
-      return supported_;
+      return formatted;
     }
 
     int flat_width = estimated_flat_width(expression);

--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -266,13 +266,20 @@ class ExpressionPrinter {
       supported_ = false;
       return std::string();
     }
+    Expression* only = body->expressions().first();
     std::string body_text;
-    if (!format_sequence(body,
-                         source_,
-                         0,
-                         &body_text,
-                         style_,
-                         options_)) {
+    if (!only->is_Return() && !only->is_BreakContinue() &&
+        !only->is_While() && !only->is_For() &&
+        !only->is_TryFinally() &&
+        !(only->is_If() && only->as_If()->yes() != null &&
+          only->as_If()->yes()->is_Sequence())) {
+      body_text = flat(only, PRECEDENCE_NONE);
+    } else if (!format_sequence(body,
+                                source_,
+                                0,
+                                &body_text,
+                                style_,
+                                options_)) {
       supported_ = false;
       return std::string();
     }
@@ -635,7 +642,6 @@ class ExpressionPrinter {
         result->add_line(style_.continuation_step, call_argument(argument));
         continue;
       }
-      if (!argument->is_NamedArgument()) return false;
       Sequence* body = suite->is_Block()
           ? suite->as_Block()->body()
           : suite->as_Lambda()->body();
@@ -650,8 +656,9 @@ class ExpressionPrinter {
           result,
           style_.continuation_step,
           style_.continuation_step + style_.indentation_step,
-          named_suite_prefix(argument->as_NamedArgument()) +
-              suite_introduction(suite),
+          (argument->is_NamedArgument()
+              ? named_suite_prefix(argument->as_NamedArgument())
+              : std::string()) + suite_introduction(suite),
           body_text);
     }
     return true;
@@ -896,6 +903,42 @@ class ExpressionPrinter {
               int outer_precedence,
               FormatOutput* result) {
     Expression* inner = peel_parentheses(expression);
+    if ((inner->is_Block() || inner->is_Lambda()) &&
+        outer_precedence == PRECEDENCE_NONE) {
+      Sequence* body = inner->is_Block()
+          ? inner->as_Block()->body()
+          : inner->as_Lambda()->body();
+      std::string body_text;
+      if (!format_sequence(body,
+                           source_,
+                           0,
+                           &body_text,
+                           style_,
+                           options_)) {
+        supported_ = false;
+        return false;
+      }
+      if (body_text.find('\n') != std::string::npos) {
+        FormatOutput suite_output = FormatOutput::single_line(
+            suite_introduction(inner));
+        size_t line_start = 0;
+        while (line_start < body_text.size()) {
+          size_t line_end = body_text.find('\n', line_start);
+          if (line_end == std::string::npos) line_end = body_text.size();
+          size_t non_space = line_start;
+          while (non_space < line_end && body_text[non_space] == ' ') {
+            non_space++;
+          }
+          suite_output.add_line(
+              style_.indentation_step +
+                  static_cast<int>(non_space - line_start),
+              body_text.substr(non_space, line_end - non_space));
+          line_start = line_end + 1;
+        }
+        *result = std::move(suite_output);
+        return true;
+      }
+    }
     if (inner->is_Call() && outer_precedence == PRECEDENCE_NONE &&
         call_requires_suite_shape(inner->as_Call())) {
       FormatOutput suite_output;

--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -201,6 +201,18 @@ class ExpressionPrinter {
     return result;
   }
 
+  std::string flat_local(DeclarationLocal* declaration) {
+    std::string result = flat(declaration->name(), PRECEDENCE_NONE);
+    if (declaration->type() != null) {
+      result += "/" + flat(declaration->type(), PRECEDENCE_NONE);
+    }
+    result += " " + std::string(Token::symbol(declaration->kind()).c_str());
+    if (declaration->value() != null) {
+      result += " " + flat(declaration->value(), PRECEDENCE_NONE);
+    }
+    return result;
+  }
+
   Expression* suite_value(Expression* argument) {
     if (argument->is_Block() || argument->is_Lambda()) return argument;
     if (!argument->is_NamedArgument()) return null;
@@ -355,6 +367,9 @@ class ExpressionPrinter {
     }
     if (expression->is_NamedArgument()) {
       return flat_named_argument(expression->as_NamedArgument());
+    }
+    if (expression->is_DeclarationLocal()) {
+      return flat_local(expression->as_DeclarationLocal());
     }
     if (expression->is_Block() || expression->is_Lambda()) {
       return flat_suite(expression);

--- a/src/compiler/format_source.cc
+++ b/src/compiler/format_source.cc
@@ -288,5 +288,26 @@ std::string FormatCommentState::render_verbatim(
   return result;
 }
 
+std::string FormatCommentState::render_verbatim_preserving_continuations(
+    int first_line, int last_line, int new_first_indentation) {
+  const auto& lines = source_->lines();
+  ASSERT(first_line >= 0 && first_line <= last_line &&
+         last_line < static_cast<int>(lines.size()));
+  int from = lines[first_line].from;
+  int to = lines[last_line].to;
+  for (int id : unconsumed_in(from, to)) consume(id);
+
+  std::string result = source_->reindent_line(
+      first_line, new_first_indentation);
+  if (first_line < last_line) {
+    result += source_->text(lines[first_line + 1].from, to);
+  }
+  while (!result.empty() &&
+         (result.back() == '\n' || result.back() == '\r')) {
+    result.pop_back();
+  }
+  return result;
+}
+
 } // namespace compiler
 } // namespace toit

--- a/src/compiler/format_source.cc
+++ b/src/compiler/format_source.cc
@@ -234,26 +234,39 @@ bool FormatCommentState::all_consumed() const {
 bool FormatCommentState::render_own_line(int from,
                                          int to,
                                          int indentation_delta,
-                                         std::string* result) {
+                                         std::string* result,
+                                         int max_blank_lines) {
   ASSERT(result != null);
-  std::vector<std::string> rendered;
-  for (int id : unconsumed_in(from, to)) {
+  ASSERT(max_blank_lines >= 0);
+  std::vector<int> comments = unconsumed_in(from, to);
+  result->clear();
+  int previous_end_line = -1;
+  for (int id : comments) {
     const FormatComment& comment = source_->comments()[id];
     if (comment.follows_code) return false;
-    int column = std::max(0, comment.start_column + indentation_delta);
-    std::string text = std::string(column, ' ');
-    if (comment.spans_lines) {
-      text += source_->shift_multiline_comment(id, column);
-    } else {
-      text += comment.text;
+    if (previous_end_line >= 0) {
+      int blank_lines = std::min(
+          max_blank_lines,
+          std::max(0, comment.start_line - previous_end_line - 1));
+      result->append(1 + blank_lines, '\n');
     }
-    rendered.push_back(std::move(text));
+    int column = std::max(0, comment.start_column + indentation_delta);
+    *result += std::string(column, ' ');
+    if (comment.spans_lines) {
+      *result += source_->shift_multiline_comment(id, column);
+    } else {
+      *result += comment.text;
+    }
     consume(id);
+    previous_end_line = comment.end_line;
   }
-  result->clear();
-  for (const auto& text : rendered) {
-    if (!result->empty()) *result += "\n";
-    *result += text;
+
+  if (previous_end_line >= 0 && to < source_->source()->size()) {
+    int target_line = source_->line_index_at(to);
+    int blank_lines = std::min(
+        max_blank_lines,
+        std::max(0, target_line - previous_end_line - 1));
+    result->append(blank_lines, '\n');
   }
   return true;
 }

--- a/src/compiler/format_source.h
+++ b/src/compiler/format_source.h
@@ -106,7 +106,8 @@ class FormatCommentState {
   bool render_own_line(int from,
                        int to,
                        int indentation_delta,
-                       std::string* result);
+                       std::string* result,
+                       int max_blank_lines = 2);
 
   // Reproduces and consumes a closed physical-line region.
   std::string render_verbatim(int first_line,

--- a/src/compiler/format_source.h
+++ b/src/compiler/format_source.h
@@ -114,6 +114,14 @@ class FormatCommentState {
                               int last_line,
                               int new_first_indentation);
 
+  // Reproduces and consumes a closed physical-line region while changing
+  // only its first line's indentation. This is used for multiline strings,
+  // whose continuation whitespace is part of the literal value.
+  std::string render_verbatim_preserving_continuations(
+      int first_line,
+      int last_line,
+      int new_first_indentation);
+
  private:
   const FormatSource* source_;
   std::vector<bool> consumed_;

--- a/src/compiler/format_statement.cc
+++ b/src/compiler/format_statement.cc
@@ -47,7 +47,8 @@ class StatementPrinter {
             cursor,
             expression_start,
             indentation - original_indentation,
-            &leading)) return false;
+            &leading,
+            style_.max_blank_lines)) return false;
         if (!leading.empty()) statements.push_back(std::move(leading));
       }
       std::string text;

--- a/src/compiler/format_statement.cc
+++ b/src/compiler/format_statement.cc
@@ -19,6 +19,13 @@ using namespace ast;
 
 namespace {
 
+Expression* peel_parentheses(Expression* expression) {
+  while (expression != null && expression->is_Parenthesis()) {
+    expression = expression->as_Parenthesis()->expression();
+  }
+  return expression;
+}
+
 class StatementPrinter {
  public:
   StatementPrinter(Source* source,
@@ -143,6 +150,15 @@ class StatementPrinter {
         expression, source_, result, expression_options_);
   }
 
+  bool condition(Expression* expression, std::string* result) {
+    if (!flat(expression, result)) return false;
+    if (expression->is_Parenthesis() &&
+        peel_parentheses(expression)->is_Call()) {
+      *result = "(" + *result + ")";
+    }
+    return true;
+  }
+
   bool formatted(Expression* expression,
                  int indentation,
                  FormatOutput* result) {
@@ -201,7 +217,7 @@ class StatementPrinter {
                   const std::string& keyword,
                   std::string* result) {
     std::string condition;
-    if (!flat(conditional->expression(), &condition)) return false;
+    if (!this->condition(conditional->expression(), &condition)) return false;
     std::string body;
     if (!suite(conditional->yes(),
                indentation + style_.indentation_step,
@@ -264,6 +280,19 @@ class StatementPrinter {
       *result = render_prefixed(prefix + " ", value, indentation);
       return true;
     }
+    if (expression->is_Binary() &&
+        Token::precedence(expression->as_Binary()->kind()) ==
+            PRECEDENCE_ASSIGNMENT) {
+      Binary* assignment = expression->as_Binary();
+      std::string left;
+      if (!flat(assignment->left(), &left)) return false;
+      FormatOutput value;
+      if (!formatted(assignment->right(), indentation, &value)) return false;
+      std::string operation = Token::symbol(assignment->kind()).c_str();
+      *result = render_prefixed(
+          left + " " + operation + " ", value, indentation);
+      return true;
+    }
     if (expression->is_BreakContinue()) {
       BreakContinue* jump = expression->as_BreakContinue();
       std::string text = jump->is_break() ? "break" : "continue";
@@ -289,7 +318,7 @@ class StatementPrinter {
     if (expression->is_While()) {
       While* loop = expression->as_While();
       std::string condition;
-      if (!flat(loop->condition(), &condition)) return false;
+      if (!this->condition(loop->condition(), &condition)) return false;
       std::string body;
       if (!suite(loop->body(),
                  indentation + style_.indentation_step,

--- a/src/compiler/format_statement.cc
+++ b/src/compiler/format_statement.cc
@@ -56,8 +56,13 @@ class StatementPrinter {
         int first_line = facts()->line_index_at(expression_start);
         int last_line = facts()->line_index_at(
             std::max(expression_start, end(expression) - 1));
-        text = comments_->render_verbatim(
-            first_line, last_line, indentation);
+        if (contains_multiline_string(expression)) {
+          text = comments_->render_verbatim_preserving_continuations(
+              first_line, last_line, indentation);
+        } else {
+          text = comments_->render_verbatim(
+              first_line, last_line, indentation);
+        }
       } else if (!statement(expression, indentation, &text)) {
         return false;
       }
@@ -97,14 +102,27 @@ class StatementPrinter {
         expression->is_TryFinally();
   }
 
+  bool contains_multiline_string(Expression* expression) const {
+    int from = start(expression);
+    int to = end(expression);
+    const uint8* bytes = source_->text();
+    for (int offset = from; offset + 2 < to; offset++) {
+      if (bytes[offset] == '"' && bytes[offset + 1] == '"' &&
+          bytes[offset + 2] == '"') return true;
+    }
+    return false;
+  }
+
   bool should_render_verbatim(Expression* expression) const {
     int from = start(expression);
+    int to = end(expression);
+    if (contains_multiline_string(expression)) return true;
     int first_line = facts()->line_index_at(from);
     int header_to = facts()->lines()[first_line].to;
     if (comments_->has_unconsumed_in(from, header_to)) return true;
     if (is_control(expression)) return false;
     int last_line = facts()->line_index_at(
-        std::max(from, end(expression) - 1));
+        std::max(from, to - 1));
     return comments_->has_unconsumed_in(
         facts()->lines()[first_line].from,
         facts()->lines()[last_line].to);

--- a/src/compiler/format_unit.cc
+++ b/src/compiler/format_unit.cc
@@ -77,7 +77,11 @@ class UnitPrinter {
     }
     std::string trailing;
     if (!comments_->render_own_line(
-        cursor, source_->size(), 0, &trailing)) return false;
+        cursor,
+        source_->size(),
+        0,
+        &trailing,
+        style_.max_blank_lines)) return false;
     if (!trailing.empty()) sections.push_back(std::move(trailing));
     *result = join(sections, "\n\n");
     if (!result->empty()) result->push_back('\n');
@@ -112,7 +116,8 @@ class UnitPrinter {
         cursor,
         start(node),
         indentation - original_indentation(node),
-        result);
+        result,
+        style_.max_blank_lines);
   }
 
   bool has_comment_on_first_line(Node* node) const {

--- a/tests/formatter/gold/comments.gold
+++ b/tests/formatter/gold/comments.gold
@@ -5,6 +5,13 @@ main:
   /* Opaque
      alignment. */
   return value
+  // First group.
+
+
+  // Second group.
+
+
+  grouped := 2
 
 class C:
   configure

--- a/tests/formatter/gold/comments.toit
+++ b/tests/formatter/gold/comments.toit
@@ -5,6 +5,14 @@ main:
     /* Opaque
        alignment. */
     return value
+    // First group.
+
+
+
+    // Second group.
+
+
+    grouped := 2
 
 class C:
     configure

--- a/tests/formatter/gold/declarations.gold
+++ b/tests/formatter/gold/declarations.gold
@@ -20,5 +20,8 @@ abstract class Device extends Base with Mix implements Interface:
   :
     return true
 
+  scaled --stride/int=(value * factor):
+    return stride
+
 main:
   return 0

--- a/tests/formatter/gold/declarations.toit
+++ b/tests/formatter/gold/declarations.toit
@@ -13,5 +13,6 @@ abstract class Device extends Base with Mix implements Interface:
       else: return false
     configure-network-interface --organization-identifier/string --application-identifier/string --word-size/int contents/ByteArray --more-flags/int -> bool:
       return true
+    scaled --stride/int=(value * factor): return stride
 
 main: return 0

--- a/tests/formatter/gold/expressions.gold
+++ b/tests/formatter/gold/expressions.gold
@@ -15,6 +15,15 @@ main:
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
     cccccccccccccccccccccccccccccccccccccccc, dddddddddddddddddddddddddddddddddddddddd,
   ]
+  block-result := values.map: | value/int | value * 2
+  lambda-result := task:: run-background
+  named-block := parse value --if-error=: throw it
+  multi-block := values.do:
+    print it
+    total += it
+  multi-lambda := task::
+    prepare
+    execute
 
 a := 1
 

--- a/tests/formatter/gold/expressions.gold
+++ b/tests/formatter/gold/expressions.gold
@@ -32,6 +32,17 @@ main:
   named-binary := configure --enabled=(foo or bar)
   named-not := configure --hidden=(not foo)
   named-parenthesized-block := parse --if-error=(: null) value
+  lambda-value := ::
+    prepare
+    execute
+  assigned = values.map:
+    prepare
+    execute
+  dispatch value
+      : first
+      : second
+  if (catch: decode value):
+    recover
   lookup := table.get key
       --initial=: result
       --compare=: | found | found == result

--- a/tests/formatter/gold/expressions.gold
+++ b/tests/formatter/gold/expressions.gold
@@ -28,9 +28,15 @@ main:
     print item
   nested-calls := Schedule (parse-field fields[0] 0 59) (parse-field fields[1] 0 59)
   block-before-last := put-list values.size (: values[it]) converter
+  conditional-argument := consume (byte == 0 ? 0 : 1)
   lookup := table.get key
       --initial=: result
       --compare=: | found | found == result
+  primitive: | error | retry error: | value | consume value
+  description := """
+        Keep this
+          relative indentation.
+        """
 
 a := 1
 

--- a/tests/formatter/gold/expressions.gold
+++ b/tests/formatter/gold/expressions.gold
@@ -29,6 +29,9 @@ main:
   nested-calls := Schedule (parse-field fields[0] 0 59) (parse-field fields[1] 0 59)
   block-before-last := put-list values.size (: values[it]) converter
   conditional-argument := consume (byte == 0 ? 0 : 1)
+  named-binary := configure --enabled=(foo or bar)
+  named-not := configure --hidden=(not foo)
+  named-parenthesized-block := parse --if-error=(: null) value
   lookup := table.get key
       --initial=: result
       --compare=: | found | found == result

--- a/tests/formatter/gold/expressions.gold
+++ b/tests/formatter/gold/expressions.gold
@@ -26,6 +26,11 @@ main:
     execute
   while item/List? := next:
     print item
+  nested-calls := Schedule (parse-field fields[0] 0 59) (parse-field fields[1] 0 59)
+  block-before-last := put-list values.size (: values[it]) converter
+  lookup := table.get key
+      --initial=: result
+      --compare=: | found | found == result
 
 a := 1
 

--- a/tests/formatter/gold/expressions.gold
+++ b/tests/formatter/gold/expressions.gold
@@ -24,6 +24,8 @@ main:
   multi-lambda := task::
     prepare
     execute
+  while item/List? := next:
+    print item
 
 a := 1
 

--- a/tests/formatter/gold/expressions.toit
+++ b/tests/formatter/gold/expressions.toit
@@ -28,6 +28,17 @@ main:
     named-binary := configure --enabled=(foo or bar)
     named-not := configure --hidden=(not foo)
     named-parenthesized-block := parse --if-error=(: null) value
+    lambda-value := ::
+      prepare
+      execute
+    assigned = values.map:
+      prepare
+      execute
+    dispatch value
+      : first
+      : second
+    if (catch: decode value):
+      recover
     lookup := table.get key
         --initial=: result
         --compare=: | found | found == result

--- a/tests/formatter/gold/expressions.toit
+++ b/tests/formatter/gold/expressions.toit
@@ -25,6 +25,9 @@ main:
       parse-field fields[1] 0 59
     block-before-last := put-list values.size (: values[it]) converter
     conditional-argument := consume (byte == 0 ? 0 : 1)
+    named-binary := configure --enabled=(foo or bar)
+    named-not := configure --hidden=(not foo)
+    named-parenthesized-block := parse --if-error=(: null) value
     lookup := table.get key
         --initial=: result
         --compare=: | found | found == result

--- a/tests/formatter/gold/expressions.toit
+++ b/tests/formatter/gold/expressions.toit
@@ -20,6 +20,13 @@ main:
       execute
     while item/List? := next:
       print item
+    nested-calls := Schedule
+      parse-field fields[0] 0 59
+      parse-field fields[1] 0 59
+    block-before-last := put-list values.size (: values[it]) converter
+    lookup := table.get key
+        --initial=: result
+        --compare=: | found | found == result
 
 a := 1
 b := 2

--- a/tests/formatter/gold/expressions.toit
+++ b/tests/formatter/gold/expressions.toit
@@ -24,9 +24,17 @@ main:
       parse-field fields[0] 0 59
       parse-field fields[1] 0 59
     block-before-last := put-list values.size (: values[it]) converter
+    conditional-argument := consume (byte == 0 ? 0 : 1)
     lookup := table.get key
         --initial=: result
         --compare=: | found | found == result
+    primitive: | error |
+      retry error: | value |
+        consume value
+    description := """
+        Keep this
+          relative indentation.
+        """
 
 a := 1
 b := 2

--- a/tests/formatter/gold/expressions.toit
+++ b/tests/formatter/gold/expressions.toit
@@ -9,6 +9,15 @@ main:
     call-layout := send first-argument-that-is-moderately-long second-argument-that-is-moderately-long third-argument-that-is-moderately-long
     many-arguments := consume arg01 arg02 arg03 arg04 arg05 arg06 arg07 arg08 arg09 arg10 arg11 arg12 arg13 arg14 arg15
     collection-layout := [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccccccccccccc, dddddddddddddddddddddddddddddddddddddddd]
+    block-result := values.map: | value/int | value * 2
+    lambda-result := task:: run-background
+    named-block := parse value --if-error=: throw it
+    multi-block := values.do:
+      print it
+      total += it
+    multi-lambda := task::
+      prepare
+      execute
 
 a := 1
 b := 2

--- a/tests/formatter/gold/expressions.toit
+++ b/tests/formatter/gold/expressions.toit
@@ -18,6 +18,8 @@ main:
     multi-lambda := task::
       prepare
       execute
+    while item/List? := next:
+      print item
 
 a := 1
 b := 2


### PR DESCRIPTION
Part 7 of 10 in the AST-driven Toit pretty-printer stack. Depends on #3191.

## Summary

- format suite-bearing calls and declarations in conditions
- preserve nested call argument structure
- keep semantic separation around comments
- parenthesize binary, conditional, nested-call, prefix-not, and grouped-suite arguments when required by Toit grammar
- format suites in statement contexts
- use leading broken binary operators, except trailing and/or

## Verification

- focused public-command gold cases cover blocks, lambdas, named suites, nested calls, condition declarations, and grammar-sensitive arguments
- every formatted result is reparsed and checked for AST equivalence

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>