### PR TITLE
LSP utilization improvements

### DIFF
--- a/tests/lsp/cancel-compiler-test.toit
+++ b/tests/lsp/cancel-compiler-test.toit
@@ -70,3 +70,22 @@ test client/LspClient:
   client.send-cancel id
   // Just shouldn't do anything.
   client.wait-for-idle
+
+  // Canceling must kill the compiler. Without the kill, the server only
+  // becomes idle once the compiler has finished or has hit the timeout.
+  mock-compiler.set-completion-result
+    "SLOW\n20000000\n\n0\n0\n0\n0\nfoo\n-1\nbar\n-1\n"
+  start := Time.monotonic-us
+  completions = client.send-completion-request --uri=uri 1 2 --id-callback=:
+    client.send-cancel it
+  expect-equals -32800 completions["code"]
+  client.wait-for-idle
+  elapsed-ms := (Time.monotonic-us - start) / 1000
+  print "idle $elapsed-ms ms after cancel"
+  expect elapsed-ms < 5000
+
+  // The server must still work afterwards.
+  mock-compiler.set-completion-result
+    "\n0\n0\n0\n0\nfoo\n-1\nbar\n-1\n"
+  completions = client.send-completion-request --uri=uri 1 2
+  expect-equals 2 completions.size

--- a/tests/lsp/concurrency-limit-compiler-test.toit
+++ b/tests/lsp/concurrency-limit-compiler-test.toit
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+// Tests that the number of concurrently running compilers is limited.
+
+import .lsp-client show LspClient run-client-test
+import .mock-compiler
+import expect show *
+import monitor
+
+REQUEST-COUNT ::= 6
+COMPILER-DELAY-US ::= 300_000
+
+main args:
+  // Run the same batch of requests with a limit that serializes them, with a
+  // limit that lets all of them run at the same time, and without any limit.
+  serialized-ms := measure args --max-concurrent=1
+  concurrent-ms := measure args --max-concurrent=REQUEST-COUNT
+  unlimited-ms := measure args --max-concurrent=0
+  print "serialized: $(serialized-ms)ms, concurrent: $(concurrent-ms)ms, unlimited: $(unlimited-ms)ms"
+  // Serialized, the requests take REQUEST-COUNT times as long. Be generous
+  // with the factor, so that a loaded machine doesn't make the test flaky.
+  expect serialized-ms > concurrent-ms * 2
+  expect serialized-ms > unlimited-ms * 2
+
+measure args --max-concurrent/int -> int:
+  result := 0
+  run-client-test
+      args
+      --use-mock
+      --pre-initialize=: it.configuration["maxConcurrentCompilers"] = max-concurrent:
+    result = run-requests it
+  return result
+
+run-requests client/LspClient -> int:
+  mock-compiler := MockCompiler client
+
+  uri := "untitled:Untitled-1"
+  path := client.to-path uri
+
+  mock-compiler.set-mock-data --path=path (MockData [] [])
+  mock-compiler.set-analysis-result (mock-compiler.build-analysis-answer --path=path)
+  client.send-did-open --uri=uri --text="Ignored content"
+
+  // Every completion request runs a compiler that takes $COMPILER-DELAY-US.
+  mock-compiler.set-completion-result
+      "SLOW\n$COMPILER-DELAY-US\n\n0\n0\n0\n0\nfoo\n-1\nbar\n-1\n"
+
+  // The requests must overlap, so we must not wait for idle in between.
+  client.always-wait-for-idle = false
+  done := monitor.Semaphore
+  start := Time.monotonic-us
+  REQUEST-COUNT.repeat:
+    task:: catch --trace:
+      completions := client.send-completion-request --uri=uri 1 2
+      expect-equals 2 completions.size
+      done.up
+  REQUEST-COUNT.repeat: done.down
+  elapsed-ms := (Time.monotonic-us - start) / 1000
+
+  client.always-wait-for-idle = true
+  client.wait-for-idle
+  return elapsed-ms

--- a/tests/lsp/debounce-compiler-test.toit
+++ b/tests/lsp/debounce-compiler-test.toit
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+// Tests that analyses triggered by 'didChange' are debounced.
+
+import .lsp-client show LspClient run-client-test
+import .mock-compiler
+import expect show *
+
+DEBOUNCE-MS ::= 500
+
+main args:
+  run-client-test
+      args
+      --use-mock
+      --pre-initialize=: it.configuration["analysisDebounceMs"] = DEBOUNCE-MS:
+    test it
+
+test client/LspClient:
+  mock-compiler := MockCompiler client
+
+  uri := "untitled:Untitled-1"
+  path := client.to-path uri
+
+  mock-compiler.set-mock-data --path=path (MockData [] [])
+  mock-compiler.set-analysis-result (mock-compiler.build-analysis-answer --path=path)
+
+  // Every analysis of the document publishes its diagnostics. Count them.
+  diagnostics-count := 0
+  client.install-handler "textDocument/publishDiagnostics":: | params/Map |
+    if params["uri"] == uri: diagnostics-count++
+
+  // Opening a document is analyzed right away.
+  client.send-did-open --uri=uri --text="Ignored content"
+  expect-equals 1 diagnostics-count
+
+  // A burst of changes leads to two analyses: one for the first change, and
+  // one once the changes have stopped.
+  client.always-wait-for-idle = false
+  5.repeat:
+    client.send-did-change --uri=uri "Ignored content $it"
+    sleep --ms=(DEBOUNCE-MS / 5)
+  client.always-wait-for-idle = true
+  // The pending analysis must count as work in progress: the server must not
+  // report idle before it has run.
+  client.wait-for-idle
+  expect-equals 3 diagnostics-count
+
+  // Changes that are further apart than the debounce delay each start a new
+  // burst and are thus analyzed individually.
+  client.always-wait-for-idle = false
+  3.repeat:
+    client.send-did-change --uri=uri "Ignored content again $it"
+    sleep --ms=(DEBOUNCE-MS * 2)
+  client.always-wait-for-idle = true
+  client.wait-for-idle
+  expect-equals 6 diagnostics-count

--- a/tests/lsp/lsp-client.toit
+++ b/tests/lsp/lsp-client.toit
@@ -46,6 +46,9 @@ run-client-test
         --spawn-process=spawn-process
         --pre-initialize=: | client args |
             client.configuration["reproDir"] = repro-dir
+            // Tests send a 'didChange' and then immediately wait for the
+            // analysis. Don't make them wait for the debounce.
+            client.configuration["analysisDebounceMs"] = 0
             pre-initialize.call client args
   finally:
     directory.rmdir --recursive repro-dir

--- a/tests/package.lock
+++ b/tests/package.lock
@@ -1,81 +1,70 @@
 sdk: ^2.0.0-alpha.190
 prefixes:
