### PR TITLE
Update ESP-IDF to latest 5.4.2 patch head

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "third_party/esp-idf"]
 	path = third_party/esp-idf
 	url = https://github.com/toitware/esp-idf.git
-	branch = patch-head-5.3.1
+	branch = patch-head-5.4.2
 	ignore = untracked


### PR DESCRIPTION
Advance `third_party/esp-idf` from `9914745eda` to `5d6d9ed99e`, the current tip of `toitware/esp-idf`'s `patch-head-5.4.2` branch. The [four new commits](https://github.com/toitware/esp-idf/compare/9914745eda54f9872dd56e9e6616b79b4407ef6f...5d6d9ed99e16373564c0d11d147ea3b309385b00) fix asynchronous I2C transaction retirement, add SPI target transaction abort, address I2C/SPI hardware edge cases, and preserve partial TLS headers with dynamic mbedTLS receive buffers.

Correct the submodule's tracking branch in `.gitmodules` from `patch-head-5.3.1` to `patch-head-5.4.2` so remote updates follow the intended release branch.

Validation: ESP32 and ESP32-P4 firmware builds passed.
