### PR TITLE
Update ESP-IDF patch head

### DIFF
--- a/lib/rmt.toit
+++ b/lib/rmt.toit
@@ -827,6 +827,10 @@ class In extends Channel_:
         Channel_.CHANNEL-KIND-INPUT_
         pull-up
         dma
+    // For the new (integer) API the primitive applies the pull when it owns the
+    // pin. For a deprecated $gpio.Pin the pin owns its own configuration.
+    if pin is gpio.Pin:
+      pin.set-pull --up=pull-up --off=(not pull-up)
     super.from-sub_ resource
 
   /** Closes the channel. */

--- a/lib/rmt.toit
+++ b/lib/rmt.toit
@@ -801,6 +801,8 @@ class In extends Channel_:
     internal-RAM DMA buffer and can be much larger. DMA is only supported on
     some chips, including the ESP32P4 and ESP32S3.
 
+  If $pull-up is true, the pin's internal pull-up resistor is enabled.
+
   Passing a $gpio.Pin as $pin is deprecated; provide the integer GPIO number
     instead. The $gpio.Pin form will be removed in a future release.
   */
@@ -809,6 +811,7 @@ class In extends Channel_:
   constructor pin/any
       --resolution/int
       --memory-blocks/int=1
+      --pull-up/bool=false
       --.dma/bool=false:
     if not 1 <= memory-blocks: throw "INVALID_ARGUMENT"
 
@@ -822,7 +825,7 @@ class In extends Channel_:
         resolution
         hw-symbols
         Channel_.CHANNEL-KIND-INPUT_
-        false
+        pull-up
         dma
     super.from-sub_ resource
 

--- a/src/resources/rmt_esp32.cc
+++ b/src/resources/rmt_esp32.cc
@@ -769,10 +769,10 @@ PRIMITIVE(channel_new) {
     return Primitive::os_error(err, process);
   }
 
-  // In open-drain mode, apply the requested pull now that the channel has
-  // configured the pin. A deprecated gpio.Pin (old API) applies its pull on the
-  // Toit side instead.
-  if (is_tx && kind == 2 && reserver.any()) {
+  // Apply the requested pull now that the channel has configured the pin. For
+  // output channels this is only meaningful in open-drain mode. A deprecated
+  // gpio.Pin (old API) applies its pull on the Toit side instead.
+  if (reserver.any() && (!is_tx || kind == 2)) {
     gpio_set_pull_mode(static_cast<gpio_num_t>(gpio_num),
                        pull_up ? GPIO_PULLUP_ONLY : GPIO_FLOATING);
   }

--- a/tests/hw/esp32/rmt-drain-pullup-test.toit
+++ b/tests/hw/esp32/rmt-drain-pullup-test.toit
@@ -25,9 +25,25 @@ RESOLUTION ::= 1_000_000  // 1MHz.
 main:
   print "$RMT-PIN <-> $LEVEL-PIN <-> $MEASURE-PIN"
   run-test:
+    test-input-pull-up
     2.repeat:
       test-no-pull-up --idle-level=it
       test-pull-up --idle-level=it
+
+test-input-pull-up:
+  measure-pin := gpio.Pin MEASURE-PIN --input
+
+  input := rmt.In RMT-PIN --resolution=RESOLUTION
+  // Give the 1M resistor time to pull the otherwise floating input low.
+  sleep --ms=1
+  expect-equals 0 measure-pin.get
+  input.close
+
+  input = rmt.In RMT-PIN --resolution=RESOLUTION --pull-up
+  // The internal pull-up wins over the 1M resistor to ground.
+  expect-equals 1 measure-pin.get
+  input.close
+  measure-pin.close
 
 test-no-pull-up --idle-level/int:
   print "Testing no pull up idle_level=$idle-level"

--- a/tests/hw/esp32/rmt-test.toit
+++ b/tests/hw/esp32/rmt-test.toit
@@ -138,7 +138,9 @@ test-simple-pulse pin-in/int pin-out/int:
   PULSE-LENGTH ::= 50
 
   out := rmt.Out pin-out --resolution=RESOLUTION
-  in := rmt.In pin-in --resolution=RESOLUTION
+  // Also exercise input-owned pull configuration. The output drives both
+  // levels, so the weak pull-up does not otherwise affect this pulse test.
+  in := rmt.In pin-in --resolution=RESOLUTION --pull-up
   in.start-reading --min-ns=1 --max-ns=(120 * 1000)
   out-signals := rmt.Signals 1
   out-signals.set 0 --level=1 --period=PULSE-LENGTH


### PR DESCRIPTION
## Summary

- Update the ESP-IDF submodule from `9914745eda` to the current `patch-head-5.4.2` commit, `5d6d9ed99e`.
- Pick up the merged asynchronous I2C/SPI fixes from toitware/esp-idf#128, #130, and #131.
- Pick up the intervening dynamic mbedTLS receive-buffer fix from toitware/esp-idf#132.

This PR intentionally contains only the ESP-IDF gitlink update. The dependent I2C/SPI Toit changes remain in their existing stacked PRs.

## Testing

The dependent I2C/SPI stack has been validated with:

- complete paired-board ESP32 and ESP32-S3 I2C/SPI selections
- classic ESP32 with `CONFIG_SPI_MASTER_ISR_IN_IRAM=y` and both target implementations enabled
- native ESP-IDF I2C/SPI IRAM builds
