### PR TITLE
Fix a GC segmentation fault 

### DIFF
--- a/src/third_party/dartino/gc_metadata.cc
+++ b/src/third_party/dartino/gc_metadata.cc
@@ -205,8 +205,18 @@ restart:
         // We went back to the start of source data we were trying to fit in
         // the destination chunk, and not even the first line could fit.  Time
         // to move to the next destination chunk.
-        dest.chunk()->set_compaction_top(dest.address);
+        // If we arrived here straight after a chunk switch, dest.address is
+        // still biased below the chunk start to account for the tail of an
+        // object placed in an earlier chunk (see below).  Nothing was placed
+        // in this chunk, so its top is its start, and the bias must carry over
+        // to the next chunk since the source line is unchanged.
+        uword bias = 0;
+        if (dest.address < dest.chunk()->start()) {
+          bias = dest.chunk()->start() - dest.address;
+        }
+        dest.chunk()->set_compaction_top(dest.address + bias);
         dest = dest.next_chunk();
+        dest.address -= bias;
         goto restart;
       }
       dest_table--;

--- a/src/third_party/dartino/object_memory.h
+++ b/src/third_party/dartino/object_memory.h
@@ -69,7 +69,10 @@ class Chunk : public ChunkList::Element {
 
   uword compaction_top() { return compaction_top_; }
 
-  void set_compaction_top(uword top) { compaction_top_ = top; }
+  void set_compaction_top(uword top) {
+    ASSERT(start_ <= top && top <= end_);
+    compaction_top_ = top;
+  }
 
   // Returns the size of this chunk in bytes.
   uword size() const { return end_ - start_; }

--- a/tests/gc-compaction-overhang-test.toit
+++ b/tests/gc-compaction-overhang-test.toit
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+// Regression test for old-space compaction: when a destination chunk is
+// abandoned right after a chunk switch, the destination address is biased
+// below the chunk start to compensate for the tail of an object moved to the
+// previous chunk. That biased address must not become the abandoned chunk's
+// compaction top, and the bias must carry over to the next chunk.
+//
+// Layout (64-bit host, 32K chunks, 256-byte lines): [A][E][C] contiguous in
+// old space, where E + C exceed one chunk, C starts in the line that holds the
+// tail of A, and A's end offset within that line is in (0, 0x70).
+
+import expect show *
+import system
+
+fill ba/ByteArray value/int -> ByteArray:
+  ba.fill value
+  return ba
+
+check ba/ByteArray value/int:
+  ba.size.repeat: expect-equals value ba[it]
+
+run k/int:
+  filler/List? := List 700
+  700.repeat: filler[it] = ByteArray 1000
+  200.repeat: ByteArray 1000  // Garbage; drives scavenges that promote filler.
+  keep := List 7
+  keep[0] = fill (ByteArray 32240 + 8 * k) 10   // A1.
+  keep[1] = fill (ByteArray 128) 11             // E1.
+  keep[2] = fill (ByteArray 32656) 12           // C1: goes to old space directly.
+  keep[3] = fill (ByteArray 32240) 13           // A2: scavenge promotes A1, E1.
+  keep[4] = fill (ByteArray 128) 14             // E2.
+  keep[5] = fill (ByteArray 32656) 15           // C2: old space, right after E1.
+  keep[6] = fill (ByteArray 32240) 16           // A3: promotes A2, E2.
+  filler = null
+  system.process-stats --gc
+  7.repeat: check keep[it] 10 + it
+  3.repeat:
+    300.repeat: ByteArray 1000
+    system.process-stats --gc
+    7.repeat: check keep[it] 10 + it
+
+main:
+  if system.platform == system.PLATFORM-FREERTOS: return
+  32.repeat:
+    run it
+    // Return the heap to a small, compacted state before the next layout.
+    system.process-stats --gc
+    system.process-stats --gc


### PR DESCRIPTION
I noticed an occasional toit segfault in LSP logs and asked robots to investigate. The repro (`tests/gc-compaction-overhang-test.toit`, included in this PR) reliably crashes for me:

```
$ jag toit version
v2.0.0-alpha.198
$ uname -a
Linux lima-default 7.0.0-30-generic #30-Ubuntu SMP PREEMPT_DYNAMIC Fri Jul 31 18:22:54 UTC 2026 x86_64 GNU/Linux
$ jag toit run -- tests/gc-compaction-overhang-test.toit
EXCEPTION error.
/home/dev/.cache/jaguar/v1.71.0/sdk/lib/toit/bin/toit.run: Segmentation fault
  0: run-program               <pkg:pkg-host>/pipe.toit:633:5
  1: run                       /home/runner/work/toit/toit/tools/toit.toit:390:10
  2: compile-or-analyze-or-run /home/runner/work/toit/toit/tools/toit.toit:492:16
  3: main.<lambda>             /home/runner/work/toit/toit/tools/toit.toit:190:16
  4: Command.run_.<block>      <pkg:pkg-cli>/cli.toit:447:40
  5: Parser_.parse             <pkg:pkg-cli>/parser_.toit:259:5
  6: Command.run_              <pkg:pkg-cli>/cli.toit:445:12
  7: Command.run-for-exit-code.<block> <pkg:pkg-cli>/cli.toit:390:7
  8: catch.<block>             <sdk>/core/exceptions.toit:124:10
  9: catch                     <sdk>/core/exceptions.toit:122:1
 10: catch                     <sdk>/core/exceptions.toit:85:10
 11: Command.run-for-exit-code <pkg:pkg-cli>/cli.toit:389:18
 12: Command.run               <pkg:pkg-cli>/cli.toit:368:18
 13: main                      /home/runner/work/toit/toit/tools/toit.toit:287:16
Error: exit status 1
```

**FULL DISCLOSURE**: this was written by LLMs, and I have not reviewed this for correctness. Understanding the garbage collector might be a bit too deep in the yak shaving stack for me at the moment. :) But I figured I would send this out anyway in case it's helpful for at least repro purposes.