### PR TITLE
Harden subprocess wait and signaling primitives

### DIFF
--- a/src/resource.h
+++ b/src/resource.h
@@ -108,6 +108,9 @@ class ResourceGroup : public ResourceGroupListFromProcess::Element {
 
   IntResource* register_id(word id);
   void register_resource(Resource* resource);
+  bool is_resource_registered(Resource* resource) const {
+    return resources_.is_linked(resource);
+  }
 
   void unregister_id(word id);
   void unregister_resource(Resource* resource);

--- a/src/resources/subprocess_posix.cc
+++ b/src/resources/subprocess_posix.cc
@@ -64,7 +64,10 @@ PRIMITIVE(init) {
 PRIMITIVE(wait_for) {
   ARGS(IntResource, subprocess);
   if (subprocess->resource_group()->event_source() != SubprocessEventSource::instance()) FAIL(WRONG_OBJECT_TYPE);
-  subprocess->resource_group()->register_resource(subprocess);
+  ResourceGroup* group = subprocess->resource_group();
+  // A wait can be interrupted and retried. Registering the same intrusive-list
+  // node twice corrupts both the resource group and subprocess event source.
+  if (!group->is_resource_registered(subprocess)) group->register_resource(subprocess);
   return process->null_object();
 }
 

--- a/src/resources/subprocess_posix.cc
+++ b/src/resources/subprocess_posix.cc
@@ -84,7 +84,10 @@ PRIMITIVE(dont_wait_for) {
 PRIMITIVE(kill) {
   ARGS(IntResource, subprocess, int, signal);
   if (subprocess->resource_group()->event_source() != SubprocessEventSource::instance()) FAIL(WRONG_OBJECT_TYPE);
-  if (::kill(subprocess->id(), signal) != 0) return Primitive::os_error(errno, process);
+  if (::kill(subprocess->id(), signal) != 0) {
+    if (errno == EINVAL) FAIL(INVALID_ARGUMENT);
+    return Primitive::os_error(errno, process);
+  }
   return process->null_object();
 }
 

--- a/src/resources/subprocess_posix.cc
+++ b/src/resources/subprocess_posix.cc
@@ -84,7 +84,7 @@ PRIMITIVE(dont_wait_for) {
 PRIMITIVE(kill) {
   ARGS(IntResource, subprocess, int, signal);
   if (subprocess->resource_group()->event_source() != SubprocessEventSource::instance()) FAIL(WRONG_OBJECT_TYPE);
-  kill(subprocess->id(), signal);
+  if (::kill(subprocess->id(), signal) != 0) return Primitive::os_error(errno, process);
   return process->null_object();
 }
 

--- a/src/resources/subprocess_win.cc
+++ b/src/resources/subprocess_win.cc
@@ -95,8 +95,8 @@ PRIMITIVE(kill) {
   ARGS(SubprocessResource, subprocess, int, signal);
   if (signal != 9) FAIL(INVALID_ARGUMENT);
 
+  if (!TerminateProcess(subprocess->handle(), signal)) WINDOWS_ERROR;
   subprocess->set_killed();
-  TerminateProcess(subprocess->handle(), signal);
   return process->null_object();
 }
 

--- a/tests/subprocess-wait-registration-test.toit
+++ b/tests/subprocess-wait-registration-test.toit
@@ -18,7 +18,7 @@ main:
     // Native signaling failures must reach the caller. Signal 999 is outside
     // the supported range and cannot be delivered on any host platform.
     error := catch: pipe.kill_ process.pid 999
-    expect-not-null error
+    expect-equals "INVALID_ARGUMENT" error
 
     // This is what a retry after an interrupted wait does at the native
     // boundary. It must not link the subprocess resource more than once.

--- a/tests/subprocess-wait-registration-test.toit
+++ b/tests/subprocess-wait-registration-test.toit
@@ -15,6 +15,11 @@ main:
   25.repeat:
     process := pipe.fork --create-stdin "cat" ["cat"]
 
+    // Native signaling failures must reach the caller. Signal 999 is outside
+    // the supported range and cannot be delivered on any host platform.
+    error := catch: pipe.kill_ process.pid 999
+    expect-not-null error
+
     // This is what a retry after an interrupted wait does at the native
     // boundary. It must not link the subprocess resource more than once.
     wait-for_ process.pid

--- a/tests/subprocess-wait-registration-test.toit
+++ b/tests/subprocess-wait-registration-test.toit
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+import host.pipe
+import system show platform PLATFORM-FREERTOS
+
+SIGKILL ::= 9
+
+main:
+  // FreeRTOS cannot launch host subprocesses.
+  if platform == PLATFORM-FREERTOS: return
+
+  25.repeat:
+    process := pipe.fork --create-stdin "cat" ["cat"]
+
+    // This is what a retry after an interrupted wait does at the native
+    // boundary. It must not link the subprocess resource more than once.
+    wait-for_ process.pid
+    wait-for_ process.pid
+
+    pipe.kill_ process.pid SIGKILL
+    exit-value := with-timeout --ms=1_000: process.wait
+    expect-equals SIGKILL (pipe.exit-signal exit-value)
+
+wait-for_ subprocess -> none:
+  #primitive.subprocess.wait-for


### PR DESCRIPTION
## Summary

- make repeated native subprocess wait registration idempotent
- prevent intrusive-list corruption when a wait is interrupted and retried
- propagate POSIX kill failures instead of silently discarding them
- propagate Windows TerminateProcess failures and only mark a process killed after success
- add direct regression coverage for repeated registration and signaling errors

The cancellation-safe pkg-host waiter is toitlang/pkg-host#98. The supported Process termination API is toitlang/pkg-host#99.

## Tests

- cmake --build build/host --target toit -j4
- build/host/sdk/bin/toit analyze tests/subprocess-wait-registration-test.toit
- build/host/sdk/bin/toit run tests/subprocess-wait-registration-test.toit
- rebuilt SDK passed the pkg-host process kill regression