-  ar: pkg-ar
-  certificate_roots: toit-cert-roots
-  cli: pkg-cli
-  font_x11_adobe: pkg-font-x11-adobe
-  fs: pkg-fs
-  host: pkg-host
-  partition-table: toit-partition-table-esp32
-  semver: toit-semver
-  tar: pkg-tar
+  ar: github.com/toitlang/pkg-ar-1
+  certificate_roots: github.com/toitware/toit-cert-roots-1
+  cli: github.com/toitlang/pkg-cli-2
+  font_x11_adobe: github.com/toitlang/pkg-font-x11-adobe-0
+  fs: github.com/toitlang/pkg-fs-2
+  host: github.com/toitlang/pkg-host-1
+  partition-table: github.com/toitware/toit-partition-table-esp32-1
+  semver: github.com/toitware/toit-semver-1
+  tar: github.com/toitlang/pkg-tar-2
 packages:
-  pkg-ar:
-    url: github.com/toitlang/pkg-ar
-    name: ar
-    version: 1.4.1
+  github.com/toitlang/pkg-ar-1:
     hash: 66f0359ed405dbebbc06a0cda9864b10b2d6aa34
-  pkg-cli:
-    url: github.com/toitlang/pkg-cli
-    name: cli
-    version: 2.16.0
+    url: github.com/toitlang/pkg-ar
+    version: 1.4.1
+  github.com/toitlang/pkg-cli-2:
     hash: 8b57ca731ab1798a2a97c4afc1ea464072cf2cbb
     prefixes:
-      desktop: pkg-desktop
-      fs: pkg-fs
-      host: pkg-host
-      lockfile: toit-lockfile
-  pkg-desktop:
-    url: github.com/toitlang/pkg-desktop
-    name: desktop
-    version: 1.1.0
+      desktop: github.com/toitlang/pkg-desktop-1
+      fs: github.com/toitlang/pkg-fs-2
+      host: github.com/toitlang/pkg-host-1
+      lockfile: github.com/toitware/toit-lockfile-1
+    url: github.com/toitlang/pkg-cli
+    version: 2.16.0
+  github.com/toitlang/pkg-desktop-1:
     hash: d6ad1d5c25e16d0c2910a132acba426251b5d87f
     prefixes:
-      host: pkg-host
-  pkg-font-x11-adobe:
-    url: github.com/toitlang/pkg-font-x11-adobe
-    name: font_x11_adobe
-    version: 0.1.0
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitlang/pkg-desktop
+    version: 1.1.0
+  github.com/toitlang/pkg-font-x11-adobe-0:
     hash: f844400722165252148f087cdf189abab0a47f3d
-  pkg-fs:
-    url: github.com/toitlang/pkg-fs
-    name: fs
-    version: 2.3.1
+    url: github.com/toitlang/pkg-font-x11-adobe
+    version: 0.1.0
+  github.com/toitlang/pkg-fs-2:
     hash: 60836d4500317af2093d59d50c117d612c33f1fa
     prefixes:
-      host: pkg-host
-  pkg-host:
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitlang/pkg-fs
+    version: 2.3.1
+  github.com/toitlang/pkg-host-1:
+    hash: 50b7e52052c0b0baa48eef60609ff0f4df2f02b7
     url: github.com/toitlang/pkg-host
-    name: host
-    version: 1.17.0
-    hash: 05a26b5fa1cc73dc64a5e9cc16c40ae5aa24e0fb
-  pkg-tar:
-    url: github.com/toitlang/pkg-tar
-    name: tar
-    version: 2.1.0
+    version: 1.21.0
+  github.com/toitlang/pkg-tar-2:
     hash: c9abee2219ec674a12a2e7cdc9cd7a74af875fe7
     prefixes:
-      host: pkg-host
-  toit-cert-roots:
-    url: github.com/toitware/toit-cert-roots
-    name: certificate-roots
-    version: 1.11.0
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitlang/pkg-tar
+    version: 2.1.0
+  github.com/toitware/toit-cert-roots-1:
     hash: c117dbba4757d7c69e91af7a875ab6989f051a33
-  toit-lockfile:
-    url: github.com/toitware/toit-lockfile
-    name: lockfile
-    version: 1.0.0
+    url: github.com/toitware/toit-cert-roots
+    version: 1.11.0
+  github.com/toitware/toit-lockfile-1:
     hash: 47ddd8c13811e6cc368d6fef8f383b855f9d0ada
     prefixes:
-      fs: pkg-fs
-      host: pkg-host
-  toit-partition-table-esp32:
-    url: github.com/toitware/toit-partition-table-esp32
-    name: partition-table
-    version: 1.4.0
+      fs: github.com/toitlang/pkg-fs-2
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitware/toit-lockfile
+    version: 1.0.0
+  github.com/toitware/toit-partition-table-esp32-1:
     hash: 9ee4032b913a00d0c0f87446261d034842b707f1
-  toit-semver:
-    url: github.com/toitware/toit-semver
-    name: semver
-    version: 1.2.0
+    url: github.com/toitware/toit-partition-table-esp32
+    version: 1.4.0
+  github.com/toitware/toit-semver-1:
     hash: 7b862ca7b40601ae2a63ec6ffbacebb48c929e02
+    url: github.com/toitware/toit-semver
+    version: 1.2.0

--- a/tests/package.yaml
+++ b/tests/package.yaml
@@ -10,13 +10,13 @@ dependencies:
     version: ^2.16.0
   font_x11_adobe:
     url: github.com/toitlang/pkg-font-x11-adobe
-    version: ^0.1.0
+    version: ~0.1.0
   fs:
     url: github.com/toitlang/pkg-fs
     version: ^2.3.1
   host:
     url: github.com/toitlang/pkg-host
-    version: ^1.17.0
+    version: ^1.21.0
   partition-table:
     url: github.com/toitware/toit-partition-table-esp32
     version: ^1.4.0

