### PR TITLE
compiler: calibrate canonical formatter output

### DIFF
--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -51,13 +51,16 @@ AST node.  Indentation disambiguates comments in nested statement sequences.
 
 ## Layout selection
 
-AST printers construct a small set of legal, node-specific output shapes.
-There is no general token-order layout IR and no post-selection relocation or
-syntax-repair phase.  Required parentheses and reordered semantic pieces are
-part of each candidate before it is measured.
+AST printers first estimate the width of the flat spelling.  The estimate is
+deliberately approximate: it ignores formatter-controlled parentheses,
+optional commas, and continuation backslashes; insignificant source whitespace
+is normalized.  Literal contents and collection separators are counted because
+they materially affect the result.  The estimate is used only for a stable
+yes/no decision; it is not rendered and need not equal the selected output's
+actual width.
 
-Candidates are selected with a soft score rather than a maximum width.  The
-score considers:
+The flat decision uses a soft preference rather than a maximum width.  It
+considers:
 
 * line extent beyond a preferred region;
 * the number of additional physical lines;
@@ -70,9 +73,15 @@ Indentation may nevertheless move the soft breaking point slightly left
 relative to the construct.  Neither condition is a hard limit.
 
 Compact calls with many arguments may stay flat beyond the preferred extent
-when breaking would introduce many lines.  A `\` continuation is a legal
-candidate when it provides a better result than either one long physical line
-or one argument per line.
+when breaking would introduce many lines.  A `\` continuation may be selected
+when it provides a better result than either one long physical line or one
+argument per line.
+
+If flat output is rejected, the node selects a grammar-legal broken policy and
+renders it directly.  Decisions inside the broken output are then made in
+their new line and indentation context.  No complete broken alternative is
+built or measured in advance, and no general token-order layout IR or
+post-selection syntax-repair phase is used.
 
 Initial canonical choices are:
 
@@ -87,10 +96,11 @@ Consecutive fields form a compact group with one field per line.  Methods,
 classes, and transitions between declaration kinds retain a blank separator.
 
 Call, method-header, binary, and collection layouts are adaptive rather than
-global modes.  Each AST node contributes its legal candidates, and the common
-score chooses among flat, partially broken, fully broken, packed-row, and
-backslash forms according to both extent and item count.  There are no
-user-facing or development style switches in the command.
+global modes.  Each AST node has small, explicit policies for flat, partially
+broken, fully broken, packed-row, and backslash forms.  The common flat
+decision and node-specific heuristics choose among them according to both
+extent and item count.  There are no user-facing or development style switches
+in the command.
 
 ## Calibration
 
@@ -110,8 +120,10 @@ original scoring and retains the desired slight pressure to break earlier.
 The corpus and gold cases also exercise the adaptive outcomes: many compact
 arguments may remain on one long line, a backslash may avoid a line per
 argument, named suffixes may split independently, and collections may pack
-several items per row.  These are outcomes of one score, not formatter modes
-or user preferences.
+several items per row.  These are outcomes of one deterministic policy, not
+formatter modes or user preferences.  The flat-decision implementation
+reproduces the same 269-file canonical output without constructing or scoring
+complete broken alternatives.
 
 ## Grammar constraints
 
@@ -150,7 +162,8 @@ added there.
 
 CTest binaries are reserved for mechanisms that cannot be observed through
 the command: AST equivalence diagnostics, atomic replacement failure modes,
-source/comment fact extraction, candidate scoring, and verifier rejection.
+source/comment fact extraction, flat-decision heuristics, and verifier
+rejection.
 Corpus probes over `lib`, `tools`, and `examples` find interactions that then
 become focused gold cases; they are not substitutes for those cases.
 
@@ -170,10 +183,10 @@ be one commit and may be submitted as one PR in a stacked review.
    punctuation gaps, frozen trailing-comment lines, and opaque multiline
    comments.  Test ownership and indentation shifting without formatting AST
    nodes.
-5. **Add scoring and output primitives.** Add a small line-oriented output
-   builder and candidate scorer.  Test soft width, line/item pressure,
-   indentation pressure, and dominance pruning.  This layer contains no Toit
-   syntax policy.
+5. **Add flat decisions and output primitives.** Add a small line-oriented
+   output builder and the rough `is flat acceptable?` heuristic.  Test soft
+   width, line/item pressure, and indentation pressure.  This layer contains
+   no Toit syntax policy and stores no speculative output.
 6. **Print atoms and precedence expressions.** Cover identifiers, literals,
    unary, binary, dot, index, slice, and ternary expressions.  Reconstruct
    only required or selected clarity parentheses and verify every result by
@@ -181,12 +194,13 @@ be one commit and may be submitted as one PR in a stacked review.
 7. **Print method and declaration headers.** Cover parameters, return-type
    movement, fields, classes, imports, and exports, including comments that
    move with semantic pieces.
-8. **Print calls and suites.** Add flat, unnamed-prefix/named-continuation,
-   fully broken, and backslash-continuation candidates.  Cover blocks,
-   lambdas, greedy calls, and layout-dependent parentheses.
-9. **Print collections.** Add flat, packed-row, and one-item-per-line
-   candidates for lists, sets, maps, and byte arrays, including all comment
-   slots and trailing commas.
+8. **Print calls and suites.** Add flat decisions and direct rendering for
+   unnamed-prefix/named-continuation, fully broken, and
+   backslash-continuation policies.  Cover blocks, lambdas, greedy calls, and
+   layout-dependent parentheses.
+9. **Print collections.** Add flat decisions and direct packed-row rendering
+   for lists, sets, maps, and byte arrays, including all comment slots and
+   trailing commas.
 10. **Print statements and bodies.** Cover declarations, assignments,
     returns, control flow, loops, try/finally, empty suites, inline suites, and
     complete comment ownership across nested sequences.
@@ -198,9 +212,9 @@ be one commit and may be submitted as one PR in a stacked review.
     formatting over `lib`, `tools`, and `examples`.
 13. **Calibrate canonical choices.** Compare call, collection,
     binary-argument, bitwise-grouping, and indentation-pressure alternatives
-    over representative Toit repositories.  Record the churn and selected
-    shapes, retain one adaptive scoring policy, and remove the development
-    switches before enabling the command.
+    over representative Toit repositories.  Record the churn, retain one
+    deterministic flat-decision policy with node-specific heuristics, and
+    remove the development switches before enabling the command.
 
 The golden corpus is specification data.  Each case checks exact output,
 idempotence, reparsing, AST equivalence, and comment preservation.  Corpus

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -63,7 +63,7 @@ score considers:
 * the number of additional physical lines;
 * the number of items split across lines;
 * construct-specific readability costs; and
-* optional, slight pressure from the current indentation.
+* slight pressure from the enclosing indentation.
 
 An indented construct may extend farther right than a top-level construct.
 Indentation may nevertheless move the soft breaking point slightly left
@@ -83,9 +83,35 @@ Initial canonical choices are:
 * at most two preserved blank lines; and
 * two spaces before a trailing comment unless it is lexically attached.
 
-Collection and call shapes deliberately remain scoring experiments.  Internal
-style switches may compare alternatives during development, but the released
-formatter will expose one canonical style rather than user configuration.
+Consecutive fields form a compact group with one field per line.  Methods,
+classes, and transitions between declaration kinds retain a blank separator.
+
+Call, method-header, binary, and collection layouts are adaptive rather than
+global modes.  Each AST node contributes its legal candidates, and the common
+score chooses among flat, partially broken, fully broken, packed-row, and
+backslash forms according to both extent and item count.  There are no
+user-facing or development style switches in the command.
+
+## Calibration
+
+The initial canonical output was measured over all 269 Toit files under
+`lib`, `tools`, and `examples`.  The final policy formats every file and
+changes 257 of them (8,160 inserted and 11,124 removed lines), so the first
+application is intentionally a broad normalization rather than a small
+whitespace cleanup.
+
+Disabling clarity parentheses between unlike bitwise operators changed 43
+files and repeatedly hid useful grouping, so those parentheses are canonical
+and the experimental switch was removed.  Disabling indentation pressure
+changed 10 files.  Counting only enclosing indentation, rather than counting
+continuation indentation a second time, changes four files relative to the
+original scoring and retains the desired slight pressure to break earlier.
+
+The corpus and gold cases also exercise the adaptive outcomes: many compact
+arguments may remain on one long line, a backslash may avoid a line per
+argument, named suffixes may split independently, and collections may pack
+several items per row.  These are outcomes of one score, not formatter modes
+or user preferences.
 
 ## Grammar constraints
 
@@ -170,10 +196,11 @@ be one commit and may be submitted as one PR in a stacked review.
 12. **Integrate `toit format`.** Add the hidden CLI command, verifier gate,
     atomic in-place writes, golden tests, idempotence tests, and corpus-level
     formatting over `lib`, `tools`, and `examples`.
-13. **Calibrate canonical choices.** Run experimental call, collection,
-    binary-argument, and indentation-pressure modes over representative Toit
-    repositories.  Record churn and shape counts, choose one mode for each,
-    and remove the development switches before enabling the command.
+13. **Calibrate canonical choices.** Compare call, collection,
+    binary-argument, bitwise-grouping, and indentation-pressure alternatives
+    over representative Toit repositories.  Record the churn and selected
+    shapes, retain one adaptive scoring policy, and remove the development
+    switches before enabling the command.
 
 The golden corpus is specification data.  Each case checks exact output,
 idempotence, reparsing, AST equivalence, and comment preservation.  Corpus

--- a/src/compiler/format_declaration.cc
+++ b/src/compiler/format_declaration.cc
@@ -22,13 +22,11 @@ class MethodHeaderPrinter {
   MethodHeaderPrinter(Method* method,
                       Source* source,
                       int base_indentation,
-                      const FormatStyle& style,
-                      const FormatExpressionOptions& expression_options)
+                      const FormatStyle& style)
       : method_(method)
       , source_(source)
       , base_indentation_(base_indentation)
-      , style_(style)
-      , expression_options_(expression_options) {}
+      , style_(style) {}
 
   bool run(FormatOutput* result) {
     if (!prepare()) return false;
@@ -80,15 +78,13 @@ class MethodHeaderPrinter {
   Source* source_;
   int base_indentation_;
   const FormatStyle& style_;
-  const FormatExpressionOptions& expression_options_;
   std::string prefix_;
   std::string return_type_;
   std::vector<std::string> parameters_;
   int first_named_ = -1;
 
   bool expression(Expression* node, std::string* result) {
-    return format_expression_flat(
-        node, source_, result, expression_options_);
+    return format_expression_flat(node, source_, result);
   }
 
   bool prepare_parameter(Parameter* parameter, std::string* result) {
@@ -194,12 +190,10 @@ bool format_method_header(Method* method,
                           Source* source,
                           int base_indentation,
                           FormatOutput* result,
-                          const FormatStyle& style,
-                          const FormatExpressionOptions& expression_options) {
+                          const FormatStyle& style) {
   ASSERT(method != null && source != null && result != null);
   ASSERT(base_indentation >= 0);
-  MethodHeaderPrinter printer(
-      method, source, base_indentation, style, expression_options);
+  MethodHeaderPrinter printer(method, source, base_indentation, style);
   return printer.run(result);
 }
 

--- a/src/compiler/format_declaration.h
+++ b/src/compiler/format_declaration.h
@@ -22,9 +22,7 @@ bool format_method_header(ast::Method* method,
                           Source* source,
                           int base_indentation,
                           FormatOutput* result,
-                          const FormatStyle& style = FormatStyle(),
-                          const FormatExpressionOptions& expression_options =
-                              FormatExpressionOptions());
+                          const FormatStyle& style = FormatStyle());
 
 } // namespace compiler
 } // namespace toit

--- a/src/compiler/format_expression.cc
+++ b/src/compiler/format_expression.cc
@@ -77,12 +77,10 @@ class ExpressionPrinter {
  public:
   ExpressionPrinter(Source* source,
                     int base_indentation,
-                    const FormatStyle& style,
-                    const FormatExpressionOptions& options)
+                    const FormatStyle& style)
       : source_(source)
       , base_indentation_(base_indentation)
-      , style_(style)
-      , options_(options) {}
+      , style_(style) {}
 
   bool run(Expression* expression, FormatOutput* result) {
     ASSERT(expression != null && result != null);
@@ -101,7 +99,6 @@ class ExpressionPrinter {
   Source* source_;
   int base_indentation_;
   const FormatStyle& style_;
-  const FormatExpressionOptions& options_;
   bool supported_ = true;
 
   int start(Node* node) const {
@@ -284,8 +281,7 @@ class ExpressionPrinter {
                                 source_,
                                 0,
                                 &body_text,
-                                style_,
-                                options_)) {
+                                style_)) {
       supported_ = false;
       return std::string();
     }
@@ -385,7 +381,6 @@ class ExpressionPrinter {
 
   bool needs_bitwise_parentheses(Token::Kind parent,
                                  Token::Kind child) const {
-    if (!options_.parenthesize_mixed_bitwise) return false;
     if (!is_bitwise(parent) && !is_bitwise(child)) return false;
     if (Token::precedence(parent) == PRECEDENCE_ASSIGNMENT) return false;
     return parent != child;
@@ -627,8 +622,7 @@ class ExpressionPrinter {
                            source_,
                            0,
                            &body_text,
-                           style_,
-                           options_)) {
+                           style_)) {
         supported_ = false;
         return true;
       }
@@ -696,8 +690,7 @@ class ExpressionPrinter {
                            source_,
                            0,
                            &body_text,
-                           style_,
-                           options_)) return false;
+                           style_)) return false;
       append_suite_body(
           result,
           style_.continuation_step,
@@ -740,8 +733,7 @@ class ExpressionPrinter {
                          source_,
                          0,
                          &body_text,
-                         style_,
-                         options_)) return false;
+                         style_)) return false;
 
     *result = FormatOutput::single_line(first);
     size_t line_start = 0;
@@ -959,8 +951,7 @@ class ExpressionPrinter {
                            source_,
                            0,
                            &body_text,
-                           style_,
-                           options_)) {
+                           style_)) {
         supported_ = false;
         return false;
       }
@@ -1121,10 +1112,9 @@ class ExpressionPrinter {
 
 bool format_expression_flat(Expression* expression,
                             Source* source,
-                            std::string* result,
-                            const FormatExpressionOptions& options) {
+                            std::string* result) {
   ASSERT(source != null);
-  ExpressionPrinter printer(source, 0, FormatStyle(), options);
+  ExpressionPrinter printer(source, 0, FormatStyle());
   return printer.run_flat(expression, result);
 }
 
@@ -1132,11 +1122,10 @@ bool format_expression(Expression* expression,
                        Source* source,
                        int base_indentation,
                        FormatOutput* result,
-                       const FormatStyle& style,
-                       const FormatExpressionOptions& options) {
+                       const FormatStyle& style) {
   ASSERT(source != null);
   ASSERT(base_indentation >= 0);
-  ExpressionPrinter printer(source, base_indentation, style, options);
+  ExpressionPrinter printer(source, base_indentation, style);
   return printer.run(expression, result);
 }
 

--- a/src/compiler/format_expression.h
+++ b/src/compiler/format_expression.h
@@ -22,19 +22,11 @@
 namespace toit {
 namespace compiler {
 
-struct FormatExpressionOptions {
-  // Development switch used to measure the readability/churn tradeoff. It is
-  // not intended to become a user-facing formatter option.
-  bool parenthesize_mixed_bitwise = true;
-};
-
 // Produces the canonical one-line spelling for an expression. Returns false
 // when the expression kind is not implemented or inherently spans lines.
 bool format_expression_flat(ast::Expression* expression,
                             Source* source,
-                            std::string* result,
-                            const FormatExpressionOptions& options =
-                                FormatExpressionOptions());
+                            std::string* result);
 
 // Formats one expression directly from its AST. Returns false for expression
 // kinds not implemented by the current review slice.
@@ -42,9 +34,7 @@ bool format_expression(ast::Expression* expression,
                        Source* source,
                        int base_indentation,
                        FormatOutput* result,
-                       const FormatStyle& style = FormatStyle(),
-                       const FormatExpressionOptions& options =
-                           FormatExpressionOptions());
+                       const FormatStyle& style = FormatStyle());
 
 } // namespace compiler
 } // namespace toit

--- a/src/compiler/format_statement.cc
+++ b/src/compiler/format_statement.cc
@@ -30,11 +30,9 @@ class StatementPrinter {
  public:
   StatementPrinter(Source* source,
                    const FormatStyle& style,
-                   const FormatExpressionOptions& expression_options,
                    FormatCommentState* comments)
       : source_(source)
       , style_(style)
-      , expression_options_(expression_options)
       , comments_(comments) {}
 
   bool sequence(Sequence* sequence, int indentation, std::string* result) {
@@ -83,7 +81,6 @@ class StatementPrinter {
  private:
   Source* source_;
   const FormatStyle& style_;
-  const FormatExpressionOptions& expression_options_;
   FormatCommentState* comments_;
 
   FormatSource* facts() const {
@@ -150,8 +147,7 @@ class StatementPrinter {
   }
 
   bool flat(Expression* expression, std::string* result) {
-    return format_expression_flat(
-        expression, source_, result, expression_options_);
+    return format_expression_flat(expression, source_, result);
   }
 
   bool condition(Expression* expression, std::string* result) {
@@ -170,8 +166,7 @@ class StatementPrinter {
                              source_,
                              indentation,
                              result,
-                             style_,
-                             expression_options_);
+                             style_);
   }
 
   static std::string indent(int indentation) {
@@ -401,11 +396,10 @@ bool format_sequence(Sequence* sequence,
                      int indentation,
                      std::string* result,
                      const FormatStyle& style,
-                     const FormatExpressionOptions& expression_options,
                      FormatCommentState* comments) {
   ASSERT(source != null && result != null);
   ASSERT(indentation >= 0);
-  StatementPrinter printer(source, style, expression_options, comments);
+  StatementPrinter printer(source, style, comments);
   return printer.sequence(sequence, indentation, result);
 }
 

--- a/src/compiler/format_statement.h
+++ b/src/compiler/format_statement.h
@@ -25,8 +25,6 @@ bool format_sequence(ast::Sequence* sequence,
                      int indentation,
                      std::string* result,
                      const FormatStyle& style = FormatStyle(),
-                     const FormatExpressionOptions& expression_options =
-                         FormatExpressionOptions(),
                      FormatCommentState* comments = null);
 
 } // namespace compiler

--- a/src/compiler/format_unit.cc
+++ b/src/compiler/format_unit.cc
@@ -25,11 +25,9 @@ class UnitPrinter {
  public:
   UnitPrinter(Source* source,
               const FormatStyle& style,
-              const FormatExpressionOptions& expression_options,
               FormatCommentState* comments)
       : source_(source)
       , style_(style)
-      , expression_options_(expression_options)
       , comments_(comments) {}
 
   bool run(Unit* unit, std::string* result) {
@@ -91,7 +89,6 @@ class UnitPrinter {
  private:
   Source* source_;
   const FormatStyle& style_;
-  const FormatExpressionOptions& expression_options_;
   FormatCommentState* comments_;
 
   const FormatSource* facts() const { return comments_->source(); }
@@ -184,8 +181,7 @@ class UnitPrinter {
   }
 
   bool flat(Expression* expression, std::string* result) {
-    return format_expression_flat(
-        expression, source_, result, expression_options_);
+    return format_expression_flat(expression, source_, result);
   }
 
   bool format_import(Import* import, std::string* result) {
@@ -268,8 +264,7 @@ class UnitPrinter {
                            source_,
                            indentation,
                            &initializer,
-                           style_,
-                           expression_options_)) return false;
+                           style_)) return false;
     prefix += field->is_final() ? " ::= " : " := ";
     ASSERT(!initializer.lines().empty());
     *result = prefix + initializer.lines()[0].text;
@@ -292,8 +287,7 @@ class UnitPrinter {
                               source_,
                               indentation,
                               &header,
-                              style_,
-                              expression_options_)) return false;
+                              style_)) return false;
     *result = header.render(indentation);
     if (method->body() != null) {
       std::string body;
@@ -302,7 +296,6 @@ class UnitPrinter {
                            indentation + style_.indentation_step,
                            &body,
                            style_,
-                           expression_options_,
                            comments_)) return false;
       if (!body.empty()) *result += "\n" + body;
     }
@@ -382,12 +375,11 @@ bool format_unit(Unit* unit,
                  Source* source,
                  List<Scanner::Comment> comments,
                  std::string* result,
-                 const FormatStyle& style,
-                 const FormatExpressionOptions& expression_options) {
+                 const FormatStyle& style) {
   ASSERT(unit != null && source != null && result != null);
   FormatSource facts(source, comments);
   FormatCommentState comment_state(&facts);
-  UnitPrinter printer(source, style, expression_options, &comment_state);
+  UnitPrinter printer(source, style, &comment_state);
   if (!printer.run(unit, result)) return false;
   return comment_state.all_consumed();
 }

--- a/src/compiler/format_unit.cc
+++ b/src/compiler/format_unit.cc
@@ -64,13 +64,21 @@ class UnitPrinter {
     }
     if (!directives.empty()) sections.push_back(join(directives, "\n"));
 
+    Node* previous_declaration = null;
     for (auto node : unit->declarations()) {
       std::string text;
       std::string prefix;
       if (!leading(node, 0, cursor, &prefix)) return false;
       if (!declaration(node, 0, &text)) return false;
       if (!prefix.empty()) text = prefix + "\n" + text;
-      sections.push_back(std::move(text));
+      if (previous_declaration != null &&
+          previous_declaration->is_Field() && node->is_Field()) {
+        ASSERT(!sections.empty());
+        sections.back() += "\n" + text;
+      } else {
+        sections.push_back(std::move(text));
+      }
+      previous_declaration = node;
       cursor = end(node);
     }
     std::string trailing;
@@ -343,6 +351,7 @@ class UnitPrinter {
 
     std::vector<std::string> members;
     int cursor = facts()->lines()[facts()->line_index_at(start(klass))].to;
+    Node* previous_member = null;
     for (auto member : klass->members()) {
       std::string text;
       std::string prefix;
@@ -353,7 +362,14 @@ class UnitPrinter {
       if (!declaration(
           member, indentation + style_.indentation_step, &text)) return false;
       if (!prefix.empty()) text = prefix + "\n" + text;
-      members.push_back(std::move(text));
+      if (previous_member != null &&
+          previous_member->is_Field() && member->is_Field()) {
+        ASSERT(!members.empty());
+        members.back() += "\n" + text;
+      } else {
+        members.push_back(std::move(text));
+      }
+      previous_member = member;
       cursor = end(member);
     }
     *result = header;

--- a/src/compiler/format_unit.h
+++ b/src/compiler/format_unit.h
@@ -24,9 +24,7 @@ bool format_unit(ast::Unit* unit,
                  Source* source,
                  List<Scanner::Comment> comments,
                  std::string* result,
-                 const FormatStyle& style = FormatStyle(),
-                 const FormatExpressionOptions& expression_options =
-                     FormatExpressionOptions());
+                 const FormatStyle& style = FormatStyle());
 
 } // namespace compiler
 } // namespace toit

--- a/tests/formatter/gold/declarations.gold
+++ b/tests/formatter/gold/declarations.gold
@@ -4,7 +4,6 @@ export alpha beta
 
 abstract class Device extends Base with Mix implements Interface:
   static VALUE/int ::= 1
-
   static TEXT ::= """
         preserve
         continuation bytes

--- a/tests/formatter/gold/expressions.gold
+++ b/tests/formatter/gold/expressions.gold
@@ -57,21 +57,13 @@ main:
         """
 
 a := 1
-
 b := 2
-
 c := 3
-
 foo := true
-
 bar := false
-
 gee := true
-
 byte := 16
-
 x := 1
-
 y := 2
 
 consume value:

--- a/tests/formatter/gold/expressions.gold
+++ b/tests/formatter/gold/expressions.gold
@@ -1,7 +1,11 @@
 main:
   precedence := (a + b) * c
   logical := foo and (bar or gee)
+  logical-layout := alpha-identifier-that-is-deliberately-very-long and
+      beta-identifier-that-is-deliberately-very-long and
+      gamma-identifier-that-is-deliberately-very-long
   bits := (byte >> 4) & 0xf
+  resolver-sensitive := (Foo).bar
   call := consume (build x y)
   bytes := #[1, 2, 3]
   mapping := {one: 1, two: 2}

--- a/tests/formatter/gold/expressions.toit
+++ b/tests/formatter/gold/expressions.toit
@@ -1,7 +1,9 @@
 main:
     precedence := ((a + b)) * c
     logical := foo and (bar or gee)
+    logical-layout := alpha-identifier-that-is-deliberately-very-long and beta-identifier-that-is-deliberately-very-long and gamma-identifier-that-is-deliberately-very-long
     bits := byte >> 4 & 0xf
+    resolver-sensitive := (Foo).bar
     call := consume  (build x y)
     bytes := #[1,2,  3]
     mapping := {one:1,two: 2}


### PR DESCRIPTION
Part 10 of 10 in the AST-driven Toit pretty-printer stack. Depends on #3194.

## Summary

- choose explicit grouping between unlike bitwise operators
- remove the bitwise development switch
- apply slight soft-width pressure from enclosing indentation only
- keep consecutive fields compact
- document the direct flat-decision architecture and calibration results
- pin trailing logical operators and resolver-sensitive receiver parentheses in gold tests

## Calibration

- all 269 files under `lib`, `tools`, and `examples` format and pass semantic verification
- the direct implementation produces byte-identical canonical output to the calibrated implementation without constructing or scoring complete broken alternatives
- disabling mixed-bitwise grouping changed 43 files and reduced clarity
- disabling indentation pressure changed 10 files
- the canonical first pass changes 257 of 269 corpus files

## Verification

- all eight focused formatter gold and mechanism tests pass
- the 269-file output is byte-identical to the calibration baseline
- a second complete corpus pass produces zero differences
- 1,005 of 1,006 host tests pass; the remaining explicitly-flaky UDP multicast test times out in the test environment

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
