### PR TITLE
Don't redefine mkdtemp on mingw-w64 14+

### DIFF
--- a/tests/ctest/ar-read-test.cc
+++ b/tests/ctest/ar-read-test.cc
@@ -15,7 +15,8 @@
 #include "../../src/compiler/list.h"
 #include "../../src/utils.h"
 
-#ifdef WIN32
+// mingw-w64 14 and newer provide mkdtemp.
+#if defined(WIN32) && !(defined(__MINGW64_VERSION_MAJOR) && __MINGW64_VERSION_MAJOR >= 14)
 static char* mkdtemp(char* tmpl) {
   UNIMPLEMENTED();
 }


### PR DESCRIPTION
Without this, newer compilers get compilation errors:

```
  C:/toit/tests/ctest/ar-read-test.cc:19:14: error: 'char* mkdtemp(char*)' was declared 'extern' and later
  'static' [-fpermissive]
```