--- a/tools/lsp/server/compiler-scheduler.toit
+++ b/tools/lsp/server/compiler-scheduler.toit
@@ -1,0 +1,151 @@
+// Copyright (C) 2026 Toit contributors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; version
+// 2.1 only.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// The license can be found in the file `LICENSE` in the top level
+// directory of this repository.
+
+import monitor
+
+import .verbose
+
+/**
+Decides when compiler actions run.
+
+All compiler work of the server goes through this class: $run executes an
+  action as soon as a compiler slot is free, and $schedule debounces and
+  coalesces actions that are triggered in bursts, like the analysis after
+  every keystroke. Heuristics about how often and how many compilers run
+  live here and not in the server.
+*/
+class CompilerScheduler:
+  slots_ /Slots_ ::= Slots_
+  /// Tasks that currently hold a slot. Nested $run calls reuse the slot.
+  slot-holders_ /List ::= []
+  /// Bursts of scheduled actions that are still being handled, keyed by id.
+  bursts_ /Map ::= {:}
+  /// Called when the last pending burst of scheduled actions has finished.
+  /// Runs under a cancelation guard and must not yield.
+  on-idle /Lambda? := null
+  /// How long a burst must be quiet before a scheduled action runs. A value <=
+  /// 0 disables debouncing.
+  debounce-ms /int := ?
+
+  constructor --max-concurrent/int --.debounce-ms/int:
+    slots_.limit = max-concurrent
+
+  /// Sets how many compiler actions may run at the same time. A value <= 0 means no limit.
+  max-concurrent= value/int -> none:
+    slots_.limit = value
+
+  /// Whether no scheduled action is pending or running.
+  is-idle -> bool:
+    return bursts_.is-empty
+
+  /**
+  Runs the compiler action $block as soon as a compiler slot is free.
+
+  The $id names the kind of action, for example "completion".
+  A nested call from within a running action reuses the slot of that action.
+
+  Returns the result of the $block.
+  */
+  run --id/string [block] -> any:
+    current := Task.current
+    if slot-holders_.contains current: return block.call
+    verbose: "Waiting for compiler slot: $id"
+    slots_.acquire
+    slot-holders_.add current
+    try:
+      verbose: "Running compiler action: $id"
+      return block.call
+    finally:
+      critical-do:
+        slot-holders_.remove current
+        slots_.release
+
+  /**
+  Schedules the compiler $action for the given $id and $arg.
+
+  Calls with the same $id are coalesced into bursts. The first call of a
+    burst runs the $action right away with a list containing just $arg, so
+    that a single change gets feedback without delay. Calls that follow
+    within the debounce delay of each other are collected. Once the burst has
+    been quiet for that long, the $action is called once with all collected
+    args. Equal args are only passed once.
+
+  The $action takes a list of args. All actions scheduled under the same $id
+    must be interchangeable, since only one of them is used for a coalesced run.
+  */
+  schedule --id/string --arg/any action/Lambda -> none:
+    if debounce-ms <= 0:
+      run --id=id: action.call [arg]
+      return
+
+    deadline-us := Time.monotonic-us + debounce-ms * 1_000
+    burst/Burst_? := bursts_.get id
+    if burst:
+      burst.add arg action deadline-us
+      return
+
+    burst = Burst_ action deadline-us
+    bursts_[id] = burst
+    task:: catch --trace:
+      try:
+        run --id=id: action.call [arg]
+        while true:
+          // Just keep sleeping until we wake up after the deadline.
+          remaining-us := burst.deadline-us - Time.monotonic-us
+          if remaining-us > 0:
+            sleep (Duration --us=remaining-us)
+            continue
+          // The burst has been quiet for long enough. Run what accumulated
+          // while we were sleeping (or running). If nothing did, the burst is over.
+          if burst.args.is-empty: break
+          args := List.from burst.args
+          burst.args.clear
+          run --id=id: burst.action.call args
+      finally:
+        // This task isn't canceled today, but if it ever is, the unwinding
+        // must not drop the idle notification.
+        critical-do:
+          // Calls that arrive from here on start a new burst.
+          bursts_.remove id
+          if bursts_.is-empty and on-idle: on-idle.call
+
+class Burst_:
+  args /Set ::= {}
+  action /Lambda := ?
+  /// The monotonic time at which the burst is considered quiet.
+  deadline-us /int := ?
+
+  constructor .action .deadline-us:
+
+  add arg/any action/Lambda deadline-us/int -> none:
+    args.add arg
+    this.action = action
+    this.deadline-us = deadline-us
+
+monitor Slots_:
+  /// Max number of slots, <= 0 means no limit.
+  limit_ /int := 0
+  taken_ /int := 0
+
+  // A method instead of a plain field, so that the monitor wakes up waiters.
+  limit= value/int -> none:
+    limit_ = value
+
+  acquire -> none:
+    await: limit_ <= 0 or taken_ < limit_
+    taken_++
+
+  release -> none:
+    taken_--

--- a/tools/lsp/server/compiler.toit
+++ b/tools/lsp/server/compiler.toit
@@ -103,9 +103,13 @@ class Compiler:
         try:
           sleep --ms=timeout-ms_
           if not has-terminated:
-            SIGKILL ::= 9
-            pipe.kill_ process.pid SIGKILL
-            was-killed-because-of-timeout = true
+            // Don't log the broken-pipe errors the file server sees when the
+            // compiler goes away.
+            file-server.mark-shutting-down
+            // On Windows, terminating a process that has already exited on its
+            // own fails. Nothing to do in that case.
+            if (catch: process.kill --hard) == null:
+              was-killed-because-of-timeout = true
         finally:
           timeout-task = null
 
@@ -118,30 +122,47 @@ class Compiler:
       reader := io.Reader.adapt to-parser
       read-callback.call reader
     finally:
+      is-canceled := Task.current.is-canceled
       if timeout-task: timeout-task.cancel
-      file-server.close
-      to-parser.close
-      multiplex.close
+      // The cleanup below blocks (most notably in 'process.wait'). If we are
+      // unwinding because of a cancelation, those blocking operations would
+      // throw immediately, leaving the compiler process running and unreaped.
+      critical-do:
+        if is-canceled:
+          // The request was canceled. Kill the compiler instead of letting it
+          // run to completion: closing its pipes while it is still talking to
+          // us would just make it complain on stderr.
+          // Nothing has reaped the process yet ('process.wait' below is the
+          // only place that does), so the pid is still valid. On Windows,
+          // terminating a process that has already exited on its own fails,
+          // which is fine.
+          file-server.mark-shutting-down
+          catch: process.kill --hard
 
-      exit-value := process.wait
-      verbose: "Compiler terminated with exit_signal: $(pipe.exit-signal exit-value)"
-      has-terminated = true
-      if not ignore-crashes:
-        exit-signal := pipe.exit-signal exit-value
-        if exit-signal:
-          // Assume that any exit-signal was because of a crash of the compiler.
-          if on-crash_:
-            reason := (pipe.signal-to-string exit-signal)
-            if was-killed-because-of-timeout: reason += "\nKilled after timeout"
-            on-crash_.call flags compiler-input reason file-server.protocol
-          did-crash = true
+        file-server.close
+        to-parser.close
+        multiplex.close
+
+        exit-value := process.wait
+        verbose: "Compiler terminated with exit_signal: $(pipe.exit-signal exit-value)"
+        has-terminated = true
+        // A canceled run killed the compiler on purpose. Don't report that as a crash.
+        if not ignore-crashes and not is-canceled:
+          exit-signal := pipe.exit-signal exit-value
+          if exit-signal:
+            // Assume that any exit-signal was because of a crash of the compiler.
+            if on-crash_:
+              reason := (pipe.signal-to-string exit-signal)
+              if was-killed-because-of-timeout: reason += "\nKilled after timeout"
+              on-crash_.call flags compiler-input reason file-server.protocol
+            did-crash = true
     return not did-crash
 
   analyze --project-uri/string? uris/List -> AnalysisResult?:
     // Work around small stack size.
     // TODO(1268): remove work-around
     latch := monitor.Latch
-    task:: catch --trace:
+    analysis-task := task:: catch --trace:
       paths := uris.map: | uri |
         path := translator.to-path uri --to-compiler
         // There are multiple ways to encode URIs. Check that the uri is already
@@ -239,7 +260,12 @@ class Compiler:
             if on-error_: on-error_.call "LSP Server: unexpected line from compiler: $line"
           result = AnalysisResult diagnostics-per-uri diagnostics-without-position summary
       latch.set (completed-successfully ? result : null)
