### PR TITLE
Preserve newline conversion for ESP32 USB stdin

### DIFF
--- a/src/resources/stdio_esp32.cc
+++ b/src/resources/stdio_esp32.cc
@@ -94,6 +94,7 @@ static void release_uart_stdin() {
 #ifdef TOIT_STDIN_USB_SERIAL_JTAG
 static int usb_serial_jtag_stdin_users = 0;
 static QueueHandle_t usb_serial_jtag_stdin_queue = null;
+static int usb_serial_jtag_stdin_fd = -1;
 
 static void usb_serial_jtag_notify(usj_select_notif_t notification, BaseType_t* task_woken) {
   if (notification != USJ_SELECT_READ_NOTIF || usb_serial_jtag_stdin_queue == null) return;
@@ -112,12 +113,28 @@ static esp_err_t acquire_usb_serial_jtag_stdin(QueueHandle_t* queue) {
   usb_serial_jtag_stdin_queue = xQueueCreate(STDIN_QUEUE_SIZE, sizeof(word));
   if (usb_serial_jtag_stdin_queue == null) return ESP_ERR_NO_MEM;
 
+  // Read through the USB VFS to preserve its configured newline conversion.
+  // STDIN_FILENO only reaches the primary console, which may be UART.
+#ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+  const char* path = "/dev/usbserjtag";
+#else
+  const char* path = "/dev/secondary";
+#endif
+  usb_serial_jtag_stdin_fd = ::open(path, O_RDONLY | O_NONBLOCK);
+  if (usb_serial_jtag_stdin_fd < 0) {
+    vQueueDelete(usb_serial_jtag_stdin_queue);
+    usb_serial_jtag_stdin_queue = null;
+    return ESP_FAIL;
+  }
+
   usb_serial_jtag_driver_config_t config = USB_SERIAL_JTAG_DRIVER_CONFIG_DEFAULT();
   esp_err_t err = ESP_FAIL;
   SystemEventSource::instance()->run([&]() -> void {
     err = usb_serial_jtag_driver_install(&config);
   });
   if (err != ESP_OK) {
+    ::close(usb_serial_jtag_stdin_fd);
+    usb_serial_jtag_stdin_fd = -1;
     vQueueDelete(usb_serial_jtag_stdin_queue);
     usb_serial_jtag_stdin_queue = null;
     return err;
@@ -149,6 +166,8 @@ static void release_usb_serial_jtag_stdin() {
     esp_rom_printf("[stdio] error: failed to uninstall USB Serial/JTAG driver\n");
     ESP_ERROR_CHECK(err);
   }
+  ::close(usb_serial_jtag_stdin_fd);
+  usb_serial_jtag_stdin_fd = -1;
   vQueueDelete(usb_serial_jtag_stdin_queue);
   usb_serial_jtag_stdin_queue = null;
 }
@@ -304,7 +323,13 @@ PRIMITIVE(stdin_read) {
 #endif
 #ifdef TOIT_STDIN_USB_SERIAL_JTAG
   auto read_usb = [&]() -> int {
-    return usb_serial_jtag_read_bytes(bytes.address(), STDIN_BUFFER_SIZE, 0);
+    int count = ::read(usb_serial_jtag_stdin_fd, bytes.address(), STDIN_BUFFER_SIZE);
+    if (count < 0) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) return 0;
+      read_error = errno;
+      return -1;
+    }
+    return count;
   };
 #endif
 

--- a/tests/qemu/README.md
+++ b/tests/qemu/README.md
@@ -23,18 +23,21 @@ Release archives for other hosts are available on the same release page.
 
 ## Run the automated tests
 
-After building the regular ESP32 firmware, build a separate S3 envelope whose
-primary console is USB Serial/JTAG and run all standard-stream fixtures:
+After building the regular ESP32 and ESP32-S3 firmware, build a separate S3
+envelope whose primary console is USB Serial/JTAG and run all standard-stream
+fixtures:
 
 ```sh
 tests/qemu/build-s3-usb-envelope.sh
 QEMU_SYSTEM_XTENSA=$QEMU tests/qemu/run-tests.sh
 ```
 
-The runner tests stdin, stdout, and stderr through both an ESP32 UART and the
-ESP32-S3 USB Serial/JTAG device. It also verifies that `io.stdin` and
-`uart.Port.console` can share the console UART. Each input is sent only after
-the corresponding readiness marker appears, and every wait has a timeout.
+The runner tests stdin, stdout, and stderr with both LF and CR input through an
+ESP32 UART, a primary ESP32-S3 USB Serial/JTAG console, and both inputs of the
+standard ESP32-S3 UART-primary/USB-secondary configuration. It also verifies
+that `io.stdin` and `uart.Port.console` can share the console UART. Each input
+is sent only after the corresponding readiness marker appears, and every wait
+has a timeout.
 
 ## Build and create a flash image
 

--- a/tests/qemu/run-tests.sh
+++ b/tests/qemu/run-tests.sh
@@ -11,6 +11,7 @@ QEMU_SYSTEM_XTENSA="${QEMU_SYSTEM_XTENSA:-qemu-system-xtensa}"
 TOIT="${TOIT:-${ROOT_DIR}/build/host/sdk/bin/toit}"
 UART_ENVELOPE="${UART_ENVELOPE:-${ROOT_DIR}/build/esp32/firmware.envelope}"
 USB_ENVELOPE="${USB_ENVELOPE:-${ROOT_DIR}/build/esp32s3-usj/firmware.envelope}"
+MIXED_ENVELOPE="${MIXED_ENVELOPE:-${ROOT_DIR}/build/esp32s3/firmware.envelope}"
 QEMU_TIMEOUT_TICKS="${QEMU_TIMEOUT_TICKS:-300}"
 
 if ! command -v "${QEMU_SYSTEM_XTENSA}" >/dev/null 2>&1; then
@@ -21,7 +22,7 @@ if [[ ! -x "${TOIT}" ]]; then
   echo "Toit executable is not executable: ${TOIT}" >&2
   exit 2
 fi
-for envelope in "${UART_ENVELOPE}" "${USB_ENVELOPE}"; do
+for envelope in "${UART_ENVELOPE}" "${USB_ENVELOPE}" "${MIXED_ENVELOPE}"; do
   if [[ ! -f "${envelope}" ]]; then
     echo "Firmware envelope not found: ${envelope}" >&2
     exit 2
@@ -72,7 +73,7 @@ start_qemu() {
   local input="${TEMP_DIR}/${image}.in"
   QEMU_LOG="${TEMP_DIR}/${image}.log"
 
-  mkfifo "${input}"
+  if [[ ! -p "${input}" ]]; then mkfifo "${input}"; fi
   exec 3<>"${input}"
 
   local -a console_options
@@ -160,6 +161,12 @@ run_stdio_test() {
   printf 'hello-qemu\n' >&3
   wait_for STDOUT:hello-qemu
   wait_for STDERR:hello-qemu
+  # Enter on a serial terminal sends CR. The configured VFS must turn it
+  # into LF so read-line completes, for both primary and secondary consoles.
+  printf 'hello-cr\r' >&3
+  wait_for STDOUT:hello-cr
+  wait_for STDERR:hello-cr
+  wait_for STDIO-DONE
   stop_qemu
   echo "PASS: ${machine} ${console} stdin/stdout/stderr"
 }
@@ -182,6 +189,10 @@ run_esptool_flash_test() {
   printf 'hello-flashed-qemu\n' >&3
   wait_for STDOUT:hello-flashed-qemu
   wait_for STDERR:hello-flashed-qemu
+  printf 'hello-flashed-cr\r' >&3
+  wait_for STDOUT:hello-flashed-cr
+  wait_for STDERR:hello-flashed-cr
+  wait_for STDIO-DONE
   stop_qemu
   echo "PASS: bundled esptool flashed and booted an ESP32 in QEMU"
 }
@@ -201,8 +212,11 @@ run_uart_sharing_test() {
 make_image stdio.toit "${UART_ENVELOPE}" stdio-uart
 make_image stdio-uart-console.toit "${UART_ENVELOPE}" uart-share
 make_image stdio.toit "${USB_ENVELOPE}" stdio-usb
+make_image stdio.toit "${MIXED_ENVELOPE}" stdio-mixed
 
 run_esptool_flash_test
 run_stdio_test esp32 stdio-uart uart
 run_uart_sharing_test
 run_stdio_test esp32s3 stdio-usb usb-serial-jtag
+run_stdio_test esp32s3 stdio-mixed uart
+run_stdio_test esp32s3 stdio-mixed usb-serial-jtag

--- a/tests/qemu/stdio.toit
+++ b/tests/qemu/stdio.toit
@@ -9,8 +9,10 @@ main:
   // The ESP32 UART driver flushes pending input when installed.
   input := io.stdin
   io.stdout.write "STDIO-READY\n"
-  data := input.read-line --keep-newline
-  io.stdout.write "STDOUT:"
-  if data: io.stdout.write data
-  io.stderr.write "STDERR:"
-  if data: io.stderr.write data
+  2.repeat:
+    data := input.read-line --keep-newline
+    io.stdout.write "STDOUT:"
+    if data: io.stdout.write data
+    io.stderr.write "STDERR:"
+    if data: io.stderr.write data
+  io.stdout.write "STDIO-DONE\n"


### PR DESCRIPTION
Reading USB Serial/JTAG directly from the driver bypasses configured CR-to-LF conversion, so pressing Enter on a CR-sending terminal can leave `io.stdin.read-line` blocked. Read through a shared nonblocking USB VFS descriptor for both primary and secondary USB consoles, with descriptor cleanup tied to the driver's lifetime.

Extend the QEMU regression fixtures to send both LF and CR and cover USB-primary plus both inputs of the UART-primary/USB-secondary configuration. Update the existing test instructions for the additional firmware requirement.

Validation: rebuilt ESP32 and both ESP32-S3 console configurations; all six QEMU checks passed, including flashing, UART sharing, and all console input paths. Host stdio tests and shell/whitespace checks passed. Physical ESP32-S3 testing also passed 100 lines in each USB-primary and USB-secondary configuration, covering CR/LF, empty lines, fragmented input, and a 1,500-byte line (37-byte chunks spaced 10 ms apart).

For comparison, rebuilt the same firmware with the original USB reader: CR-only input leaves it blocked, reproducing the regression. At a faster rate of 37-byte chunks spaced 1 ms apart, both the original reader and the fixed reader lose input bytes; that existing throughput limitation remains outside this change.
