### PR TITLE
Preserve Debian upgrade ordering with a version epoch

### DIFF
--- a/.github/workflows/tar-ball.yml
+++ b/.github/workflows/tar-ball.yml
@@ -181,7 +181,9 @@ jobs:
           # Remove the leading 'v' from the version if it exists.
           version_without_v=${version#v}
           # Debian uses '~' to sort prereleases before the final release.
-          debian_version=${version_without_v/-alpha./~alpha.}
+          # Keep epoch 1 in all future versions: packages through alpha.198
+          # used '-alpha.', which sorts after '~alpha.' without an epoch.
+          debian_version=1:${version_without_v/-alpha./~alpha.}
           sed -i "s/VERSION/$debian_version/" debian/changelog
           sed -i "s/RELEASE_DATE/$(date --rfc-email)/" debian/changelog
           sudo apt-get update
@@ -205,9 +207,14 @@ jobs:
           expected_version=${{ needs.build-and-upload.outputs.version }}
           pkg_version=$(dpkg -s toit | grep Version | cut -d ' ' -f 2)
           expected_pkg_version=${expected_version#v}
-          expected_pkg_version=${expected_pkg_version/-alpha./~alpha.}-1
+          expected_pkg_version=1:${expected_pkg_version/-alpha./~alpha.}-1
           if [ "$pkg_version" != "$expected_pkg_version" ]; then
             echo "Expected pkg version $expected_pkg_version but got $pkg_version"
+            exit 1
+          fi
+          # Compare against the actual version of the last pre-epoch release.
+          if ! dpkg --compare-versions "$pkg_version" gt 2.0.0-alpha.198-1; then
+            echo "Package $pkg_version does not upgrade from alpha.198"
             exit 1
           fi
           toit_version=$(toit version)

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,115 +4,115 @@ toit (VERSION-1) unstable; urgency=medium
 
  -- Florian Loitsch <florian@toit.io>  RELEASE_DATE
 
-toit (2.0.0~alpha.198-1) unstable; urgency=medium
+toit (2.0.0-alpha.198-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Wed, 19 Aug 2026 00:52:17 +0200
 
-toit (2.0.0~alpha.197-1) unstable; urgency=medium
+toit (2.0.0-alpha.197-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Wed, 5 Aug 2026 23:37:07 +0200
 
-toit (2.0.0~alpha.196-1) unstable; urgency=medium
+toit (2.0.0-alpha.196-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Sun, 26 Jul 2026 20:53:47 +0200
 
-toit (2.0.0~alpha.195-1) unstable; urgency=medium
+toit (2.0.0-alpha.195-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Thu, 2 Jul 2026 18:49:50 +0200
 
-toit (2.0.0~alpha.194-1) unstable; urgency=medium
+toit (2.0.0-alpha.194-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Tue, 19 May 2026 08:52:13 -0700
 
-toit (2.0.0~alpha.193-1) unstable; urgency=medium
+toit (2.0.0-alpha.193-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Sat, 2 May 2026 16:32:22 +0200
 
-toit (2.0.0~alpha.192-1) unstable; urgency=medium
+toit (2.0.0-alpha.192-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Wed, 15 Apr 2026 23:23:40 +0200
 
-toit (2.0.0~alpha.191-1) unstable; urgency=medium
+toit (2.0.0-alpha.191-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Tue, 31 Mar 2026 12:25:28 +0200
 
-toit (2.0.0~alpha.190-1) unstable; urgency=medium
+toit (2.0.0-alpha.190-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Sun, 15 Feb 2026 20:47:33 +0100
 
-toit (2.0.0~alpha.189-1) unstable; urgency=medium
+toit (2.0.0-alpha.189-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Tue, 28 Oct 2025 12:18:29 +0100
 
-toit (2.0.0~alpha.188-1) unstable; urgency=medium
+toit (2.0.0-alpha.188-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Sun, 17 Aug 2025 12:24:46 +0200
 
-toit (2.0.0~alpha.187-1) unstable; urgency=medium
+toit (2.0.0-alpha.187-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Tue, 12 Aug 2025 19:11:24 +0200
 
-toit (2.0.0~alpha.186-1) unstable; urgency=medium
+toit (2.0.0-alpha.186-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Thu, 3 Jul 2025 08:58:36 +0200
 
-toit (2.0.0~alpha.185-1) unstable; urgency=medium
+toit (2.0.0-alpha.185-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Tue, 17 Jun 2025 14:18:13 +0200
 
-toit (2.0.0~alpha.184-1) unstable; urgency=medium
+toit (2.0.0-alpha.184-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Mon, 2 Jun 2025 12:54:23 +0200
 
-toit (2.0.0~alpha.183-1) unstable; urgency=medium
+toit (2.0.0-alpha.183-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Wed, 28 May 2025 13:50:28 +0200
 
-toit (2.0.0~alpha.182-1) unstable; urgency=medium
+toit (2.0.0-alpha.182-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Mon, 26 May 2025 16:42:32 +0200
 
-toit (2.0.0~alpha.181-1) unstable; urgency=medium
+toit (2.0.0-alpha.181-1) unstable; urgency=medium
 
   * New upstream release.
 
  -- Florian Loitsch <florian@toit.io>  Mon, 26 May 2025 14:35:31 +0200
 
-toit (2.0.0~alpha.180-1) unstable; urgency=medium
+toit (2.0.0-alpha.180-1) unstable; urgency=medium
 
   * Initial release.
 


### PR DESCRIPTION
Changing prereleases from `-alpha.` to `~alpha.` makes the next Debian package sort below published versions such as `2.0.0-alpha.198-1`. Introduce epoch `1` so existing installations can upgrade while final releases still sort after prereleases. The epoch must remain in future Debian versions.

Restore historical changelog entries to their published spelling and add a package-version comparison against alpha.198 to the release workflow.

Validation: executed the workflow's version-generation commands, parsed generated changelogs with `dpkg-parsechangelog`, and verified ordering from the published alpha.198 through epoch-1 alpha.199, alpha.200, final 2.0.0, and 2.0.1. Shell syntax and whitespace checks passed. A full Debian package installation/upgrade was not run.