-    return latch.get
+    try:
+      return latch.get
+    finally:
+      // If we are unwinding (typically because the request was canceled), the
+      // task that actually runs the compiler must be stopped as well.
+      if not latch.has-value: analysis-task.cancel
 
   /**
   Gets all the completion from the compiler and calls the given $block

--- a/tools/lsp/server/file_server.toit
+++ b/tools/lsp/server/file_server.toit
@@ -131,6 +131,7 @@ class PipeFileServer implements FileServer:
   protocol / FileServerProtocol
   to-compiler_   / io.CloseableWriter
   from-compiler_ / io.CloseableReader
+  is-shutting-down_ / bool := false
 
   constructor .protocol .to-compiler_ .from-compiler_:
 
@@ -140,11 +141,18 @@ class PipeFileServer implements FileServer:
   */
   run -> string:
     task::
-      catch --trace:
+      // Once the compiler process is going away, writing to its stdin fails
+      // with "Broken pipe". These are expected during teardown and should not
+      // be logged.
+      catch --trace=(: not is-shutting-down_):
         protocol.handle from-compiler_ to-compiler_
     return "-2"
 
+  mark-shutting-down -> none:
+    is-shutting-down_ = true
+
   close:
+    mark-shutting-down
     from-compiler_.close
     to-compiler_.close
 

--- a/tools/lsp/server/multiplex.toit
+++ b/tools/lsp/server/multiplex.toit
@@ -68,6 +68,10 @@ class MultiplexConnection:
         if frame-size < 0:
           frame-size = -frame-size
           to = compiler-to-fs_
+        // The compiler may die mid-frame, leaving a header without its
+        // payload. Treat a truncated frame like a closed connection instead
+        // of throwing UNEXPECTED_END_OF_READER out of the dispatch task.
+        if not buffered-from-compiler_.try-ensure-buffered frame-size: return
         data := buffered-from-compiler_.read-bytes frame-size
         to.write_ data
     finally:

--- a/tools/lsp/server/rpc.toit
+++ b/tools/lsp/server/rpc.toit
@@ -118,10 +118,13 @@ class RpcConnection:
     else:
       payload = json.encode packet
     mutex_.do:
-      writeln_ "Content-Length: $(payload.size)"
-      writeln_ "Content-Type: $(use-ubjson_ ? CONTENT-TYPE-UBJSON_ : CONTENT-TYPE-JSON_)"
-      writeln_ ""
-      write_   payload
+      // A half-written packet would corrupt the stream for good. Don't let a
+      // cancelation or deadline interrupt the write.
+      critical-do --no-respect-deadline:
+        writeln_ "Content-Length: $(payload.size)"
+        writeln_ "Content-Type: $(use-ubjson_ ? CONTENT-TYPE-UBJSON_ : CONTENT-TYPE-JSON_)"
+        writeln_ ""
+        write_   payload
 
   read:
     while true:

--- a/tools/lsp/server/server.toit
+++ b/tools/lsp/server/server.toit
@@ -114,29 +114,44 @@ class LspServer:
 
   last-crash-report-time_ := null
 
-  /// A set of open request-ids
-  /// When a request is canceled, it is removed from the set, so
-  ///   that we don't respond multiple times.
-  open-requests_ /Set := {}
+  /**
+  A map from open request-ids to the task that handles the request.
+
+  When a request is canceled, the corresponding task is canceled and the entry
+    is removed from the map, so that we don't respond multiple times.
+  */
+  open-requests_ /Map := {:}
 
   constructor .connection_ .toit-path-override_:
 
   run -> none:
     while true:
-      parsed := connection_.read
-      if parsed == null: return
-      id := parsed.get "id"
-      if id: open-requests_.add id
-      task:: catch --trace:
-        active-requests_++
-        method := parsed["method"]
-        params := parsed.get "params"
-        verbose: "Request for $method $id"
-        response := handle_ method params
-        verbose: "Request $method $id handled"
-        if id and (open-requests_.contains id):
-          open-requests_.remove id
-          connection_.reply id response
+      request := connection_.read
+      if not request: return
+      id := request.get "id"
+      handler-task := task:: catch --trace:
+        handle-request-in-task_ request
+      // Register the task for cancelation.
+      if id: open-requests_[id] = handler-task
+
+  handle-request-in-task_ request/Map -> none:
+    active-requests_++
+    id := request.get "id"
+    try:
+      method := request["method"]
+      params := request.get "params"
+      verbose: "Request for $method $id"
+      response := handle_ method params
+      verbose: "Request $method $id handled"
+      if id and (open-requests_.contains id):
+        // Only reply if we hadn't already replied with "Cancelled".
+        open-requests_.remove id
+        connection_.reply id response
+    finally:
+      // The handler task may be unwinding because the request was
+      // canceled. Clean up under cancelation guard.
+      critical-do:
+        if id: open-requests_.remove id
         active-requests_--
         if active-requests_ == 0 and not on-idle-callbacks_.is-empty:
           callbacks := on-idle-callbacks_
@@ -247,9 +262,13 @@ class LspServer:
 
   cancel params/CancelParams -> none:
     id := params.id
-    task := open-requests_.get id
-    if task:
+    handler-task/Task? := open-requests_.get id
+    if handler-task:
       open-requests_.remove id
+      // Actually abort the work that is done for this request. The handler
+      // task unwinds at its next blocking operation, which lets $Compiler.run
+      // kill and reap the compiler process it may have started.
+      handler-task.cancel
       connection_.reply id
           ResponseError
             --code=ErrorCodes.request-cancelled
@@ -623,107 +642,113 @@ class LspServer:
 
     // Documents for which the summary changed.
     changed-summary-documents := {}
-    // Documents for which we want to report diagnostics.
-    report-diagnostics-documents := {}
+    // Documents that need to be analyzed as a result of the changes.
+    documents-needing-analysis/Set? := null
+    // Applying the result and reporting diagnostics must not be interrupted
+    // by a cancelation of the request, or the bookkeeping ends up
+    // half-applied.
+    critical-do:
+      // Documents for which we want to report diagnostics.
+      report-diagnostics-documents := {}
 
-    // Always report diagnostics for the given uris, unless there is a more recent
-    // analysis already, or if the document has been updated in the meantime.
-    uris.do: | uri |
-      doc := analyzed-documents.get-or-create --uri=uri
-      opened-doc := documents_.get-opened --uri=uri
-      content-revision := opened-doc ? opened-doc.revision : -1
-      if not doc.analysis-revision >= revision and not content-revision > revision:
-        report-diagnostics-documents.add uri
+      // Always report diagnostics for the given uris, unless there is a more recent
+      // analysis already, or if the document has been updated in the meantime.
+      uris.do: | uri |
+        doc := analyzed-documents.get-or-create --uri=uri
+        opened-doc := documents_.get-opened --uri=uri
+        content-revision := opened-doc ? opened-doc.revision : -1
+        if not doc.analysis-revision >= revision and not content-revision > revision:
+          report-diagnostics-documents.add uri
 
