### PR TITLE
Fix source detection for files shorter than a shebang

### DIFF
--- a/tests/toit/default-command-test.toit
+++ b/tests/toit/default-command-test.toit
@@ -38,3 +38,23 @@ main args:
     expect-not-equals 0 fork-result.exit-code
     combined = fork-result.stdout + fork-result.stderr
     expect (combined.contains "Unknown command or invalid source file")
+
+    // Short files without a Toit extension aren't source files.
+    short-path := "$tmp-dir/short"
+    ["", "#", "!", "x"].do: | contents/string |
+      file.write-contents --path=short-path contents
+      [[], ["--"]].do: | prefix/List |
+        result := toit-exe.fork (prefix + [short-path])
+        expect-equals 1 result.exit-code
+        message := result.stdout + result.stderr
+        expect (message.contains "Unknown command or invalid source file")
+
+    // Files without a Toit extension can still be shebang scripts or snapshots.
+    script-path := "$tmp-dir/script"
+    file.write-contents --path=script-path
+        "#!/usr/bin/env toit\n" + (file.read-contents src-path).to-string
+    snapshot-path := "$tmp-dir/snapshot"
+    toit-exe.backticks ["compile", "--snapshot", "-o", snapshot-path, src-path]
+    [src-path, script-path, snapshot-path].do: | path/string |
+      [[], ["--"]].do: | prefix/List |
+        expect-equals "hello\n" (toit-exe.backticks (prefix + [path, "hello"]))

--- a/tools/toit.toit
+++ b/tools/toit.toit
@@ -45,7 +45,7 @@ is-toit-source path/string -> bool:
   if not file.is-file path: return false
   contents := file.read-contents path
   if snapshot-lib.SnapshotBundle.is-bundle-content contents: return true
-  if contents[0] == '#' and contents[1] == '!':
+  if contents.size >= 2 and contents[0] == '#' and contents[1] == '!':
     // We accept any file that starts with a shebang line.
     return true
   return false


### PR DESCRIPTION
## Summary

- Check the file length before indexing the two shebang bytes in `is-toit-source`.
- Add CLI regression coverage for empty and one-byte files, both as direct arguments and after `--`.
- Verify that `.toit` files, extensionless shebang scripts, and extensionless snapshots still run through both paths.

## Verification

- Confirmed the new regression test fails before the fix.
- Rebuilt the Toit executable with `ninja -C build/host -j 4 toit`.
- All three focused CTest tests pass: default-command, run-compile, and version.
- Analyzed the modified source and test separately; both pass.
- `git diff --check` passes.