### PR TITLE
lsp: pull in latest pkg-host

### DIFF
--- a/tools/lsp/server/package.lock
+++ b/tools/lsp/server/package.lock
@@ -1,51 +1,45 @@
 sdk: ^2.0.0-alpha.190
 prefixes:
-  cli: pkg-cli
-  fs: pkg-fs
-  host: pkg-host
-  tar: pkg-tar
+  cli: github.com/toitlang/pkg-cli-2
+  fs: github.com/toitlang/pkg-fs-2
+  host: github.com/toitlang/pkg-host-1
+  tar: github.com/toitlang/pkg-tar-2
 packages:
-  pkg-cli:
-    url: github.com/toitlang/pkg-cli
-    name: cli
-    version: 2.15.0
+  github.com/toitlang/pkg-cli-2:
     hash: 0df45c95994cbda72011cd062ac79983875b676f
     prefixes:
-      desktop: pkg-desktop
-      fs: pkg-fs
-      host: pkg-host
-      lockfile: toit-lockfile
-  pkg-desktop:
-    url: github.com/toitlang/pkg-desktop
-    name: desktop
-    version: 1.1.0
+      desktop: github.com/toitlang/pkg-desktop-1
+      fs: github.com/toitlang/pkg-fs-2
+      host: github.com/toitlang/pkg-host-1
+      lockfile: github.com/toitware/toit-lockfile-1
+    url: github.com/toitlang/pkg-cli
+    version: 2.15.0
+  github.com/toitlang/pkg-desktop-1:
     hash: d6ad1d5c25e16d0c2910a132acba426251b5d87f
     prefixes:
-      host: pkg-host
-  pkg-fs:
-    url: github.com/toitlang/pkg-fs
-    name: fs
-    version: 2.3.1
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitlang/pkg-desktop
+    version: 1.1.0
+  github.com/toitlang/pkg-fs-2:
     hash: 60836d4500317af2093d59d50c117d612c33f1fa
     prefixes:
-      host: pkg-host
-  pkg-host:
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitlang/pkg-fs
+    version: 2.3.1
+  github.com/toitlang/pkg-host-1:
+    hash: 50b7e52052c0b0baa48eef60609ff0f4df2f02b7
     url: github.com/toitlang/pkg-host
-    name: host
-    version: 1.17.0
-    hash: 05a26b5fa1cc73dc64a5e9cc16c40ae5aa24e0fb
-  pkg-tar:
-    url: github.com/toitlang/pkg-tar
-    name: tar
-    version: 2.1.0
+    version: 1.21.0
+  github.com/toitlang/pkg-tar-2:
     hash: c9abee2219ec674a12a2e7cdc9cd7a74af875fe7
     prefixes:
-      host: pkg-host
-  toit-lockfile:
-    url: github.com/toitware/toit-lockfile
-    name: lockfile
-    version: 1.0.0
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitlang/pkg-tar
+    version: 2.1.0
+  github.com/toitware/toit-lockfile-1:
     hash: 47ddd8c13811e6cc368d6fef8f383b855f9d0ada
     prefixes:
-      fs: pkg-fs
-      host: pkg-host
+      fs: github.com/toitlang/pkg-fs-2
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitware/toit-lockfile
+    version: 1.0.0

--- a/tools/lsp/server/package.yaml
+++ b/tools/lsp/server/package.yaml
@@ -7,7 +7,7 @@ dependencies:
     version: ^2.3.1
   host:
     url: github.com/toitlang/pkg-host
-    version: ^1.17.0
+    version: ^1.21.0
   tar:
     url: github.com/toitlang/pkg-tar
     version: ^2.1.0


### PR DESCRIPTION
This fixes `ALREADY_CLOSED` LSP log message spam
(https://github.com/toitlang/pkg-host/pull/100).