-    summaries.do: |summary-uri summary|
-      assert: summary != null
-      opened := documents_.get-opened --uri=summary-uri
-      content-revision := opened ? opened.revision : -1
-      update-result := analyzed-documents.update-document-after-analysis
-          --uri=summary-uri
-          --analysis-revision=revision
-          --content-revision=content-revision
-          --summary=summary
-      has-changed-summary := (update-result & AnalyzedDocuments.SUMMARY-CHANGED-EXTERNALLY-BIT) != 0
-      first-analysis-after-content-change :=
-          (update-result & AnalyzedDocuments.FIRST-ANALYSIS-AFTER-CONTENT-CHANGE-BIT) != 0
+      summaries.do: |summary-uri summary|
+        assert: summary != null
+        opened := documents_.get-opened --uri=summary-uri
+        content-revision := opened ? opened.revision : -1
+        update-result := analyzed-documents.update-document-after-analysis
+            --uri=summary-uri
+            --analysis-revision=revision
+            --content-revision=content-revision
+            --summary=summary
+        has-changed-summary := (update-result & AnalyzedDocuments.SUMMARY-CHANGED-EXTERNALLY-BIT) != 0
+        first-analysis-after-content-change :=
+            (update-result & AnalyzedDocuments.FIRST-ANALYSIS-AFTER-CONTENT-CHANGE-BIT) != 0
 
-      // If the summary has changed, it either means that:
-      //  - this was one of the $uris that was analyzed
-      //  - the $summary_uri depends on one of the $uris (but was also reachable from them)
-      //  - the $summary_uri (or one of its dependencies) was changed. This could be because
-      //    of a change on disk, or because of a `did_change` call. In the latter case,
-      //    there would still be another analysis running, but this one completed earlier.
-      if has-changed-summary:
-        changed-summary-documents.add summary-uri
-      if has-changed-summary or first-analysis-after-content-change:
-        report-diagnostics-documents.add summary-uri
-      dep-document := analyzed-documents.get-existing --uri=summary-uri
-      request-revision := dep-document.analysis-requested-by-revision
-      if request-revision != -1 and request-revision < revision:
-        report-diagnostics-documents.add summary-uri
-
-    // All reverse dependencies of changed documents need to have their diagnostics printed.
-    // We add all transitive dependencies, as it's hard to track implicit exports.
-    // For example, the return type of a method, requires all users of the method
-    //   to check whether a member call of the result is now allowed or not.
-    //   Say class 'A' in lib1 has a method 'foo' that is changed to take an additional parameter.
-    //   Say lib2 imports lib1 and return an 'A' from its 'bar' method.
-    //   Say lib3 imports lib2 and calls `bar.foo`. This call needs a diagnostic change, since
-    //     the 'foo' method now requires an additional parameter.
-    //
-    // This can happen multiple layers down.
-    // Note that we do this only if the summary of the initial file changes. As such, we
-    //   usually don't analyze everything.
-    //
-    // We will also remove files that are in a different project-root. During the
-    //   reverse dependency creation we add them (so we don't end up in an infinite
-    //   recursion), but they will be removed just afterwards.
-    changed-summary-documents.do:
-      document := analyzed-documents.get-existing --uri=it
-      add-transitive-reverse-deps_
-          --analyzed=analyzed-documents
-          --start-uris=document.reverse-deps
-          --result=report-diagnostics-documents
-
-    // Remove the documents that are not in the same project-root, or are in
-    // .packages (assuming we don't want them).
-    should-report-package-diagnostics := settings_.should-report-package-diagnostics
-    report-diagnostics-documents.filter --in-place: | uri/string |
-      document-project-uri := documents_.project-uri-for --uri=uri
-      if document-project-uri != project-uri: continue.filter false
-      if not should-report-package-diagnostics and is-inside-dot-packages --uri=uri:
-        // Only report diagnostics for package files if they are open.
-        if not documents_.get-opened --uri=uri:
-          continue.filter false
-      true
-
-    // Send the diagnostics we have to the client.
-    report-diagnostics-documents.do: |uri|
-      document := analyzed-documents.get-existing --uri=uri
-      request-revision := document.analysis-requested-by-revision
-      was-analyzed := summaries.contains uri
-      if was-analyzed:
-        diagnostics := diagnostics-per-uri.get uri --if-absent=: []
-        send-diagnostics (PushDiagnosticsParams --uri=uri --diagnostics=diagnostics)
+        // If the summary has changed, it either means that:
+        //  - this was one of the $uris that was analyzed
+        //  - the $summary_uri depends on one of the $uris (but was also reachable from them)
+        //  - the $summary_uri (or one of its dependencies) was changed. This could be because
+        //    of a change on disk, or because of a `did_change` call. In the latter case,
+        //    there would still be another analysis running, but this one completed earlier.
+        if has-changed-summary:
+          changed-summary-documents.add summary-uri
+        if has-changed-summary or first-analysis-after-content-change:
+          report-diagnostics-documents.add summary-uri
+        dep-document := analyzed-documents.get-existing --uri=summary-uri
+        request-revision := dep-document.analysis-requested-by-revision
         if request-revision != -1 and request-revision < revision:
-          // Mark the request as done.
-          document.analysis-requested-by-revision = -1
-      else if request-revision < revision:
-        document.analysis-requested-by-revision = revision
+          report-diagnostics-documents.add summary-uri
 
-    // Local lambda that returns whether a document needs analysis.
-    needs-analysis := : |uri|
-      document := analyzed-documents.get-existing --uri=uri
-      up-to-date := document.analysis-revision >= revision
-      opened := documents_.get-opened --uri=uri
-      content-revision := opened ? opened.revision : -1
-      will-be-analyzed := content-revision > revision
-      not up-to-date and not will-be-analyzed
+      // All reverse dependencies of changed documents need to have their diagnostics printed.
+      // We add all transitive dependencies, as it's hard to track implicit exports.
+      // For example, the return type of a method, requires all users of the method
+      //   to check whether a member call of the result is now allowed or not.
+      //   Say class 'A' in lib1 has a method 'foo' that is changed to take an additional parameter.
+      //   Say lib2 imports lib1 and return an 'A' from its 'bar' method.
+      //   Say lib3 imports lib2 and calls `bar.foo`. This call needs a diagnostic change, since
+      //     the 'foo' method now requires an additional parameter.
+      //
+      // This can happen multiple layers down.
+      // Note that we do this only if the summary of the initial file changes. As such, we
+      //   usually don't analyze everything.
+      //
+      // We will also remove files that are in a different project-root. During the
+      //   reverse dependency creation we add them (so we don't end up in an infinite
+      //   recursion), but they will be removed just afterwards.
+      changed-summary-documents.do:
+        document := analyzed-documents.get-existing --uri=it
+        add-transitive-reverse-deps_
+            --analyzed=analyzed-documents
+            --start-uris=document.reverse-deps
+            --result=report-diagnostics-documents
 
