### PR TITLE
esp32: merge UART and USB console input

### DIFF
--- a/lib/io/stdio.toit
+++ b/lib/io/stdio.toit
@@ -27,8 +27,9 @@ stderr-instance_ ::= StandardWriter_ false
 /**
 Returns the standard input stream.
 
-On ESP32, input is supported when ESP-IDF's primary console is a UART or USB
-  Serial/JTAG. Other console backends are unsupported.
+On ESP32, input merges the primary console UART and USB Serial/JTAG when they
+  are configured as console backends. The ESP32-S2 USB CDC console and other
+  console backends are unsupported.
 
 The stream cannot be closed. It shares the platform input with other standard
   input APIs. If multiple readers or containers read concurrently, the first

--- a/src/event_sources/ev_queue_esp32.cc
+++ b/src/event_sources/ev_queue_esp32.cc
@@ -26,8 +26,8 @@
 #include "ev_queue_esp32.h"
 
 // The max queue set size is the maximum number of events in the queue. This is used for the gpio queue,
-// up to two UART queues and the stop semaphore.
-#define MAX_QUEUE_SET_SIZE (GPIO_QUEUE_SIZE + 2 * UART_QUEUE_SIZE + STDIN_QUEUE_SIZE + 1)
+// up to three UART queues, the USB stdin queue, and the stop semaphore.
+#define MAX_QUEUE_SET_SIZE (GPIO_QUEUE_SIZE + 3 * UART_QUEUE_SIZE + STDIN_QUEUE_SIZE + 1)
 
 namespace toit {
 
@@ -105,17 +105,17 @@ void EventQueueEventSource::entry() {
       EventQueueResource* receiver = null;
       for (auto r : resources()) {
         auto resource = static_cast<EventQueueResource*>(r);
-        if (resource->queue() == handle) {
+        if (resource->handles_queue(handle)) {
           receiver = resource;
           break;
         }
       }
       if (receiver != null) {
         word data;
-        if (receiver->receive_event(&data)) {
+        if (receiver->receive_event(handle, &data)) {
           for (auto r : resources()) {
             auto resource = static_cast<EventQueueResource*>(r);
-            if (resource->queue() == handle) dispatch(locker, r, data);
+            if (resource->handles_queue(handle)) dispatch(locker, r, data);
           }
         }
       }
@@ -125,43 +125,59 @@ void EventQueueEventSource::entry() {
 
 void EventQueueEventSource::on_register_resource(Locker& locker, Resource* r) {
   auto resource = static_cast<EventQueueResource*>(r);
-  QueueHandle_t queue = resource->queue();
-  if (queue == null) return;
-  for (auto existing : resources()) {
-    if (existing == r) continue;
-    auto existing_resource = static_cast<EventQueueResource*>(existing);
-    if (existing_resource->queue() == queue) return;
-  }
-  // We can only add to the queue set when the queue is empty, so we
-  // repeatedly try to drain the queue before adding it to the set.
-  int attempts = 0;
-  do {
-    if (attempts++ > 16) FATAL("couldn't register event resource");
-    word data;
-    while (resource->receive_event(&data)) {
-      dispatch(locker, r, data);
+  QueueHandle_t queues[] = { resource->queue(), resource->secondary_queue() };
+  for (int i = 0; i < 2; i++) {
+    QueueHandle_t queue = queues[i];
+    if (queue == null || (i == 1 && queue == queues[0])) continue;
+    bool already_registered = false;
+    for (auto existing : resources()) {
+      if (existing == r) continue;
+      auto existing_resource = static_cast<EventQueueResource*>(existing);
+      if (existing_resource->handles_queue(queue)) {
+        already_registered = true;
+        break;
+      }
     }
-  } while (xQueueAddToSet(queue, queue_set_) != pdPASS);
+    if (already_registered) continue;
+    // We can only add to the queue set when the queue is empty, so we
+    // repeatedly try to drain the queue before adding it to the set.
+    int attempts = 0;
+    do {
+      if (attempts++ > 16) FATAL("couldn't register event resource");
+      word data;
+      while (resource->receive_event(queue, &data)) {
+        dispatch(locker, r, data);
+      }
+    } while (xQueueAddToSet(queue, queue_set_) != pdPASS);
+  }
 }
 
 void EventQueueEventSource::on_unregister_resource(Locker& locker, Resource* r) {
   auto resource = static_cast<EventQueueResource*>(r);
-  QueueHandle_t queue = resource->queue();
-  if (queue == null) return;
-  for (auto existing : resources()) {
-    auto existing_resource = static_cast<EventQueueResource*>(existing);
-    if (existing_resource->queue() == queue) return;
-  }
-  // We can only remove from the queue set when the queue is empty, so we
-  // repeatedly try to drain the queue before removing it from the set.
-  int attempts = 0;
-  do {
-    if (attempts++ > 16) FATAL("couldn't unregister event resource");
-    word data;
-    while (resource->receive_event(&data)) {
-      // Don't dispatch while unregistering.
+  QueueHandle_t queues[] = { resource->queue(), resource->secondary_queue() };
+  for (int i = 0; i < 2; i++) {
+    QueueHandle_t queue = queues[i];
+    if (queue == null || (i == 1 && queue == queues[0])) continue;
+    bool still_registered = false;
+    for (auto existing : resources()) {
+      auto existing_resource = static_cast<EventQueueResource*>(existing);
+      if (existing_resource->handles_queue(queue)) {
+        still_registered = true;
+        break;
+      }
     }
-  } while (xQueueRemoveFromSet(queue, queue_set_) != pdPASS);
+    if (still_registered) continue;
+    // We can only remove from the queue set when the queue is empty, so we
+    // repeatedly try to drain the queue before removing it from the set.
+    int attempts = 0;
+    do {
+      if (attempts++ > 16) FATAL("couldn't unregister event resource");
+      word data;
+      while (resource->receive_event(queue, &data)) {
+        // Don't dispatch while unregistering.
+      }
+    } while (xQueueRemoveFromSet(queue, queue_set_) != pdPASS);
+  }
 }
 
 } // namespace toit

--- a/src/event_sources/ev_queue_esp32.h
+++ b/src/event_sources/ev_queue_esp32.h
@@ -36,19 +36,28 @@ struct GpioEvent {
 
 class EventQueueResource : public Resource {
 public:
-  EventQueueResource(ResourceGroup* group, QueueHandle_t queue)
+  EventQueueResource(ResourceGroup* group, QueueHandle_t queue, QueueHandle_t secondary_queue = null)
       : Resource(group)
-      , queue_(queue){}
+      , queue_(queue)
+      , secondary_queue_(secondary_queue) {}
 
   virtual ~EventQueueResource() {};
 
   // Might be accessed from interrupt handlers. On the ESP32 it thus needs to be
   // in IRAM, or be marked as inline.
   FORCE_INLINE QueueHandle_t queue() const { return queue_; }
+  FORCE_INLINE QueueHandle_t secondary_queue() const { return secondary_queue_; }
+  FORCE_INLINE bool handles_queue(QueueHandle_t queue) const {
+    return queue_ == queue || secondary_queue_ == queue;
+  }
 
   // Receives one event with a zero timeout.  Provides the data argument for the
   // dispatch call on the event source.  Returns whether an event was available.
   virtual bool receive_event(word* data) { return false; }
+  virtual bool receive_event(QueueHandle_t queue, word* data) {
+    ASSERT(queue == queue_);
+    return receive_event(data);
+  }
 
   // Checks if the pin number matches the resource it dispatches with the new
   // value.
@@ -58,6 +67,7 @@ public:
 
 private:
   QueueHandle_t queue_; // Note: The queue is freed from the driver uninstall.
+  QueueHandle_t secondary_queue_;
 };
 
 class EventQueueEventSource : public EventSource, public Thread {

--- a/src/resources/stdio_esp32.cc
+++ b/src/resources/stdio_esp32.cc
@@ -13,12 +13,19 @@
 #include "sdkconfig.h"
 
 #ifdef CONFIG_ESP_CONSOLE_UART
+#define TOIT_STDIN_UART
+#endif
+#if defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG) || defined(CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG)
+#define TOIT_STDIN_USB_SERIAL_JTAG
+#endif
+
+#ifdef TOIT_STDIN_UART
 #include "driver/uart.h"
 #include "driver/uart_vfs.h"
 #include "uart_console_esp32.h"
 #endif
 
-#ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#ifdef TOIT_STDIN_USB_SERIAL_JTAG
 #include "driver/usb_serial_jtag.h"
 #include "driver/usb_serial_jtag_select.h"
 #include "driver/usb_serial_jtag_vfs.h"
@@ -35,13 +42,15 @@ namespace toit {
 
 static const word STDIN_READ_EVENT = 1 << 0;
 static const int STDIN_BUFFER_SIZE = 1024;
+#ifdef TOIT_STDIN_UART
 static const int UART_STDIN_RX_BUFFER_SIZE = 4096;
+#endif
 
-// ESP-IDF selects exactly one primary console. In particular,
-// CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG_ENABLED may additionally enable USB
-// Serial/JTAG output, but it does not select it as the standard streams.
+// ESP-IDF's console VFS only reads from the primary console. Subscribe to both
+// drivers directly so stdin can merge the configured UART and USB Serial/JTAG
+// input streams.
 
-#ifdef CONFIG_ESP_CONSOLE_UART
+#ifdef TOIT_STDIN_UART
 static int console_uart_stdin_users = 0;
 
 static esp_err_t acquire_uart_stdin(QueueHandle_t* queue) {
@@ -82,7 +91,7 @@ static void release_uart_stdin() {
 }
 #endif
 
-#ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#ifdef TOIT_STDIN_USB_SERIAL_JTAG
 static int usb_serial_jtag_stdin_users = 0;
 static QueueHandle_t usb_serial_jtag_stdin_queue = null;
 
@@ -115,17 +124,6 @@ static esp_err_t acquire_usb_serial_jtag_stdin(QueueHandle_t* queue) {
   }
 
   usb_serial_jtag_vfs_use_driver();
-  int flags = fcntl(STDIN_FILENO, F_GETFL, 0);
-  if (flags < 0 || fcntl(STDIN_FILENO, F_SETFL, flags | O_NONBLOCK) < 0) {
-    usb_serial_jtag_vfs_use_nonblocking();
-    SystemEventSource::instance()->run([&]() -> void {
-      err = usb_serial_jtag_driver_uninstall();
-    });
-    vQueueDelete(usb_serial_jtag_stdin_queue);
-    usb_serial_jtag_stdin_queue = null;
-    return ESP_FAIL;
-  }
-
   usb_serial_jtag_set_select_notif_callback(usb_serial_jtag_notify);
   if (usb_serial_jtag_read_ready()) {
     word event = STDIN_READ_EVENT;
@@ -160,31 +158,48 @@ class StdinResource : public EventQueueResource {
  public:
   TAG(StdinResource);
 
-  StdinResource(ResourceGroup* group, QueueHandle_t queue)
-      : EventQueueResource(group, queue) {}
+  StdinResource(ResourceGroup* group, QueueHandle_t uart_queue, QueueHandle_t usb_queue)
+      : EventQueueResource(group,
+                           uart_queue != null ? uart_queue : usb_queue,
+                           uart_queue != null ? usb_queue : null)
+      , uart_queue_(uart_queue)
+      , usb_queue_(usb_queue) {}
 
   ~StdinResource() override {
-#ifdef CONFIG_ESP_CONSOLE_UART
+#ifdef TOIT_STDIN_UART
     release_uart_stdin();
-#elif defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
+#endif
+#ifdef TOIT_STDIN_USB_SERIAL_JTAG
     release_usb_serial_jtag_stdin();
+#endif
+  }
+
+  bool receive_event(QueueHandle_t queue, word* data) override {
+#ifdef TOIT_STDIN_UART
+    if (queue == uart_queue_) {
+      uart_event_t event;
+      if (!xQueueReceive(queue, &event, 0)) return false;
+      // Preserve the UART event type because Port.console may share this
+      // queue and receives the same dispatched event.
+      *data = event.type;
+      return true;
+    }
+#endif
+#ifdef TOIT_STDIN_USB_SERIAL_JTAG
+    ASSERT(queue == usb_queue_);
+    return xQueueReceive(queue, data, 0);
 #else
     UNREACHABLE();
 #endif
   }
 
-  bool receive_event(word* data) override {
-#ifdef CONFIG_ESP_CONSOLE_UART
-    uart_event_t event;
-    if (!xQueueReceive(queue(), &event, 0)) return false;
-    *data = event.type;
-    return true;
-#elif defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
-    return xQueueReceive(queue(), data, 0);
-#else
-    UNREACHABLE();
-#endif
-  }
+  bool read_uart_first() const { return read_uart_first_; }
+  void alternate_read_order() { read_uart_first_ = !read_uart_first_; }
+
+ private:
+  const QueueHandle_t uart_queue_;
+  const QueueHandle_t usb_queue_;
+  bool read_uart_first_ = true;
 };
 
 class StdinResourceGroup : public ResourceGroup {
@@ -196,13 +211,10 @@ class StdinResourceGroup : public ResourceGroup {
 
   uint32_t on_event(Resource* resource, word data, uint32_t state) override {
     USE(resource);
-#ifdef CONFIG_ESP_CONSOLE_UART
     USE(data);
     // Error events do not carry data, but must still wake a pending read so it
     // can retry instead of waiting indefinitely.
     return state | STDIN_READ_EVENT;
-#endif
-    return state | static_cast<uint32_t>(data);
   }
 };
 
@@ -222,32 +234,40 @@ PRIMITIVE(stdin_init) {
 PRIMITIVE(stdin_open) {
   ARGS(StdinResourceGroup, group)
 
-#if !defined(CONFIG_ESP_CONSOLE_UART) && !defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
+#if !defined(TOIT_STDIN_UART) && !defined(TOIT_STDIN_USB_SERIAL_JTAG)
   FAIL(UNSUPPORTED);
 #else
   ByteArray* proxy = process->object_heap()->allocate_proxy();
   if (proxy == null) FAIL(ALLOCATION_FAILED);
 
-  QueueHandle_t queue = null;
-  esp_err_t err;
-#ifdef CONFIG_ESP_CONSOLE_UART
-  err = acquire_uart_stdin(&queue);
-#else
-  err = acquire_usb_serial_jtag_stdin(&queue);
-#endif
+  QueueHandle_t uart_queue = null;
+  QueueHandle_t usb_queue = null;
+#ifdef TOIT_STDIN_UART
+  esp_err_t err = acquire_uart_stdin(&uart_queue);
   if (err != ESP_OK) return Primitive::os_error(err, process);
+#endif
+#ifdef TOIT_STDIN_USB_SERIAL_JTAG
+  esp_err_t usb_err = acquire_usb_serial_jtag_stdin(&usb_queue);
+  if (usb_err != ESP_OK) {
+#ifdef TOIT_STDIN_UART
+    release_uart_stdin();
+#endif
+    return Primitive::os_error(usb_err, process);
+  }
+#endif
 
   bool handed_to_resource = false;
   Defer release_backend { [&] {
     if (handed_to_resource) return;
-#ifdef CONFIG_ESP_CONSOLE_UART
+#ifdef TOIT_STDIN_UART
     release_uart_stdin();
-#else
+#endif
+#ifdef TOIT_STDIN_USB_SERIAL_JTAG
     release_usb_serial_jtag_stdin();
 #endif
   } };
 
-  auto resource = _new StdinResource(group, queue);
+  auto resource = _new StdinResource(group, uart_queue, usb_queue);
   if (resource == null) FAIL(MALLOC_FAILED);
   handed_to_resource = true;
   group->register_resource(resource);
@@ -260,19 +280,58 @@ PRIMITIVE(stdin_read) {
   ARGS(StdinResource, resource)
   USE(resource);
 
-#if !defined(CONFIG_ESP_CONSOLE_UART) && !defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
+#if !defined(TOIT_STDIN_UART) && !defined(TOIT_STDIN_USB_SERIAL_JTAG)
   FAIL(UNSUPPORTED);
 #else
   ByteArray* result = process->allocate_byte_array(STDIN_BUFFER_SIZE, true);
   if (result == null) FAIL(ALLOCATION_FAILED);
 
   ByteArray::Bytes bytes(result);
-  int read_count = ::read(STDIN_FILENO, bytes.address(), STDIN_BUFFER_SIZE);
-  if (read_count < 0) {
-    if (errno == EAGAIN || errno == EWOULDBLOCK) return Smi::from(-1);
-    return Primitive::os_error(errno, process);
+  int read_count = 0;
+  int read_error = 0;
+  bool uart_eof = false;
+#ifdef TOIT_STDIN_UART
+  auto read_uart = [&]() -> int {
+    int count = ::read(STDIN_FILENO, bytes.address(), STDIN_BUFFER_SIZE);
+    if (count < 0) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) return 0;
+      read_error = errno;
+      return -1;
+    }
+    if (count == 0) uart_eof = true;
+    return count;
+  };
+#endif
+#ifdef TOIT_STDIN_USB_SERIAL_JTAG
+  auto read_usb = [&]() -> int {
+    return usb_serial_jtag_read_bytes(bytes.address(), STDIN_BUFFER_SIZE, 0);
+  };
+#endif
+
+#if defined(TOIT_STDIN_UART) && defined(TOIT_STDIN_USB_SERIAL_JTAG)
+  if (resource->read_uart_first()) {
+    read_count = read_uart();
+    if (read_count == 0) read_count = read_usb();
+  } else {
+    read_count = read_usb();
+    if (read_count == 0) read_count = read_uart();
   }
-  if (read_count == 0) return process->null_object();
+  if (read_count > 0) resource->alternate_read_order();
+#elif defined(TOIT_STDIN_UART)
+  read_count = read_uart();
+#else
+  read_count = read_usb();
+#endif
+
+  if (read_count < 0) return Primitive::os_error(read_error, process);
+  if (read_count == 0) {
+#if defined(TOIT_STDIN_UART) && !defined(TOIT_STDIN_USB_SERIAL_JTAG)
+    if (uart_eof) return process->null_object();
+#else
+    USE(uart_eof);
+#endif
+    return Smi::from(-1);
+  }
   if (read_count < STDIN_BUFFER_SIZE) result->resize_external(process, read_count);
   return result;
 #endif


### PR DESCRIPTION
## Summary

- merge ESP32 stdin input from the configured console UART and USB Serial/JTAG backends
- support USB Serial/JTAG input when it is configured as either the primary or secondary console
- allow ESP32 event resources to subscribe to two FreeRTOS queues while preserving shared UART events for `uart.Port.console`
- document that ESP32-S2 USB CDC and other console backends remain unsupported

## Testing

- `make -j4 esp32` (UART-only configuration)
- `make -j4 esp32s3` (primary UART + secondary USB Serial/JTAG)
- `tests/qemu/build-s3-usb-envelope.sh <absolute-build-dir>` (USB Serial/JTAG primary)
- `ctest --test-dir build/host -R stdio --output-on-failure`
- Seeed Studio ESP32-S3 hardware: with `uart.Port.console` open concurrently, `io.stdin` received `merged-usb-input` through the native USB Serial/JTAG connection on `/dev/ttyACM2`
