### PR TITLE
compiler: flatten parenthesized inline suites

### DIFF
--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -191,7 +191,10 @@ class ExpressionPrinter {
     if (argument->expression() != null) {
       Expression* value = argument->expression();
       Expression* inner = peel_parentheses(value);
-      std::string value_text = flat(inner, PRECEDENCE_NONE);
+      std::string value_text = value->is_Parenthesis() &&
+              (inner->is_Block() || inner->is_Lambda())
+          ? flat_parenthesized_suite(inner)
+          : flat(inner, PRECEDENCE_NONE);
       if (value->is_Parenthesis() ||
           needs_call_argument_parentheses(inner)) {
         value_text = "(" + value_text + ")";
@@ -292,6 +295,28 @@ class ExpressionPrinter {
     }
     std::string result = suite_introduction(expression);
     if (!body_text.empty()) result += " " + body_text;
+    return result;
+  }
+
+  std::string flat_parenthesized_suite(Expression* expression) {
+    bool is_block = expression->is_Block();
+    Sequence* body = is_block
+        ? expression->as_Block()->body()
+        : expression->as_Lambda()->body();
+    std::string result = suite_introduction(expression);
+    for (int i = 0; i < body->expressions().length(); i++) {
+      Expression* statement = body->expressions()[i];
+      if (statement->is_Return() || statement->is_BreakContinue() ||
+          statement->is_While() || statement->is_For() ||
+          statement->is_TryFinally() ||
+          (statement->is_If() && statement->as_If()->yes() != null &&
+           statement->as_If()->yes()->is_Sequence())) {
+        supported_ = false;
+        return std::string();
+      }
+      result += (i == 0 ? " " : "; ") +
+          flat(statement, PRECEDENCE_NONE);
+    }
     return result;
   }
 

--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -306,16 +306,34 @@ class ExpressionPrinter {
     std::string result = suite_introduction(expression);
     for (int i = 0; i < body->expressions().length(); i++) {
       Expression* statement = body->expressions()[i];
-      if (statement->is_Return() || statement->is_BreakContinue() ||
-          statement->is_While() || statement->is_For() ||
+      if (statement->is_While() || statement->is_For() ||
           statement->is_TryFinally() ||
           (statement->is_If() && statement->as_If()->yes() != null &&
            statement->as_If()->yes()->is_Sequence())) {
         supported_ = false;
         return std::string();
       }
-      result += (i == 0 ? " " : "; ") +
-          flat(statement, PRECEDENCE_NONE);
+      std::string statement_text;
+      if (statement->is_Return()) {
+        Return* return_expression = statement->as_Return();
+        statement_text = "return";
+        if (return_expression->value() != null) {
+          statement_text += " " +
+              flat(return_expression->value(), PRECEDENCE_NONE);
+        }
+      } else if (statement->is_BreakContinue()) {
+        BreakContinue* jump = statement->as_BreakContinue();
+        statement_text = jump->is_break() ? "break" : "continue";
+        if (jump->label() != null) {
+          statement_text += "." + flat(jump->label(), PRECEDENCE_NONE);
+        }
+        if (jump->value() != null) {
+          statement_text += " " + flat(jump->value(), PRECEDENCE_NONE);
+        }
+      } else {
+        statement_text = flat(statement, PRECEDENCE_NONE);
+      }
+      result += (i == 0 ? " " : "; ") + statement_text;
     }
     return result;
   }

--- a/tests/formatter/gold/expressions.gold
+++ b/tests/formatter/gold/expressions.gold
@@ -32,6 +32,7 @@ main:
   named-binary := configure --enabled=(foo or bar)
   named-not := configure --hidden=(not foo)
   named-parenthesized-block := parse --if-error=(: null) value
+  named-semicolon-block := parse --if-error=(: valid = false; null) value
   lambda-value := ::
     prepare
     execute

--- a/tests/formatter/gold/expressions.gold
+++ b/tests/formatter/gold/expressions.gold
@@ -33,6 +33,7 @@ main:
   named-not := configure --hidden=(not foo)
   named-parenthesized-block := parse --if-error=(: null) value
   named-semicolon-block := parse --if-error=(: valid = false; null) value
+  named-return-block := parse --if-error=(: return false) value
   lambda-value := ::
     prepare
     execute

--- a/tests/formatter/gold/expressions.toit
+++ b/tests/formatter/gold/expressions.toit
@@ -29,6 +29,7 @@ main:
     named-not := configure --hidden=(not foo)
     named-parenthesized-block := parse --if-error=(: null) value
     named-semicolon-block := parse --if-error=(: valid = false; null) value
+    named-return-block := parse --if-error=(:return false) value
     lambda-value := ::
       prepare
       execute

--- a/tests/formatter/gold/expressions.toit
+++ b/tests/formatter/gold/expressions.toit
@@ -28,6 +28,7 @@ main:
     named-binary := configure --enabled=(foo or bar)
     named-not := configure --hidden=(not foo)
     named-parenthesized-block := parse --if-error=(: null) value
+    named-semicolon-block := parse --if-error=(: valid = false; null) value
     lambda-value := ::
       prepare
       execute


### PR DESCRIPTION
Part 9 of 10 in the AST-driven Toit pretty-printer stack. Depends on #3193.

## Summary

- render parenthesized multi-expression suites with canonical semicolon separation
- support return, break, and continue inside parenthesized inline suites
- keep ordinary multi-statement suites multiline

## Verification

- public-command gold cases cover parenthesized named blocks with assignment and return
- the changes close the final semantic-verification failures found by the 269-file corpus probe

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>