-    // See which documents need to be analyzed as a result of changes.
-    documents-needing-analysis := report-diagnostics-documents.filter --in-place: // Reuse the set.
-      needs-analysis.call it
+      // Remove the documents that are not in the same project-root, or are in
+      // .packages (assuming we don't want them).
+      should-report-package-diagnostics := settings_.should-report-package-diagnostics
+      report-diagnostics-documents.filter --in-place: | uri/string |
+        document-project-uri := documents_.project-uri-for --uri=uri
+        if document-project-uri != project-uri: continue.filter false
+        if not should-report-package-diagnostics and is-inside-dot-packages --uri=uri:
+          // Only report diagnostics for package files if they are open.
+          if not documents_.get-opened --uri=uri:
+            continue.filter false
+        true
+
+      // Send the diagnostics we have to the client.
+      report-diagnostics-documents.do: |uri|
+        document := analyzed-documents.get-existing --uri=uri
+        request-revision := document.analysis-requested-by-revision
+        was-analyzed := summaries.contains uri
+        if was-analyzed:
+          diagnostics := diagnostics-per-uri.get uri --if-absent=: []
+          send-diagnostics (PushDiagnosticsParams --uri=uri --diagnostics=diagnostics)
+          if request-revision != -1 and request-revision < revision:
+            // Mark the request as done.
+            document.analysis-requested-by-revision = -1
+        else if request-revision < revision:
+          document.analysis-requested-by-revision = revision
+
+      // Local lambda that returns whether a document needs analysis.
+      needs-analysis := : |uri|
+        document := analyzed-documents.get-existing --uri=uri
+        up-to-date := document.analysis-revision >= revision
+        opened := documents_.get-opened --uri=uri
+        content-revision := opened ? opened.revision : -1
+        will-be-analyzed := content-revision > revision
+        not up-to-date and not will-be-analyzed
+
+      // See which documents need to be analyzed as a result of changes.
+      documents-needing-analysis = report-diagnostics-documents.filter --in-place: // Reuse the set.
+        needs-analysis.call it
 
     if not documents-needing-analysis.is-empty:
       // It's highly unlikely that a reverse dependency changes its summary as a result

--- a/tools/lsp/server/server.toit
+++ b/tools/lsp/server/server.toit
@@ -21,6 +21,7 @@ import host.file
 import host.directory
 import host.pipe
 import io
+import monitor
 
 import .protocol.change
 import .protocol.completion
@@ -37,6 +38,7 @@ import .protocol.hover
 import .protocol-toit
 
 import .compiler
+import .compiler-scheduler
 import .documents
 import .file-server
 import .repro
@@ -48,6 +50,8 @@ import .toitdoc-markdown show ToitdocMarkdownVisitor
 
 DEFAULT-SETTINGS /Map ::= {:}
 DEFAULT-TIMEOUT-MS ::= 10_000
+DEFAULT-MAX-CONCURRENT-COMPILERS ::= 4
+DEFAULT-ANALYSIS-DEBOUNCE-MS ::= 250
 DEFAULT-REPRO-DIR ::= "/tmp/lsp_repros"
 CRASH-REPORT-RATE-LIMIT-MS ::= 30_000
 
@@ -87,6 +91,13 @@ monitor Settings:
   timeout-ms -> int:
     return get_ "timeoutMs" --if-absent=: DEFAULT-TIMEOUT-MS
 
+  analysis-debounce-ms -> int:
+    return get_ "analysisDebounceMs" --if-absent=: DEFAULT-ANALYSIS-DEBOUNCE-MS
+
+  /// A value <= 0 means that the number of compilers is not limited.
+  max-concurrent-compilers -> int:
+    return get_ "maxConcurrentCompilers" --if-absent=: DEFAULT-MAX-CONCURRENT-COMPILERS
+
   should-write-repro -> bool:
     return (get_ "shouldWriteReproOnCrash" --if-absent=: false) == true
 
@@ -103,6 +114,8 @@ class LspServer:
 
   active-requests_ := 0
   on-idle-callbacks_ := []
+  /// Signaled whenever the server may have become idle.
+  idle-signal_ /monitor.Signal ::= monitor.Signal
 
   next-analysis-revision_ := 0
 
@@ -111,6 +124,9 @@ class LspServer:
 
   /// The settings from the client (or, if not supported, default settings).
   settings_ /Settings := Settings
+
+  /// Decides when compiler actions run. All compiler work goes through it.
+  scheduler_ /CompilerScheduler
 
   last-crash-report-time_ := null
 
@@ -123,6 +139,13 @@ class LspServer:
   open-requests_ /Map := {:}
 
   constructor .connection_ .toit-path-override_:
+    scheduler_ = CompilerScheduler
+        --max-concurrent=DEFAULT-MAX-CONCURRENT-COMPILERS
+        --debounce-ms=DEFAULT-ANALYSIS-DEBOUNCE-MS
+    // We can't pass on-idle to CompilerScheduler constructor due to needing
+    // "this" to be fully constructed before we can create a lambda.
+    scheduler_.on-idle = :: idle-signal_.raise
+    task --background:: catch --trace: run-idle-checker_
 
   run -> none:
     while true:
@@ -135,7 +158,7 @@ class LspServer:
       if id: open-requests_[id] = handler-task
 
   handle-request-in-task_ request/Map -> none:
-    active-requests_++
+    work-started_
     id := request.get "id"
     try:
       method := request["method"]
@@ -152,11 +175,25 @@ class LspServer:
       // canceled. Clean up under cancelation guard.
       critical-do:
         if id: open-requests_.remove id
-        active-requests_--
-        if active-requests_ == 0 and not on-idle-callbacks_.is-empty:
-          callbacks := on-idle-callbacks_
-          on-idle-callbacks_ = []
-          callbacks.do: it.call
+        work-finished_
+
+  work-started_ -> none:
+    active-requests_++
+
+  work-finished_ -> none:
+    active-requests_--
+    idle-signal_.raise
+
+  is-idle_ -> bool:
+    return active-requests_ == 0 and scheduler_.is-idle
+
+  run-idle-checker_ -> none:
+    while true:
+      idle-signal_.wait: is-idle_ and not on-idle-callbacks_.is-empty
+      callbacks := on-idle-callbacks_
+      on-idle-callbacks_ = []
+      callbacks.do: | callback |
+        catch --trace: callback.call
 
   handle_ method/string params/Map? -> any:
     // TODO(florian): this should be a switch or something.
@@ -258,6 +295,8 @@ class LspServer:
       // Client configurations can only make the output verbose, but not disable it,
       //   if it was given by command-line.
       is-verbose = is-verbose or settings_.is-verbose
+      scheduler_.max-concurrent = settings_.max-concurrent-compilers
+      scheduler_.debounce-ms = settings_.analysis-debounce-ms
     // TODO(florian): register DidChangeConfigurationNotification.type
 
   cancel params/CancelParams -> none:
@@ -283,12 +322,12 @@ class LspServer:
     //   taken into account.
     content-revision := next-analysis-revision_
     documents_.did-open --uri=uri document.text content-revision
-    analyze [uri]
+    scheduler_.run --id="analysis": analyze [uri]
 
   analyze-many params -> none:
     uris := params["uris"]
     uris = uris.map: translator.canonicalize it
-    analyze uris
+    scheduler_.run --id="analysis": analyze uris
 
   archive params/ArchiveParams -> string:
     non-canonicalized-uris := params.uris or [params.uri]
@@ -299,7 +338,8 @@ class LspServer:
     project-uri := documents_.project-uri-for --uri=uris[0]
     paths := uris.map: translator.to-path it
     compiler := compiler_
