### PR TITLE
Fix nightly terminal and I2S failures

### DIFF
--- a/tests/hw/esp32/fail.cmake
+++ b/tests/hw/esp32/fail.cmake
@@ -59,6 +59,9 @@ set(TOIT_SKIP_TESTS
   i2s-board1.toit-esp32-philips24
   i2s-board1.toit-esp32-philips24-slave
   i2s-board1.toit-esp32-msb16-writer-fast-slave
+  # The plain philips16 variant can corrupt the classic ESP32's deep-sleep boot
+  # state and leave it boot-looping on a garbage wake stub.
+  i2s-board1.toit-esp32-philips16
   # Broken on the esp32s3 (same esp-idf I2S issue). Consistently failing in the
   # nightly (6/6) and reproduced locally.
   i2s-board1.toit-esp32s3-pcm8

--- a/tests/terminal/terminal-test-runner-win.cc
+++ b/tests/terminal/terminal-test-runner-win.cc
@@ -21,6 +21,17 @@ static void fail(const char* message, const std::string& output = "") {
   exit(1);
 }
 
+static void fail_process(
+    const char* message,
+    HANDLE process,
+    const std::string& output) {
+  DWORD exit_code = 0;
+  if (!GetExitCodeProcess(process, &exit_code)) fail(message, output);
+  fprintf(stderr, "%s (exit code %lu)\n", message, exit_code);
+  if (!output.empty()) fprintf(stderr, "terminal output:\n%s\n", output.c_str());
+  exit(1);
+}
+
 static void close_if_valid(HANDLE handle) {
   if (handle != NULL && handle != INVALID_HANDLE_VALUE) CloseHandle(handle);
 }
@@ -108,6 +119,7 @@ int main(int argc, char** argv) {
   bool sent_input = false;
   bool resized = false;
   bool saw_done = false;
+  bool process_exited = false;
   ULONGLONG deadline = GetTickCount64() + 10 * 1000;
 
   while (!saw_done && GetTickCount64() < deadline) {
@@ -140,13 +152,25 @@ int main(int argc, char** argv) {
     }
     saw_done = output.find("DONE") != std::string::npos;
 
-    if (!saw_done && WaitForSingleObject(process.hProcess, 0) == WAIT_OBJECT_0) {
-      fail("terminal test exited before completion", output);
+    if (!process_exited &&
+        WaitForSingleObject(process.hProcess, 0) == WAIT_OBJECT_0) {
+      // ConPTY delivers output asynchronously. The process can exit before its
+      // final output is visible in the pipe. Keep draining until DONE or the
+      // existing protocol deadline instead of failing as soon as it exits.
+      process_exited = true;
     }
     if (!saw_done) Sleep(10);
   }
 
-  if (!saw_done) fail("terminal test timed out", output);
+  if (!saw_done) {
+    if (process_exited) {
+      fail_process(
+          "terminal test exited before completion",
+          process.hProcess,
+          output);
+    }
+    fail("terminal test timed out", output);
+  }
   if (WaitForSingleObject(process.hProcess, 5 * 1000) != WAIT_OBJECT_0) {
     fail("terminal test did not exit", output);
   }


### PR DESCRIPTION
## Summary

- keep draining ConPTY output after the Windows terminal child exits, because its final output can arrive asynchronously
- report the actual child exit code when the terminal protocol never reaches `DONE`
- skip the unreliable classic-ESP32 `philips16` I2S hardware variant, which can enter a corrupt deep-sleep boot loop

## Context

The Windows failure stopped reading as soon as the child process handle was signaled. In the failed run, ConPTY had emitted `RAW` and the mode-transition sequences, but the final `RESTORED`, `WATCHING`, and `DONE` output had not reached the pipe yet. The runner now continues draining until `DONE` or the existing protocol deadline. The test remains in the normal, non-flaky test set and all of its assertions remain unchanged.

The September 2 serial run captured the classic ESP32 entering `DEEPSLEEP_RESET` during `philips16`, followed by impossible ROM load addresses and lengths. The underlying four-byte zero-frame defect also reproduces with pure ESP-IDF. Until the fatal state is understood, this exact hardware variant should not gate the nightly.

## Validation

- cross-compiled `terminal-test-runner.exe` with the Win64 MinGW toolchain
- verified the Windows terminal test is selected by the normal CTest set and not by the flaky set
- ran `tests/terminal/terminal-test` successfully on POSIX
- ran `git diff --check`
- reproduced the exact `philips16` test once on the actual classic-ESP32 rig; it completed with three known four-byte zero insertions and normal boot state
- confirmed the ESP32-S3 SPI test passes after the physical rig connection was corrected, so it remains enabled