-    compiler.parse --paths=paths --project-uri=project-uri
+    scheduler_.run --id="archive":
+      compiler.parse --paths=paths --project-uri=project-uri
     buffer := io.Buffer
     write-repro
         --writer=buffer
@@ -315,8 +355,8 @@ class LspServer:
   snapshot-bundle params/SnapshotBundleParams -> Map?:
     uri := translator.canonicalize params.uri
     project-uri := documents_.project-uri-for --uri=uri
-    compiler := compiler_
-    bundle := compiler.snapshot-bundle --project-uri=project-uri uri
+    bundle := scheduler_.run --id="snapshot-bundle":
+      compiler_.snapshot-bundle --project-uri=project-uri uri
     // Encode the byte-array as base64.
     if not bundle: return null
     return {
@@ -346,28 +386,32 @@ class LspServer:
       // The next analysis-revision is thus the one where the new content has been
       //   taken into account.
       documents_.did-change --uri=uri it.text next-analysis-revision_
-    analyze [uri]
+    // Editors send a change for every keystroke. Let the scheduler decide
+    // when to analyze and batch the changed documents into one run.
+    scheduler_.schedule --id="analysis" --arg=uri:: | uris/List |
+      analyze uris
 
   completion params/CompletionParams -> any: // Either a List/*<CompletionItem>*/ or a $CompletionList.
     uri := translator.canonicalize params.text-document.uri
     project-uri := documents_.project-uri-for --uri=uri --recompute
-    compiler_.complete --project-uri=project-uri uri params.position.line params.position.character:
-      | prefix/string edit-range/Range? completions/List |
-      if completions.is-empty: return completions
-      if not prefix.ends-with "-": return completions
-      // The prefix ends with a '-'. VS Code doesn't like that and assumes that any completion we
-      // give is a new word. We therefore either adda default-range, or run through all
-      // completions and add a textEdit.
-      // TODO(florian): completion-range feature is disabled until we can test it on a
-      // real editor. When changing, make sure to update the test and the Go version.
-      if false and client-supports-completion-range_:
-        return CompletionList
-            --items=completions
-            --item-defaults=(CompletionItemDefaults --edit-range=edit-range)
-      completions.do: | item/CompletionItem |
-        text-edit := TextEdit --range=edit-range --new-text=item.label
-        item.set-text-edit text-edit
-      return completions
+    scheduler_.run --id="completion":
+      compiler_.complete --project-uri=project-uri uri params.position.line params.position.character:
+        | prefix/string edit-range/Range? completions/List |
+        if completions.is-empty: return completions
+        if not prefix.ends-with "-": return completions
+        // The prefix ends with a '-'. VS Code doesn't like that and assumes that any completion we
+        // give is a new word. We therefore either adda default-range, or run through all
+        // completions and add a textEdit.
+        // TODO(florian): completion-range feature is disabled until we can test it on a
+        // real editor. When changing, make sure to update the test and the Go version.
+        if false and client-supports-completion-range_:
+          return CompletionList
+              --items=completions
+              --item-defaults=(CompletionItemDefaults --edit-range=edit-range)
+        completions.do: | item/CompletionItem |
+          text-edit := TextEdit --range=edit-range --new-text=item.label
+          item.set-text-edit text-edit
+        return completions
     unreachable
 
   // TODO(florian): The specification supports a list of locations, or Locationlinks..
@@ -375,7 +419,8 @@ class LspServer:
   goto-definition params/TextDocumentPositionParams -> List/*<Location>*/:
     uri := translator.canonicalize params.text-document.uri
     project-uri := documents_.project-uri-for --uri=uri --recompute
-    return compiler_.goto-definition --project-uri=project-uri uri params.position.line params.position.character
+    return scheduler_.run --id="goto-definition":
+      compiler_.goto-definition --project-uri=project-uri uri params.position.line params.position.character
 
   rename params/RenameParams -> any:
     uri := translator.canonicalize params.text-document.uri
@@ -393,18 +438,19 @@ class LspServer:
     // a shared dependency file).
     all-references := []
     seen := {}
-    entry-uris.do: | entry-uri |
-      references := compiler_.find-references
-          --project-uri=project-uri
-          --entry-uri=entry-uri
-          uri
-          params.position.line
-          params.position.character
-      references.do: | location/Location |
-        key := "$location.uri:$(location.range.start.line):$(location.range.start.character):$(location.range.end.line):$(location.range.end.character)"
-        if not seen.contains key:
-          seen.add key
-          all-references.add location
+    scheduler_.run --id="rename":
+      entry-uris.do: | entry-uri |
+        references := compiler_.find-references
+            --project-uri=project-uri
+            --entry-uri=entry-uri
+            uri
+            params.position.line
+            params.position.character
+        references.do: | location/Location |
+          key := "$location.uri:$(location.range.start.line):$(location.range.start.character):$(location.range.end.line):$(location.range.end.character)"
+          if not seen.contains key:
+            seen.add key
+            all-references.add location
 
     if all-references.is-empty: return null
     // Group TextEdits by URI.
@@ -417,16 +463,18 @@ class LspServer:
   prepare-rename params/TextDocumentPositionParams -> any:
     uri := translator.canonicalize params.text-document.uri
     project-uri := documents_.project-uri-for --uri=uri --recompute
-    return compiler_.prepare-rename --project-uri=project-uri uri params.position.line params.position.character
+    return scheduler_.run --id="prepare-rename":
+      compiler_.prepare-rename --project-uri=project-uri uri params.position.line params.position.character
 
   selection-range params/Map -> List:
     uri := translator.canonicalize params["textDocument"]["uri"]
     project-uri := documents_.project-uri-for --uri=uri --recompute
     positions := params["positions"]
-    range-lists := compiler_.selection-range
-        --project-uri=project-uri
-        uri
-        positions
+    range-lists := scheduler_.run --id="selection-range":
+      compiler_.selection-range
+          --project-uri=project-uri
+          uri
+          positions
     return range-lists.map: | ranges/List? |
       if not ranges or ranges.is-empty:
         null
@@ -499,7 +547,8 @@ class LspServer:
     uri := translator.canonicalize params.text-document.uri
     project-uri := documents_.project-uri-for --uri=uri --recompute
 
-    definition := compiler_.hover --project-uri=project-uri uri params.position.line params.position.character
+    definition := scheduler_.run --id="hover":
+      compiler_.hover --project-uri=project-uri uri params.position.line params.position.character
     if not definition: return null
 
     if definition.text:
@@ -531,7 +580,8 @@ class LspServer:
     analyzed-documents := documents_.analyzed-documents-for --project-uri=project-uri
     document := analyzed-documents.get --uri=uri
     if not (document and document.summary):
-      analyze --project-uri=project-uri [uri] next-analysis-revision_++
+      scheduler_.run --id="document-symbol":
+        analyze --project-uri=project-uri [uri] next-analysis-revision_++
       document = analyzed-documents.get-existing --uri=uri
       if not document.summary: return []
     opened-document := documents_.get-opened --uri=uri
@@ -548,7 +598,8 @@ class LspServer:
   semantic-tokens params/SemanticTokensParams -> SemanticTokens:
     uri := translator.canonicalize params.text-document.uri
     project-uri := documents_.project-uri-for --uri=uri --recompute
-    tokens := compiler_.semantic-tokens --project-uri=project-uri uri
+    tokens := scheduler_.run --id="semantic-tokens":
+      compiler_.semantic-tokens --project-uri=project-uri uri
     return SemanticTokens --data=tokens
 
   shutdown:
@@ -569,6 +620,8 @@ class LspServer:
   Analyzes the given $uris and sends diagnostics to the client.
 
   Transitively analyzes all newly discovered files.
+
+  Must be called from within a $CompilerScheduler.run action.
   */
   analyze uris/List revision/int?=null -> none:
     if uris.is-empty: return

--- a/tools/package.lock
+++ b/tools/package.lock
@@ -1,83 +1,72 @@
 sdk: ^2.0.0-alpha.190
 prefixes:
-  ar: pkg-ar
-  certificate_roots: toit-cert-roots
-  cli: pkg-cli
-  desktop: pkg-desktop
-  fs: pkg-fs
-  host: pkg-host
-  http: pkg-http
-  lockfile: toit-lockfile
-  partition-table: toit-partition-table-esp32
-  semver: toit-semver
-  tar: pkg-tar
+  ar: github.com/toitlang/pkg-ar-1
+  certificate_roots: github.com/toitware/toit-cert-roots-1
+  cli: github.com/toitlang/pkg-cli-2
+  desktop: github.com/toitlang/pkg-desktop-1
+  fs: github.com/toitlang/pkg-fs-2
+  host: github.com/toitlang/pkg-host-1
+  http: github.com/toitlang/pkg-http-2
+  lockfile: github.com/toitware/toit-lockfile-1
+  partition-table: github.com/toitware/toit-partition-table-esp32-1
+  semver: github.com/toitware/toit-semver-1
+  tar: github.com/toitlang/pkg-tar-2
 packages:
-  pkg-ar:
-    url: github.com/toitlang/pkg-ar
-    name: ar
-    version: 1.4.1
+  github.com/toitlang/pkg-ar-1:
     hash: 66f0359ed405dbebbc06a0cda9864b10b2d6aa34
-  pkg-cli:
-    url: github.com/toitlang/pkg-cli
-    name: cli
-    version: 2.17.0
+    url: github.com/toitlang/pkg-ar
+    version: 1.4.1
+  github.com/toitlang/pkg-cli-2:
     hash: 8f58b041d55440916a2527899df505f6c6259b20
     prefixes:
-      desktop: pkg-desktop
-      fs: pkg-fs
-      host: pkg-host
-      lockfile: toit-lockfile
-  pkg-desktop:
-    url: github.com/toitlang/pkg-desktop
-    name: desktop
-    version: 1.1.0
+      desktop: github.com/toitlang/pkg-desktop-1
+      fs: github.com/toitlang/pkg-fs-2
+      host: github.com/toitlang/pkg-host-1
+      lockfile: github.com/toitware/toit-lockfile-1
+    url: github.com/toitlang/pkg-cli
+    version: 2.17.0
+  github.com/toitlang/pkg-desktop-1:
     hash: d6ad1d5c25e16d0c2910a132acba426251b5d87f
     prefixes:
-      host: pkg-host
-  pkg-fs:
-    url: github.com/toitlang/pkg-fs
-    name: fs
-    version: 2.3.1
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitlang/pkg-desktop
+    version: 1.1.0
+  github.com/toitlang/pkg-fs-2:
     hash: 60836d4500317af2093d59d50c117d612c33f1fa
     prefixes:
-      host: pkg-host
-  pkg-host:
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitlang/pkg-fs
+    version: 2.3.1
+  github.com/toitlang/pkg-host-1:
+    hash: 50b7e52052c0b0baa48eef60609ff0f4df2f02b7
     url: github.com/toitlang/pkg-host
-    name: host
-    version: 1.17.0
-    hash: 05a26b5fa1cc73dc64a5e9cc16c40ae5aa24e0fb
-  pkg-http:
-    url: github.com/toitlang/pkg-http
-    name: http
-    version: 2.12.0
+    version: 1.21.0
+  github.com/toitlang/pkg-http-2:
     hash: b68f3f4a3c26bfdff2beca4fb5ac7bc182f20270
-  pkg-tar:
-    url: github.com/toitlang/pkg-tar
-    name: tar
-    version: 2.1.0
+    url: github.com/toitlang/pkg-http
+    version: 2.12.0
+  github.com/toitlang/pkg-tar-2:
     hash: c9abee2219ec674a12a2e7cdc9cd7a74af875fe7
     prefixes:
-      host: pkg-host
-  toit-cert-roots:
-    url: github.com/toitware/toit-cert-roots
-    name: certificate-roots
-    version: 1.11.0
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitlang/pkg-tar
+    version: 2.1.0
+  github.com/toitware/toit-cert-roots-1:
     hash: c117dbba4757d7c69e91af7a875ab6989f051a33
-  toit-lockfile:
-    url: github.com/toitware/toit-lockfile
-    name: lockfile
-    version: 1.0.0
+    url: github.com/toitware/toit-cert-roots
+    version: 1.11.0
+  github.com/toitware/toit-lockfile-1:
     hash: 47ddd8c13811e6cc368d6fef8f383b855f9d0ada
     prefixes:
-      fs: pkg-fs
-      host: pkg-host
-  toit-partition-table-esp32:
-    url: github.com/toitware/toit-partition-table-esp32
-    name: partition-table
-    version: 1.4.0
+      fs: github.com/toitlang/pkg-fs-2
+      host: github.com/toitlang/pkg-host-1
+    url: github.com/toitware/toit-lockfile
+    version: 1.0.0
+  github.com/toitware/toit-partition-table-esp32-1:
     hash: 9ee4032b913a00d0c0f87446261d034842b707f1
-  toit-semver:
-    url: github.com/toitware/toit-semver
-    name: semver
-    version: 1.2.0
+    url: github.com/toitware/toit-partition-table-esp32
+    version: 1.4.0
+  github.com/toitware/toit-semver-1:
     hash: 7b862ca7b40601ae2a63ec6ffbacebb48c929e02
+    url: github.com/toitware/toit-semver
+    version: 1.2.0

--- a/tools/package.yaml
+++ b/tools/package.yaml
@@ -16,7 +16,7 @@ dependencies:
     version: ^2.3.1
   host:
     url: github.com/toitlang/pkg-host
-    version: ^1.17.0
+    version: ^1.21.0
   http:
     url: github.com/toitlang/pkg-http
     version: ^2.12.0


### PR DESCRIPTION
I noticed that the LSP churns through many processes during normal editor use. I did some digging with help of robots, and came up with a few suggested improvements:
1) kill compiler processes when LSP requests are canceled
2) debounce `didChange` notifications so that we don't spawn a compiler process on every keystroke

Thoughts?

The diff looks bigger than it is, since large parts are just indentation changes to add `critical-do` guards.